### PR TITLE
Fix Ren and Cleo sometimes not creating attacks

### DIFF
--- a/client/src/app/game/modals/copy-attack-modal.tsx
+++ b/client/src/app/game/modals/copy-attack-modal.tsx
@@ -36,25 +36,32 @@ function CopyAttackModal({closeModal}: Props) {
 		closeModal()
 	}
 
+	let isPrimaryAvailable = !modalData.payload.blockedActions.includes('PRIMARY_ATTACK')
+	let isSecondaryAvailable = !modalData.payload.blockedActions.includes('SECONDARY_ATTACK')
+
 	return (
 		<Modal closeModal={handleClose} title={modalData.payload.modalName}>
 			<div className={css.confirmModal}>
 				<div className={css.description}>{modalData.payload.modalDescription}</div>
 				<div className={css.description}>
-					<Attack
-						key="primary"
-						name={opponentHermitInfo.props.primary.name}
-						icon={`/images/hermits-nobg/${hermitFullName}.png`}
-						attackInfo={opponentHermitInfo.props.primary}
-						onClick={handlePrimary}
-					/>
-					<Attack
-						key="secondary"
-						name={opponentHermitInfo.props.secondary.name}
-						icon={`/images/hermits-nobg/${hermitFullName}.png`}
-						attackInfo={opponentHermitInfo.props.secondary}
-						onClick={handleSecondary}
-					/>
+					{isPrimaryAvailable && (
+						<Attack
+							key="primary"
+							name={opponentHermitInfo.props.primary.name}
+							icon={`/images/hermits-nobg/${hermitFullName}.png`}
+							attackInfo={opponentHermitInfo.props.primary}
+							onClick={handlePrimary}
+						/>
+					)}
+					{isSecondaryAvailable && (
+						<Attack
+							key="secondary"
+							name={opponentHermitInfo.props.secondary.name}
+							icon={`/images/hermits-nobg/${hermitFullName}.png`}
+							attackInfo={opponentHermitInfo.props.secondary}
+							onClick={handleSecondary}
+						/>
+					)}
 				</div>
 			</div>
 		</Modal>

--- a/common/types/server-requests.ts
+++ b/common/types/server-requests.ts
@@ -6,6 +6,7 @@ import {SlotTypeT} from './cards'
 import {PlayerDeckT} from './deck'
 import {PlayerId} from '../models/player-model'
 import {CardEntity, Entity, PlayerEntity, SlotEntity} from '../entities'
+import {TurnActions} from './game-state'
 
 export type PlayerInfo = {
 	playerName: string
@@ -111,6 +112,7 @@ export namespace LocalCopyAttack {
 			modalName: string
 			modalDescription: string
 			hermitCard: LocalCardInstance
+			blockedActions: TurnActions
 		}
 	}
 

--- a/server/src/routines/game.ts
+++ b/server/src/routines/game.ts
@@ -24,7 +24,6 @@ import {
 	DiscardSlotComponent,
 	HandSlotComponent,
 	PlayerComponent,
-	RowComponent,
 	SlotComponent,
 } from 'common/components'
 import {SingleUse} from 'common/cards/base/types'

--- a/server/src/utils/state-gen.ts
+++ b/server/src/utils/state-gen.ts
@@ -182,9 +182,16 @@ function getLocalModalDataPayload(game: GameModel, modal: ModalData): LocalModal
 			cards: modal.payload.cards.map((entity) => getLocalCard(game.components.get(entity)!)),
 		}
 	} else if (modal.modalId === 'copyAttack') {
+		let hermitCard = game.components.get(modal.payload.hermitCard)!
+		let blockedActions = hermitCard.player.hooks.blockedActions.callSome([[]], (observerEntity) => {
+			let observer = game.components.get(observerEntity)
+			return observer?.wrappingEntity === hermitCard.entity
+		})[0]
+
 		return {
 			...modal.payload,
-			hermitCard: getLocalCard(game.components.get(modal.payload.hermitCard)!),
+			hermitCard: getLocalCard(hermitCard),
+			blockedActions: blockedActions,
 		}
 	}
 


### PR DESCRIPTION
Fixes a bug where Ren and Cleo would not create a attacks when copying a hermit. This was because they did not call the on attack request hook. I now use `callSome` to call the specific `getAttackRequests` hook for the created mock card before the attack loop.
Additionally I also prevented blocked actions from being selected because this led to buggy behavior.