### PR TITLE
Improve Scaling For Cards

### DIFF
--- a/client/src/components/card-list/card-list.module.scss
+++ b/client/src/components/card-list/card-list.module.scss
@@ -1,5 +1,5 @@
 $gap: 0;
-$speed: 250ms;
+$speed: 200ms;
 $card-size: 118px;
 
 .cardList {
@@ -8,25 +8,29 @@ $card-size: 118px;
 	align-items: center;
 	flex-flow: row;
 	gap: $gap;
-  container-type: inline-size;
-	container-name: cardList;
 }
 
 .wrap {
+	container-type: inline-size;
+	container-name: cardList;
 	flex-wrap: wrap;
-
-	svg {
-		height: 100%;
-	}
 }
 
-.card {
-	display: grid;
-	@for $i from 1 through 6 {
+.autoscale {
+	@for $i from 1 through 20 {
 		@container cardList (width > calc(#{$i} * #{$card-size})) {
 			width: calc(100% / #{$i});
 		}
 	}
+}
+
+.defaultSize {
+	width: $card-size;
+	flex: 0 0 auto;
+}
+
+.card {
+	display: grid;
 }
 
 .clickable:not(:disabled) {
@@ -41,8 +45,8 @@ $card-size: 118px;
 
 // React Transitions Group Animations
 .enter {
-	transition: all $speed ease-in;
 	opacity: 0;
+	width: 0px;
 
 	> svg {
 		transition: all $speed ease-in;
@@ -53,12 +57,7 @@ $card-size: 118px;
 .enterActive {
 	transition: all $speed ease-in;
 	opacity: 1;
-	width: 100px;
-
-	> svg {
-		transition: all $speed ease-in;
-		filter: scale(100%);
-	}
+	width: $card-size;
 }
 
 .enterDone {
@@ -68,7 +67,6 @@ $card-size: 118px;
 .exit {
 	transition: all $speed ease-in;
 	opacity: 1;
-	width: 100px;
 
 	> svg {
 		transition: all $speed ease-in;
@@ -81,6 +79,7 @@ $card-size: 118px;
 	transition: all $speed ease-in;
 	opacity: 0;
 	margin-right: -$gap;
+	width: 0px;
 
 	> svg {
 		transition: all $speed ease-in;

--- a/client/src/components/card-list/card-list.module.scss
+++ b/client/src/components/card-list/card-list.module.scss
@@ -1,29 +1,32 @@
 $gap: 0;
 $speed: 250ms;
+$card-size: 118px;
 
 .cardList {
 	display: flex;
 	justify-content: flex-start;
 	align-items: center;
-	flex-flow: row nowrap;
-	height: 110px;
+	flex-flow: row;
 	gap: $gap;
+  container-type: inline-size;
+	container-name: cardList;
 }
 
 .wrap {
 	flex-wrap: wrap;
-	height: unset;
 
 	svg {
-		height: 118px;
+		height: 100%;
 	}
 }
 
 .card {
-	flex: 0 0 auto;
 	display: grid;
-	place-content: center;
-	vertical-align: middle;
+	@for $i from 1 through 6 {
+		@container cardList (width > calc(#{$i} * #{$card-size})) {
+			width: calc(100% / #{$i});
+		}
+	}
 }
 
 .clickable:not(:disabled) {
@@ -40,7 +43,6 @@ $speed: 250ms;
 .enter {
 	transition: all $speed ease-in;
 	opacity: 0;
-	width: 0;
 
 	> svg {
 		transition: all $speed ease-in;
@@ -78,7 +80,6 @@ $speed: 250ms;
 .exitActive {
 	transition: all $speed ease-in;
 	opacity: 0;
-	width: 0;
 	margin-right: -$gap;
 
 	> svg {

--- a/client/src/components/card-list/card-list.tsx
+++ b/client/src/components/card-list/card-list.tsx
@@ -30,7 +30,6 @@ const CardList = (props: CardListProps) => {
 
 		let cardComponent = (
 			<CardComponent
-				key={card.entity}
 				className={cn(css.card, {
 					[css.clickable]: !!onClick && !isDisabled,
 				})}
@@ -48,7 +47,7 @@ const CardList = (props: CardListProps) => {
 			return (
 				<CSSTransition
 					key={card.entity}
-					timeout={250}
+					timeout={200}
 					unmountOnExit={true}
 					classNames={{
 						enter: css.enter,
@@ -58,11 +57,15 @@ const CardList = (props: CardListProps) => {
 						exitActive: css.exitActive,
 					}}
 				>
-					{cardComponent}
+					<div className={cn({[css.autoscale]: wrap, [css.defaultSize]: !wrap})}>{cardComponent}</div>
 				</CSSTransition>
 			)
 		} else {
-			return cardComponent
+			return (
+				<div key={card.entity} className={cn({[css.autoscale]: wrap, [css.defaultSize]: !wrap})}>
+					{cardComponent}
+				</div>
+			)
 		}
 	})
 

--- a/client/src/components/card-list/card-list.tsx
+++ b/client/src/components/card-list/card-list.tsx
@@ -57,7 +57,9 @@ const CardList = (props: CardListProps) => {
 						exitActive: css.exitActive,
 					}}
 				>
-					<div className={cn({[css.autoscale]: wrap, [css.defaultSize]: !wrap})}>{cardComponent}</div>
+					<div className={cn({[css.autoscale]: wrap, [css.defaultSize]: !wrap})}>
+						{cardComponent}
+					</div>
 				</CSSTransition>
 			)
 		} else {


### PR DESCRIPTION
This PR makes the scaling for cards in the deck editor take up the maximum amount of space possible. This greatly improves the usability on mobile and I think this looks better on desktop too.