### PR TITLE
Remove volumes from docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,4 @@ services:
     container_name: hc-tcg
     ports:
       - 9000:9000
-    volumes:
-      - hc-tcg:/app
     restart: unless-stopped
-volumes:
-  hc-tcg:


### PR DESCRIPTION
The volume was unused, and also was set up incorrect which prevented updateing the docker image properly when using the docker compose file.