### PR TITLE
Create status effect types and log fixes

### DIFF
--- a/client/src/app/game/board/board-status-effects.tsx
+++ b/client/src/app/game/board/board-status-effects.tsx
@@ -12,7 +12,7 @@ const StatusEffectContainer = ({statusEffects}: StatusEffectDisplayProps) => {
 		<div>
 			<div className={css.statusEffectContainer}>
 				{statusEffects.map((effect) => {
-					if (effect.props.type === 'damage' || effect.props.type === 'hidden') return
+					if (effect.props.type === 'damage' || effect.props.type === 'hiddenSystem') return
 					return (
 						<StatusEffect
 							key={effect.instance}

--- a/client/src/app/game/board/board-status-effects.tsx
+++ b/client/src/app/game/board/board-status-effects.tsx
@@ -12,7 +12,7 @@ const StatusEffectContainer = ({statusEffects}: StatusEffectDisplayProps) => {
 		<div>
 			<div className={css.statusEffectContainer}>
 				{statusEffects.map((effect) => {
-					if (effect.props.damageEffect || effect.props.hidden) return
+					if (effect.props.type === 'damage' || effect.props.type === 'hidden') return
 					return (
 						<StatusEffect
 							key={effect.instance}
@@ -24,7 +24,7 @@ const StatusEffectContainer = ({statusEffects}: StatusEffectDisplayProps) => {
 			</div>
 			<div className={css.damageStatusEffectContainer}>
 				{statusEffects.map((effect) => {
-					if (!effect.props.damageEffect || effect.props.hidden) return
+					if (effect.props.type !== 'damage') return
 					return (
 						<StatusEffect
 							key={effect.instance}

--- a/client/src/components/status-effects/status-effect.tsx
+++ b/client/src/components/status-effects/status-effect.tsx
@@ -17,7 +17,7 @@ const StatusEffect = (props: StatusEffectReactProps) => {
 
 	const extension = ['sleeping', 'poison', 'fire'].includes(statusEffect.id) ? '.gif' : '.png'
 	const statusEffectClass =
-		statusEffect.damageEffect == true ? css.damageStatusEffectImage : css.statusEffectImage
+		statusEffect.type == 'damage' ? css.damageStatusEffectImage : css.statusEffectImage
 
 	return (
 		<Tooltip tooltip={<StatusEffectTooltip statusEffect={props.statusEffect} counter={counter} />}>

--- a/common/cards/default/hermits/goodtimeswithscar-rare.ts
+++ b/common/cards/default/hermits/goodtimeswithscar-rare.ts
@@ -70,7 +70,10 @@ class GoodTimesWithScarRareHermitCard extends Card {
 			row.health = 50
 
 			game.state.statusEffects.forEach((ail) => {
-				if (ail.targetInstance.instance === targetInstance.instance) {
+				if (
+					ail.targetInstance.instance === targetInstance.instance &&
+					['normal', 'damage'].includes(ail.props.type)
+				) {
 					removeStatusEffect(game, pos, ail)
 				}
 			})

--- a/common/models/battle-log-model.ts
+++ b/common/models/battle-log-model.ts
@@ -4,15 +4,16 @@ import {
 	RowStateWithHermit,
 	CardInstance,
 	BattleLogT,
+	StatusEffectInstance,
 } from '../types/game-state'
 import {broadcast} from '../../server/src/utils/comm'
 import {AttackModel} from './attack-model'
-import {CardPosModel} from './card-pos-model'
+import {CardPosModel, getCardPos} from './card-pos-model'
 import {GameModel} from './game-model'
 import {formatText} from '../utils/formatting'
 import {DEBUG_CONFIG} from '../config'
 import Card from '../cards/base/card'
-import StatusEffect from '../status-effects/status-effect'
+import StatusEffect, {statusEffect, StatusEffectLog} from '../status-effects/status-effect'
 import {SlotInfo} from '../types/cards'
 
 export class BattleLogModel {
@@ -292,11 +293,26 @@ export class BattleLogModel {
 		broadcast(this.game.getPlayers(), 'CHAT_UPDATE', this.game.chat)
 	}
 
-	public addRemoveStatusEffectEntry(statusEffect: StatusEffect) {
-		this.logMessageQueue.push({
-			player: this.game.currentPlayer.id,
-			description: `$e${statusEffect.props.name}$ wore off`,
+	public addStatusEffectEntry(
+		statusEffect: StatusEffectInstance,
+		log: (values: StatusEffectLog) => string
+	) {
+		const pos = getCardPos(this.game, statusEffect.targetInstance)
+		if (!pos || !pos.rowIndex) return
+		const targetFormatting = pos.player.id === this.game.currentPlayerId ? 'p' : 'o'
+		const rowNumberString =
+			pos.player.board.activeRow === pos.rowIndex ? '' : `(${pos.rowIndex + 1})`
+
+		const logMessage = log({
+			target: `$${targetFormatting}${statusEffect.targetInstance.props.name} ${rowNumberString}$`,
+			statusEffect: `$e${statusEffect.props.name}$`,
 		})
+
+		this.logMessageQueue.push({
+			player: this.game.currentPlayerId,
+			description: logMessage,
+		})
+
 		this.sendLogs()
 	}
 }

--- a/common/status-effects/aussie-ping.ts
+++ b/common/status-effects/aussie-ping.ts
@@ -2,7 +2,7 @@ import StatusEffect, {
 	StatusEffectProps,
 	followActiveHermit,
 	hiddenStatusEffect,
-	statusEffect,
+	systemStatusEffect,
 } from './status-effect'
 import {GameModel} from '../models/game-model'
 import {CardPosModel, getCardPos} from '../models/card-pos-model'
@@ -13,7 +13,7 @@ import {slot} from '../slot'
 
 export class AussiePingStatusEffect extends StatusEffect {
 	props: StatusEffectProps = {
-		...statusEffect,
+		...systemStatusEffect,
 		id: 'aussie-ping',
 		name: 'Aussie Ping',
 		description:

--- a/common/status-effects/badomen.ts
+++ b/common/status-effects/badomen.ts
@@ -21,10 +21,6 @@ class BadOmenStatusEffect extends StatusEffect {
 
 		if (!instance.counter) instance.counter = this.props.counter
 
-		if (pos.card) {
-			game.battleLog.addEntry(player.id, `$p${pos.card.props.name}$ was inflicted with $bBad Omen$`)
-		}
-
 		opponentPlayer.hooks.onTurnStart.add(instance, () => {
 			if (!instance.counter) return
 			instance.counter--

--- a/common/status-effects/betrayed.ts
+++ b/common/status-effects/betrayed.ts
@@ -1,4 +1,4 @@
-import StatusEffect, {StatusEffectProps, statusEffect} from './status-effect'
+import StatusEffect, {StatusEffectProps, systemStatusEffect} from './status-effect'
 import {GameModel} from '../models/game-model'
 import {CardPosModel} from '../models/card-pos-model'
 import {getActiveRow, removeStatusEffect} from '../utils/board'
@@ -9,12 +9,11 @@ import {SlotInfo} from '../types/cards'
 
 class BetrayedStatusEffect extends StatusEffect {
 	props: StatusEffectProps = {
-		...statusEffect,
+		...systemStatusEffect,
 		id: 'betrayed',
 		name: 'Betrayed',
 		description:
 			'This Hermit must attack an AFK hermit if one exists and they have the neccesary items attached to attack.',
-		damageEffect: false,
 	}
 
 	override onApply(game: GameModel, instance: StatusEffectInstance, pos: CardPosModel) {

--- a/common/status-effects/fire.ts
+++ b/common/status-effects/fire.ts
@@ -15,14 +15,11 @@ class FireStatusEffect extends StatusEffect {
 		name: 'Burn',
 		description:
 			"Burned Hermits take an additional 20hp damage at the end of their opponent's turn, until knocked out. Can not stack with poison.",
+		applyLog: (values) => `${values.target} was $eBurned$`,
 	}
 
 	override onApply(game: GameModel, instance: StatusEffectInstance, pos: CardPosModel) {
 		const {player, opponentPlayer} = pos
-
-		if (pos.card) {
-			game.battleLog.addEntry(player.id, `$p${pos.card.props.name}$ was $eBurned$`)
-		}
 
 		opponentPlayer.hooks.onTurnEnd.add(instance, () => {
 			const targetPos = game.findSlot(slot.hasInstance(instance.targetInstance))

--- a/common/status-effects/melody.ts
+++ b/common/status-effects/melody.ts
@@ -11,7 +11,6 @@ class MelodyStatusEffect extends StatusEffect {
 		id: 'melody',
 		name: "Ollie's Melody",
 		description: 'This Hermit heals 10hp every turn.',
-		damageEffect: false,
 		applyCondition: slot.not(slot.hasStatusEffect('melody')),
 	}
 

--- a/common/status-effects/poison.ts
+++ b/common/status-effects/poison.ts
@@ -15,14 +15,11 @@ class PoisonStatusEffect extends StatusEffect {
 		name: 'Poison',
 		description:
 			"Poisoned Hermits take an additional 20hp damage at the end of their opponent's turn, until down to 10hp. Can not stack with burn.",
+		applyLog: (values) => `${values.target} was $ePoisoned$`,
 	}
 
 	override onApply(game: GameModel, instance: StatusEffectInstance, pos: CardPosModel) {
 		const {player, opponentPlayer} = pos
-
-		if (pos.card) {
-			game.battleLog.addEntry(player.id, `$p${pos.card.props.name}$ was $ePoisoned$`)
-		}
 
 		opponentPlayer.hooks.onTurnEnd.add(instance, () => {
 			const targetPos = game.findSlot(slot.hasInstance(instance.targetInstance))

--- a/common/status-effects/revived-by-deathloop.ts
+++ b/common/status-effects/revived-by-deathloop.ts
@@ -1,8 +1,8 @@
-import StatusEffect, {StatusEffectProps, statusEffect} from './status-effect'
+import StatusEffect, {StatusEffectProps, systemStatusEffect} from './status-effect'
 
 class RevivedByDeathloopStatusEffect extends StatusEffect {
 	props: StatusEffectProps = {
-		...statusEffect,
+		...systemStatusEffect,
 		id: 'revived-by-deathloop',
 		name: 'Revived',
 		description: "This hermit has been revived by Scar's deathloop attack.",

--- a/common/status-effects/sheep-stare.ts
+++ b/common/status-effects/sheep-stare.ts
@@ -1,4 +1,8 @@
-import StatusEffect, {StatusEffectProps, followActiveHermit, statusEffect} from './status-effect'
+import StatusEffect, {
+	StatusEffectProps,
+	followActiveHermit,
+	systemStatusEffect,
+} from './status-effect'
 import {GameModel} from '../models/game-model'
 import {CardPosModel} from '../models/card-pos-model'
 import {CoinFlipT, StatusEffectInstance} from '../types/game-state'
@@ -7,7 +11,7 @@ import {removeStatusEffect} from '../utils/board'
 
 class SheepStareEffect extends StatusEffect {
 	props: StatusEffectProps = {
-		...statusEffect,
+		...systemStatusEffect,
 		id: 'sheep-stare',
 		name: 'Sheep Stare',
 		description:

--- a/common/status-effects/slowness.ts
+++ b/common/status-effects/slowness.ts
@@ -20,10 +20,6 @@ class SlownessStatusEffect extends StatusEffect {
 
 		if (!instance.counter) instance.counter = this.props.counter
 
-		if (pos.card) {
-			game.battleLog.addEntry(player.id, `$p${pos.card.props.name}$ was inflicted with $eSlowness$`)
-		}
-
 		player.hooks.onTurnStart.add(instance, () => {
 			const targetPos = game.findSlot(slot.hasInstance(instance.targetInstance))
 			if (!targetPos || targetPos.rowIndex === null) return

--- a/common/status-effects/status-effect.ts
+++ b/common/status-effects/status-effect.ts
@@ -15,7 +15,7 @@ export type StatusEffectProps = {
 	id: string
 	name: string
 	description: string
-	type: 'normal' | 'damage' | 'system' | 'hidden'
+	type: 'normal' | 'damage' | 'system' | 'hiddenSystem'
 	applyLog: ((values: StatusEffectLog) => string) | null
 	removeLog: ((values: StatusEffectLog) => string) | null
 	applyCondition: SlotCondition
@@ -42,7 +42,7 @@ export const systemStatusEffect = {
 }
 
 export const hiddenStatusEffect = {
-	type: 'hidden' as StatusEffectProps['type'],
+	type: 'hiddenSystem' as StatusEffectProps['type'],
 	name: '',
 	description: '',
 	applyCondition: slot.anything,

--- a/common/status-effects/status-effect.ts
+++ b/common/status-effects/status-effect.ts
@@ -4,13 +4,21 @@ import {StatusEffectInstance} from '../types/game-state'
 import {SlotCondition, slot} from '../slot'
 import {SlotInfo} from '../types/cards'
 
+export type StatusEffectLog = {
+	/** The status effect target */
+	target: string
+	/** The status effect name */
+	statusEffect: string
+}
+
 export type StatusEffectProps = {
 	id: string
 	name: string
 	description: string
-	damageEffect?: boolean
+	type: 'normal' | 'damage' | 'system' | 'hidden'
+	applyLog: ((values: StatusEffectLog) => string) | null
+	removeLog: ((values: StatusEffectLog) => string) | null
 	applyCondition: SlotCondition
-	hidden?: boolean
 }
 
 export type Counter = StatusEffectProps & {
@@ -19,23 +27,38 @@ export type Counter = StatusEffectProps & {
 }
 
 export const statusEffect = {
-	damageEffect: false,
+	type: 'normal' as StatusEffectProps['type'],
 	applyCondition: slot.anything,
+	applyLog: (values: StatusEffectLog) =>
+		`${values.target} was inflicted with ${values.statusEffect}`,
+	removeLog: (values: StatusEffectLog) => `${values.statusEffect} on ${values.target} wore off`,
+}
+
+export const systemStatusEffect = {
+	type: 'system' as StatusEffectProps['type'],
+	applyCondition: slot.anything,
+	applyLog: null,
+	removeLog: null,
 }
 
 export const hiddenStatusEffect = {
-	hidden: true,
+	type: 'hidden' as StatusEffectProps['type'],
 	name: '',
 	description: '',
 	applyCondition: slot.anything,
+	applyLog: null,
+	removeLog: null,
 }
 
 export const damageEffect = {
-	damageEffect: true,
+	type: 'damage' as StatusEffectProps['type'],
 	applyCondition: (game: GameModel, pos: SlotInfo) =>
 		game.state.statusEffects.every(
-			(a) => a.targetInstance.instance !== pos.card?.instance || a.props.damageEffect === false
+			(a) => a.targetInstance.instance !== pos.card?.instance || a.props.type === 'damage'
 		),
+	applyLog: (values: StatusEffectLog) =>
+		`${values.target} was inflicted with ${values.statusEffect}`,
+	removeLog: (values: StatusEffectLog) => `${values.statusEffect} on ${values.target} wore off`,
 }
 
 export function isCounter(props: StatusEffectProps | null): props is Counter {

--- a/common/status-effects/used-clock.ts
+++ b/common/status-effects/used-clock.ts
@@ -1,4 +1,4 @@
-import StatusEffect, {Counter, StatusEffectProps, statusEffect} from './status-effect'
+import StatusEffect, {Counter, StatusEffectProps, systemStatusEffect} from './status-effect'
 import {GameModel} from '../models/game-model'
 import {CardPosModel} from '../models/card-pos-model'
 import {removeStatusEffect} from '../utils/board'
@@ -6,7 +6,7 @@ import {StatusEffectInstance} from '../types/game-state'
 
 class UsedClockStatusEffect extends StatusEffect {
 	props: StatusEffectProps & Counter = {
-		...statusEffect,
+		...systemStatusEffect,
 		id: 'used-clock',
 		name: 'Turn Skipped',
 		description: 'Turns can not be skipped consecutively.',

--- a/common/status-effects/weakness.ts
+++ b/common/status-effects/weakness.ts
@@ -20,10 +20,6 @@ class WeaknessStatusEffect extends StatusEffect {
 
 		if (!instance.counter) instance.counter = this.props.counter
 
-		if (pos.card) {
-			game.battleLog.addEntry(player.id, `$p${pos.card.props.name}$ was inflicted with $eWeakness$`)
-		}
-
 		player.hooks.onTurnStart.add(instance, () => {
 			if (!instance.counter) return
 			instance.counter--

--- a/common/utils/board.ts
+++ b/common/utils/board.ts
@@ -80,6 +80,10 @@ export function applyStatusEffect(
 
 	if (!statusEffectInstance.props.applyCondition(game, pos)) return 'FAILURE_CANNOT_COMPLETE'
 
+	if (statusEffectInstance.props.applyLog) {
+		game.battleLog.addStatusEffectEntry(statusEffectInstance, statusEffectInstance.props.applyLog)
+	}
+
 	statusEffectInstance.statusEffect.onApply(game, statusEffectInstance, pos)
 	game.state.statusEffects.push(statusEffectInstance)
 
@@ -102,7 +106,11 @@ export function removeStatusEffect(
 
 	const statusEffectObject = STATUS_EFFECT_CLASSES[statusEffects[0].props.id]
 	statusEffectObject.onRemoval(game, statusEffects[0], pos)
-	game.battleLog.addRemoveStatusEffectEntry(statusEffectObject)
+
+	if (statusEffectInstance.props.removeLog) {
+		game.battleLog.addStatusEffectEntry(statusEffectInstance, statusEffectInstance.props.removeLog)
+	}
+
 	game.state.statusEffects = game.state.statusEffects.filter((a) => !statusEffects.includes(a))
 
 	return 'SUCCESS'


### PR DESCRIPTION
- Status effects now have 4 types `normal`, `damage`, `system`, and `hidden`. This affect some of their properties.
- Logs also work properly now. Before, apply logs needed to be specified manually, and remove logs showed for all logs. Now the system is the same as the system cards and attacks use, so it's a lot easier to follow and works properly. Status effect logs can also be null for those that shouldn't make logs.