### PR TITLE
Fix stacking damage effects

### DIFF
--- a/common/status-effects/status-effect.ts
+++ b/common/status-effects/status-effect.ts
@@ -54,7 +54,7 @@ export const damageEffect = {
 	type: 'damage' as StatusEffectProps['type'],
 	applyCondition: (game: GameModel, pos: SlotInfo) =>
 		game.state.statusEffects.every(
-			(a) => a.targetInstance.instance !== pos.card?.instance || a.props.type === 'damage'
+			(a) => a.targetInstance.instance !== pos.card?.instance || a.props.type !== 'damage'
 		),
 	applyLog: (values: StatusEffectLog) =>
 		`${values.target} was inflicted with ${values.statusEffect}`,


### PR DESCRIPTION
Damage effects like "fire" and "poison" can no longer stack on the same hermit, and can again be added to a hermit with other non-damage effects