### PR TITLE
Remove bold text from pearl's description

### DIFF
--- a/common/cards/default/hermits/pearlescentmoon-rare.ts
+++ b/common/cards/default/hermits/pearlescentmoon-rare.ts
@@ -23,7 +23,7 @@ class PearlescentMoonRareHermitCard extends HermitCard {
 				cost: ['terraform', 'any'],
 				damage: 70,
 				power:
-					'If your opponent attacks on their next turn, flip a coin.\nIf heads, their attack $kmisses$. Your opponent can not miss due to this ability on consecutive turns.',
+					'If your opponent attacks on their next turn, flip a coin.\nIf heads, their attack misses. Your opponent can not miss due to this ability on consecutive turns.',
 			},
 		})
 	}


### PR DESCRIPTION
This was meant to be a feature in a later update, but I accidentally left it in when pushing the battle log update. At least nobody noticed it was strange until the formatting didn't work, so we know it's probably not a bad feature to add.