### PR TITLE
Improve Error handling in matchmaking saga

### DIFF
--- a/server/src/routines/matchmaking.ts
+++ b/server/src/routines/matchmaking.ts
@@ -90,12 +90,8 @@ export function inQueue(playerId: string) {
 
 function* randomMatchmakingSaga() {
 	while (true) {
-		// Wait 3 seconds
 		yield* delay(1000 * 3)
 		if (!(root.queue.length > 1)) continue
-
-		// Remove extra player
-		const extraPlayer = root.queue.length % 2 === 1 ? root.queue.pop() || null : null
 
 		// Shuffle
 		for (var i = root.queue.length - 1; i > 0; i--) {
@@ -105,30 +101,27 @@ function* randomMatchmakingSaga() {
 			root.queue[randomPos] = oldValue
 		}
 
-		let index = 0
-		for (index = 0; index < root.queue.length; index += 2) {
-			const player1 = root.players[root.queue[index]]
-			const player2 = root.players[root.queue[index + 1]]
+		const playersToRemove: Array<string> = []
+
+		for (let index = 0; index < root.queue.length - 1; index += 2) {
+			const player1Id = root.queue[index]
+			const player2Id = root.queue[index + 1]
+			const player1 = root.players[player1Id]
+			const player2 = root.players[player2Id]
 
 			if (player1 && player2) {
-				// Create a new game for these players
+				playersToRemove.push(player1.id, player2.id)
 				const newGame = new GameModel(player1, player2)
 				root.addGame(newGame)
 				yield* fork(gameManager, newGame)
 			} else {
-				// Something went wrong, broadcast to the player that isn't undefined to leave matchmaking
-				if (player1) broadcast([player1], 'LEAVE_MATCHMAKING')
-				if (player2) broadcast([player2], 'LEAVE_MATCHMAKING')
+				// Something went wrong, remove the undefined player from the queue
+				if (player1 === undefined) playersToRemove.push(player1Id)
+				if (player2 === undefined) playersToRemove.push(player2Id)
 			}
 		}
 
-		// Add back extra player
-		if (extraPlayer) {
-			root.queue.push(extraPlayer)
-		}
-
-		// Remove players who got games from queue
-		root.queue.splice(0, index)
+		root.queue = root.queue.filter((player) => !playersToRemove.includes(player))
 	}
 }
 


### PR DESCRIPTION
This makes it so that if there is an error with a player when a game is created, it will leave the other player in the queue instead of kicking them. This is one possible cause of ghost queues so I think it should be eliminated.