### PR TITLE
Set no Active Row on Hermit Death

### DIFF
--- a/client/src/components/import-export/import-export-utils.ts
+++ b/client/src/components/import-export/import-export-utils.ts
@@ -4,6 +4,7 @@ import {LocalCardInstance, WithoutFunctions} from 'common/types/server-requests'
 import {CardEntity} from 'common/entities'
 
 export const getDeckFromHash = (hash: string): Array<LocalCardInstance> => {
+	console.log(decode(hash))
 	try {
 		var b64 = decode(hash)
 			.split('')

--- a/client/src/components/import-export/import-export-utils.ts
+++ b/client/src/components/import-export/import-export-utils.ts
@@ -4,7 +4,6 @@ import {LocalCardInstance, WithoutFunctions} from 'common/types/server-requests'
 import {CardEntity} from 'common/entities'
 
 export const getDeckFromHash = (hash: string): Array<LocalCardInstance> => {
-	console.log(decode(hash))
 	try {
 		var b64 = decode(hash)
 			.split('')

--- a/server/src/routines/game.ts
+++ b/server/src/routines/game.ts
@@ -239,8 +239,6 @@ function* checkHermitHealth(game: GameModel) {
 			}
 
 			if (card.slot.row.entity === playerState.activeRowEntity) {
-				let activeHermit = playerState.activeRow?.getHermit()
-				if (activeHermit) playerState.hooks.onActiveRowChange.call(card, activeHermit)
 				playerState.activeRowEntity = null
 			}
 

--- a/server/src/routines/game.ts
+++ b/server/src/routines/game.ts
@@ -239,19 +239,9 @@ function* checkHermitHealth(game: GameModel) {
 			}
 
 			if (card.slot.row.entity === playerState.activeRowEntity) {
-				let targetRow = game.components.find(
-					RowComponent,
-					query.not(query.row.entity(playerState.activeRowEntity)),
-					query.row.player(playerState.entity),
-					query.row.hasHermit
-				)
-				if (targetRow) {
-					playerState.changeActiveRow(targetRow)
-				} else {
-					playerState.activeRowEntity = null
-				}
 				let activeHermit = playerState.activeRow?.getHermit()
 				if (activeHermit) playerState.hooks.onActiveRowChange.call(card, activeHermit)
+				playerState.activeRowEntity = null
 			}
 
 			// We wait to discard becuse you can not change from a row with no hermits to a new active row.


### PR DESCRIPTION
Fixes a bug where the target row would be automatically set on a hermits death.
Sorry!
