### PR TITLE
Change how armor stand uses discard

### DIFF
--- a/common/cards/alter-egos/effects/armor-stand.ts
+++ b/common/cards/alter-egos/effects/armor-stand.ts
@@ -1,7 +1,5 @@
 import EffectCard from '../../base/effect-card'
-import {isTargetingPos} from '../../../utils/attacks'
 import {GameModel} from '../../../models/game-model'
-import {discardCard} from '../../../utils/movement'
 import {CardPosModel} from '../../../models/card-pos-model'
 import {TurnActions} from '../../../types/game-state'
 import {CanAttachResult} from '../../base/card'
@@ -40,40 +38,9 @@ class ArmorStandEffectCard extends EffectCard {
 			return blockedActions
 		})
 
-		player.hooks.afterAttack.add(instance, (attack) => {
-			const attacker = attack.getAttacker()
-			if (!row.health && attacker && isTargetingPos(attack, pos)) {
-				// Discard to prevent losing a life
-				discardCard(game, row.hermitCard)
-
-				const activeRow = player.board.activeRow
-				const isActive = activeRow !== null && activeRow == pos.rowIndex
-				if (isActive && attacker.player.id !== player.id) {
-					// Reset the active row so the player can switch
-					game.changeActiveRow(player, null)
-				}
-			}
-		})
-
 		player.hooks.canAttach.add(instance, (result, pos) => {
 			if (pos.row?.hermitCard?.cardInstance !== instance) return
 			result.push('UNMET_CONDITION_SILENT')
-		})
-
-		opponentPlayer.hooks.afterAttack.add(instance, (attack) => {
-			const attacker = attack.getAttacker()
-			if (!row.health && attacker && isTargetingPos(attack, pos)) {
-				// Discard to prevent losing a life
-				discardCard(game, row.hermitCard)
-				game.battleLog.addEntry(player.id, `$p${this.name}$ was knocked out`)
-
-				const activeRow = player.board.activeRow
-				const isActive = activeRow !== null && activeRow == pos.rowIndex
-				if (isActive && attacker.player.id !== player.id) {
-					// Reset the active row so the player can switch
-					game.changeActiveRow(player, null)
-				}
-			}
 		})
 	}
 

--- a/common/cards/alter-egos/effects/thorns_ii.ts
+++ b/common/cards/alter-egos/effects/thorns_ii.ts
@@ -1,7 +1,7 @@
 import {AttackModel} from '../../../models/attack-model'
 import {CardPosModel, getCardPos} from '../../../models/card-pos-model'
 import {GameModel} from '../../../models/game-model'
-import {isTargetingPos} from '../../../utils/attacks'
+import {executeExtraAttacks, isTargetingPos} from '../../../utils/attacks'
 import EffectCard from '../../base/effect-card'
 
 class ThornsIIEffectCard extends EffectCard {
@@ -28,38 +28,36 @@ class ThornsIIEffectCard extends EffectCard {
 			// Only return a backlash attack if the attack did damage
 			if (attack.calculateDamage() <= 0) return
 
-			if (attack.getAttacker() && isTargetingPos(attack, pos)) {
-				player.custom[triggeredKey] = true
+			if (!attack.getAttacker() || !isTargetingPos(attack, pos)) return
 
-				const backlashAttack = new AttackModel({
-					id: this.getInstanceKey(instance, 'backlash'),
-					attacker: attack.getTarget(),
-					target: attack.getAttacker(),
-					type: 'effect',
-					isBacklash: true,
-					log: (values) => `${values.target} took ${values.damage} damage from $eThorns II$`,
-				}).addDamage(this.id, 30)
+			player.custom[triggeredKey] = true
 
-				backlashAttack.shouldIgnoreCards.push((instance) => {
-					const pos = getCardPos(game, instance)
-					if (!pos || !pos.row || !pos.row.effectCard) return false
+			const backlashAttack = new AttackModel({
+				id: this.getInstanceKey(instance, 'backlash'),
+				attacker: attack.getTarget(),
+				target: attack.getAttacker(),
+				type: 'effect',
+				isBacklash: true,
+				log: (values) => `${values.target} took ${values.damage} damage from $eThorns II$`,
+			}).addDamage(this.id, 30)
 
-					if (
-						['gold_armor', 'iron_armor', 'diamond_armor', 'netherite_armor'].includes(
-							pos.row.effectCard.cardId
-						)
-					) {
-						// It's an armor card, ignore it
-						return true
-					}
+			backlashAttack.shouldIgnoreCards.push((instance) => {
+				const pos = getCardPos(game, instance)
+				if (!pos || !pos.row || !pos.row.effectCard) return false
 
-					return false
-				})
+				if (
+					['gold_armor', 'iron_armor', 'diamond_armor', 'netherite_armor'].includes(
+						pos.row.effectCard.cardId
+					)
+				) {
+					// It's an armor card, ignore it
+					return true
+				}
 
-				attack.addNewAttack(backlashAttack)
-			}
+				return false
+			})
 
-			return attack
+			executeExtraAttacks(game, [backlashAttack])
 		})
 
 		opponentPlayer.hooks.onTurnEnd.add(instance, () => {

--- a/common/cards/default/effects/shield.ts
+++ b/common/cards/default/effects/shield.ts
@@ -24,7 +24,7 @@ class ShieldEffectCard extends EffectCard {
 		// Note that we are using onDefence because we want to activate on any attack to us, not just from the opponent
 
 		player.hooks.onDefence.add(instance, (attack) => {
-			if (!isTargetingPos(attack, pos) || attack.isType('status-effect')) return
+			if (!isTargetingPos(attack, pos) || attack.isType('status-effect')) return attack
 
 			if (player.custom[instanceKey] === undefined) {
 				player.custom[instanceKey] = 0
@@ -39,12 +39,12 @@ class ShieldEffectCard extends EffectCard {
 			}
 		})
 
-		player.hooks.afterDefence.add(instance, () => {
+		player.hooks.afterDefence.add(instance, (attack) => {
 			const {player, row} = pos
 
 			if (player.custom[instanceKey] !== undefined && player.custom[instanceKey] > 0 && row) {
 				discardCard(game, row.effectCard)
-				if (!row.hermitCard) return
+				if (!row.hermitCard) return attack
 				const hermitName = HERMIT_CARDS[row.hermitCard?.cardId].name
 				game.battleLog.addEntry(player.id, `$p${hermitName}'s$ $eShield$ was broken`)
 			}

--- a/common/cards/default/effects/thorns.ts
+++ b/common/cards/default/effects/thorns.ts
@@ -1,7 +1,7 @@
 import {AttackModel} from '../../../models/attack-model'
 import {CardPosModel, getCardPos} from '../../../models/card-pos-model'
 import {GameModel} from '../../../models/game-model'
-import {isTargetingPos} from '../../../utils/attacks'
+import {executeExtraAttacks, isTargetingPos} from '../../../utils/attacks'
 import EffectCard from '../../base/effect-card'
 
 class ThornsEffectCard extends EffectCard {
@@ -28,38 +28,36 @@ class ThornsEffectCard extends EffectCard {
 			// Only return a backlash attack if the attack did damage
 			if (attack.calculateDamage() <= 0) return
 
-			if (attack.getAttacker() && isTargetingPos(attack, pos)) {
-				player.custom[triggeredKey] = true
+			if (!attack.getAttacker() || !isTargetingPos(attack, pos)) return
 
-				const backlashAttack = new AttackModel({
-					id: this.getInstanceKey(instance, 'backlash'),
-					attacker: attack.getTarget(),
-					target: attack.getAttacker(),
-					type: 'effect',
-					isBacklash: true,
-					log: (values) => `${values.target} took ${values.damage} damage from $eThorns$`,
-				}).addDamage(this.id, 20)
+			player.custom[triggeredKey] = true
 
-				backlashAttack.shouldIgnoreCards.push((instance) => {
-					const pos = getCardPos(game, instance)
-					if (!pos || !pos.row || !pos.row.effectCard) return false
+			const backlashAttack = new AttackModel({
+				id: this.getInstanceKey(instance, 'backlash'),
+				attacker: attack.getTarget(),
+				target: attack.getAttacker(),
+				type: 'effect',
+				isBacklash: true,
+				log: (values) => `${values.target} took ${values.damage} damage from $eThorns$`,
+			}).addDamage(this.id, 20)
 
-					if (
-						['gold_armor', 'iron_armor', 'diamond_armor', 'netherite_armor'].includes(
-							pos.row.effectCard.cardId
-						)
-					) {
-						// It's an armor card, ignore it
-						return true
-					}
+			backlashAttack.shouldIgnoreCards.push((instance) => {
+				const pos = getCardPos(game, instance)
+				if (!pos || !pos.row || !pos.row.effectCard) return false
 
-					return false
-				})
+				if (
+					['gold_armor', 'iron_armor', 'diamond_armor', 'netherite_armor'].includes(
+						pos.row.effectCard.cardId
+					)
+				) {
+					// It's an armor card, ignore it
+					return true
+				}
 
-				attack.addNewAttack(backlashAttack)
-			}
+				return false
+			})
 
-			return attack
+			executeExtraAttacks(game, [backlashAttack])
 		})
 
 		opponentPlayer.hooks.onTurnEnd.add(instance, () => {

--- a/common/cards/default/effects/wolf.ts
+++ b/common/cards/default/effects/wolf.ts
@@ -1,6 +1,7 @@
 import {AttackModel} from '../../../models/attack-model'
 import {CardPosModel} from '../../../models/card-pos-model'
 import {GameModel} from '../../../models/game-model'
+import {executeExtraAttacks} from '../../../utils/attacks'
 import {getActiveRowPos, getRowPos} from '../../../utils/board'
 import EffectCard from '../../base/effect-card'
 
@@ -64,7 +65,7 @@ class WolfEffectCard extends EffectCard {
 				log: (values) => `${values.target} took ${values.damage} damage from $eWolf$`,
 			}).addDamage(this.id, 20)
 
-			attack.addNewAttack(backlashAttack)
+			executeExtraAttacks(game, [backlashAttack])
 		})
 	}
 

--- a/common/types/game-state.ts
+++ b/common/types/game-state.ts
@@ -120,7 +120,8 @@ export type PlayerState = {
 		/** Hook called for every attack that targets our side of the board */
 		onDefence: GameHook<(attack: AttackModel) => void>
 		/**
-		 * Hook called after the main attack loop, for every attack from our side of the board.
+		 * Hook called after the main attack loop is completed, for every attack from our side of the board.
+		 * Attacks added from this hook will not be executed.
 		 *
 		 * This is called after actions are marked as completed and blocked
 		 */

--- a/common/utils/attacks.ts
+++ b/common/utils/attacks.ts
@@ -163,6 +163,8 @@ export function executeAttacks(
 
 		if (attack.nextAttacks.length > 0) {
 			executeAttacks(game, attack.nextAttacks, withoutBlockingActions)
+			// Only want to block actions after first attack
+			withoutBlockingActions = true
 		}
 	})
 

--- a/common/utils/attacks.ts
+++ b/common/utils/attacks.ts
@@ -147,12 +147,8 @@ function shouldIgnoreCard(attack: AttackModel, instance: string): boolean {
 export function executeAttacks(
 	game: GameModel,
 	attacks: Array<AttackModel>,
-	withoutBlockingActions = false,
-	createLogs = true
+	withoutBlockingActions = false
 ) {
-	// We need to store the SU card for battle log stuff.
-	const thisAttackSagaSU = game.currentPlayer.board.singleUseCard
-
 	// STEP 1 - Call before attack and defence for all attacks
 	runBeforeAttackHooks(attacks)
 	runBeforeDefenceHooks(attacks)
@@ -166,14 +162,8 @@ export function executeAttacks(
 		executeAttack(attack)
 
 		if (attack.nextAttacks.length > 0) {
-			executeAttacks(game, attack.nextAttacks, withoutBlockingActions, false)
+			executeAttacks(game, attack.nextAttacks, withoutBlockingActions)
 		}
-
-		if (createLogs) {
-			game.battleLog.addAttackEntry(attack, game.currentPlayer.coinFlips, thisAttackSagaSU)
-		}
-
-		attack.nextAttacks = []
 	})
 
 	if (!withoutBlockingActions) {
@@ -192,12 +182,6 @@ export function executeAttacks(
 	// STEP 6 - After all attacks have been executed, call after attack and defence hooks
 	runAfterAttackHooks(attacks)
 	runAfterDefenceHooks(attacks)
-
-	// STEP 7 - Execute new attacks created in afterAttack hooks
-	attacks.forEach((attack) => {
-		if (attack.nextAttacks.length === 0) return
-		executeAttacks(game, attack.nextAttacks, true, true)
-	})
 }
 
 export function executeExtraAttacks(

--- a/server/src/routines/game.ts
+++ b/server/src/routines/game.ts
@@ -190,21 +190,27 @@ function* checkHermitHealth(game: GameModel) {
 				// Add battle log entry
 				game.battleLog.addDeathEntry(playerState, row)
 
-				if (row.hermitCard) discardCard(game, row.hermitCard)
-				if (row.effectCard) discardCard(game, row.effectCard)
+				const cardType = CARDS[row.hermitCard.cardId].type
+
+				discardCard(game, row.hermitCard)
+				discardCard(game, row.effectCard)
 				row.itemCards.forEach((itemCard) => itemCard && discardCard(game, itemCard))
 				playerRows[rowIndex] = getEmptyRow()
 				if (Number(rowIndex) === activeRow) {
 					game.changeActiveRow(playerState, null)
 					playerState.hooks.onActiveRowChange.call(activeRow, null)
 				}
-				playerState.lives -= 1
 
-				// reward card
-				const opponentState = playerStates.find((s) => s.id !== playerState.id)
-				if (!opponentState) continue
-				const rewardCard = playerState.pile.shift()
-				if (rewardCard) opponentState.hand.push(rewardCard)
+				// Only hermit cards give points
+				if (cardType === 'hermit') {
+					playerState.lives -= 1
+
+					// reward card
+					const opponentState = playerStates.find((s) => s.id !== playerState.id)
+					if (!opponentState) continue
+					const rewardCard = playerState.pile.shift()
+					if (rewardCard) opponentState.hand.push(rewardCard)
+				}
 			}
 		}
 

--- a/server/src/routines/turn-actions/attack.ts
+++ b/server/src/routines/turn-actions/attack.ts
@@ -95,8 +95,14 @@ function* attackSaga(
 	// Get initial attacks
 	let attacks: Array<AttackModel> = getAttack(game, attackPos, hermitAttackType)
 
+	const thisAttackSU = game.currentPlayer.board.singleUseCard
+
 	// Run all the code stuff
 	executeAttacks(game, attacks)
+
+	attacks.forEach((attack) => {
+		game.battleLog.addAttackEntry(attack, game.currentPlayer.coinFlips, thisAttackSU)
+	})
 
 	game.battleLog.opponentCoinFlipEntry(currentPlayer.coinFlips)
 


### PR DESCRIPTION
This is a huge issue in the code right now. Armor stand discarding itself allows for a `RowStateWithHermit` to NOT have a Hermit. With this change, it always will.

Now, only Hermit cards give a point when knocked out to compensate. I think this is fine. If we need a different system, we can discuss that in the future

I also simplified the attack loop, so attacks are NOT ran if they're added after the main attack loop is over. Thorns ect. uses `executeExtraAttacks` instead now.