### PR TITLE
Fix axe reapplying damage

### DIFF
--- a/common/cards/default/single-use/golden-axe.ts
+++ b/common/cards/default/single-use/golden-axe.ts
@@ -59,10 +59,14 @@ class GoldenAxeSingleUseCard extends SingleUseCard {
 			})
 		})
 
-		player.hooks.onTurnEnd.add(instance, () => {
+		player.hooks.afterAttack.add(instance, () => {
 			player.hooks.getAttack.remove(instance)
-			player.hooks.beforeAttack.remove(instance)
 			player.hooks.afterAttack.remove(instance)
+		})
+
+		player.hooks.onTurnEnd.add(instance, () => {
+			player.hooks.beforeAttack.remove(instance)
+			player.hooks.onTurnEnd.remove(instance)
 		})
 	}
 


### PR DESCRIPTION
Delete the hook in afterAttack instead of onTurnEnd.