### PR TITLE
Fix errors with various game logs

### DIFF
--- a/common/cards/alter-egos/effects/string.ts
+++ b/common/cards/alter-egos/effects/string.ts
@@ -24,7 +24,7 @@ class String extends Card {
 			query.not(query.slot.frozen)
 		),
 		log: (values) =>
-			`$o{${values.opponent}|You}$ attached $eString$ to $p${values.pos.hermitCard}$`,
+			`$o{${values.opponent}|You}$ attached $e${this.props.name}$ to $p${values.pos.hermitCard}$`,
 	}
 }
 

--- a/common/cards/default/single-use/spyglass.ts
+++ b/common/cards/default/single-use/spyglass.ts
@@ -19,7 +19,7 @@ class Spyglass extends Card {
 		description:
 			"Look at your opponent's hand, and then flip a coin.\nIf heads, choose one card to discard from your opponent's hand.",
 		showConfirmationModal: true,
-		log: (values) => `${values.defaultLog} and ${values.coinFlip}`,
+		log: (values) => `${values.defaultLog}, and ${values.coinFlip}`,
 		attachCondition: query.every(
 			singleUse.attachCondition,
 			(game, _pos) => game.state.turn.turnNumber !== 1
@@ -32,6 +32,13 @@ class Spyglass extends Card {
 		observer.subscribe(player.hooks.onApply, () => {
 			const coinFlip = flipCoin(player, component)
 			const canDiscard = coinFlip[0] === 'heads' && opponentPlayer.getHand().length > 0
+
+			const getEntry = (card: CardComponent): string => {
+				return `$p{You|${opponentPlayer.playerName}}$ discarded ${getFormattedName(
+					card.props.id,
+					true
+				)} from {$o${game.opponentPlayer.playerName}'s$|your} hand`
+			}
 
 			game.addModalRequest({
 				playerId: player.id,
@@ -59,13 +66,7 @@ class Spyglass extends Card {
 
 					card.discard()
 
-					game.battleLog.addEntry(
-						player.entity,
-						`$p{You|${opponentPlayer.playerName}}$ discarded ${getFormattedName(
-							card.props.id,
-							true
-						)} from {$o${game.opponentPlayer.playerName}'s$|your} hand`
-					)
+					game.battleLog.addEntry(player.entity, getEntry(card))
 
 					return 'SUCCESS'
 				},
@@ -74,6 +75,7 @@ class Spyglass extends Card {
 						// Discard a random card from the opponent's hand
 						let opponentHand = opponentPlayer.getHand()
 						const slotIndex = Math.floor(Math.random() * opponentHand.length)
+						game.battleLog.addEntry(player.entity, getEntry(opponentHand[slotIndex]))
 						opponentHand[slotIndex].discard()
 					}
 				},

--- a/common/components/player-component.ts
+++ b/common/components/player-component.ts
@@ -254,12 +254,12 @@ export class PlayerComponent {
 			const newHermit = this.game.components.findEntity(
 				CardComponent,
 				query.card.isHermit,
-				query.card.slot(query.slot.rowIs(currentActiveRow?.entity))
+				query.card.slot(query.slot.rowIs(newRow.entity))
 			)
 			const oldHermit = this.game.components.findEntity(
 				CardComponent,
 				query.card.isHermit,
-				query.card.slot(query.slot.rowIs(newRow.entity))
+				query.card.slot(query.slot.rowIs(currentActiveRow?.entity))
 			)
 			this.game.battleLog.addChangeRowEntry(this, newRow.entity, oldHermit, newHermit)
 		}

--- a/common/models/battle-log-model.ts
+++ b/common/models/battle-log-model.ts
@@ -89,7 +89,7 @@ export class BattleLogModel {
 	public addPlayCardEntry(
 		card: CardComponent,
 		coinFlips: Array<CurrentCoinFlip>,
-		slotInfo: SlotComponent | null
+		pickedSlot: SlotComponent | null
 	) {
 		let {player, opponentPlayer} = card
 
@@ -112,8 +112,9 @@ export class BattleLogModel {
 			return `${card.props.name}`
 		}
 
-		let row = slotInfo?.inRow() ? slotInfo.row : null
-		let cardInfo = slotInfo?.getCard()
+		const cardRow = card.slot.inRow() ? card.slot.row : null
+		const pickedRow = pickedSlot?.inRow() ? pickedSlot.row : null
+		const pickedCard = pickedSlot?.getCard()
 
 		const thisFlip = coinFlips.find((flip) => flip.card == card.entity)
 		const invalid = '$bINVALID VALUE$'
@@ -124,18 +125,18 @@ export class BattleLogModel {
 			coinFlip: thisFlip ? this.generateCoinFlipDescription(thisFlip) : '',
 			defaultLog: `$p{You|${player.playerName}}$ used $e${card.props.name}$`,
 			pos: {
-				rowIndex: card.slot.inRow() ? `${card.slot.row.index + 1}` : invalid,
-				id: card.props.id || invalid,
-				name: genCardName(card.player, card, row),
-				hermitCard: genCardName(card.player, cardInfo, row),
+				rowIndex: cardRow ? `${cardRow.index + 1}` : invalid,
+				id: card.props.id,
+				name: genCardName(card.player, card, cardRow),
+				hermitCard: genCardName(card.player, cardRow?.getHermit(), cardRow),
 				slotType: card.slot.type,
 			},
 			pick: {
-				rowIndex: row !== null ? `${row.index + 1}` : invalid,
-				id: cardInfo?.card.props.id || invalid,
-				name: cardInfo ? genCardName(slotInfo?.player, card, row) : invalid,
-				hermitCard: genCardName(slotInfo?.player, cardInfo, row),
-				slotType: slotInfo?.type || invalid,
+				rowIndex: pickedRow !== null ? `${pickedRow.index + 1}` : invalid,
+				id: pickedCard?.card.props.id || invalid,
+				name: pickedCard ? genCardName(pickedSlot?.player, pickedCard, pickedRow) : invalid,
+				hermitCard: genCardName(pickedSlot?.player, pickedRow?.getHermit(), pickedRow),
+				slotType: pickedSlot?.type || invalid,
 			},
 			game: this.game,
 		})
@@ -315,7 +316,8 @@ export class BattleLogModel {
 
 		if (pos instanceof CardComponent) {
 			const targetFormatting = pos.player.entity === this.game.currentPlayerEntity ? 'p' : 'o'
-			const rowNumberString = (pos.slot.inRow() && pos.slot.row.index.toString()) || 'Unknown Row'
+			const rowNumberString =
+				(pos.slot.inRow() && (pos.slot.row.index + 1).toString()) || 'Unknown Row'
 
 			const logMessage = log({
 				target: `$${targetFormatting}${pos.props.name} (${rowNumberString})$`,

--- a/common/types/cards.ts
+++ b/common/types/cards.ts
@@ -63,9 +63,9 @@ export type PlayCardLog = {
 		name: string
 		/**The id of this card */
 		id: string
-		/**The name of the Hermit Card on the row the card was placed.*/
+		/**The name of the Hermit Card on the row this card was placed.*/
 		hermitCard: string
-		/**The slot type the card was placed on.*/
+		/**The slot type this card was placed on.*/
 		slotType: string
 	}
 	/**Information about the pick for the card.*/
@@ -74,7 +74,7 @@ export type PlayCardLog = {
 		rowIndex: string
 		/**Name of the card in the slot that was picked.*/
 		name: string
-		/**The id of this card */
+		/**The id of the picked card */
 		id: string
 		/**The name of the Hermit Card on the row that was picked.*/
 		hermitCard: string

--- a/server/src/routines/turn-actions/play-card.ts
+++ b/server/src/routines/turn-actions/play-card.ts
@@ -83,7 +83,7 @@ function* playCardSaga(
 
 	// Add entry to battle log, unless it is played in a single use slot
 	if (pickedSlot.type !== 'single_use') {
-		game.battleLog.addPlayCardEntry(card, currentPlayer.coinFlips, card.slot)
+		game.battleLog.addPlayCardEntry(card, currentPlayer.coinFlips, pickedSlot)
 	}
 
 	// Call onAttach hook


### PR DESCRIPTION
- Fixes backwards change row logs
- Fixes single use logs that reference `values.pick`
- Fixes wrong row index for status effect logs
- Make String and Spyglass apply logs consistent with similar effect cards
- Add log for discarded random card on Spyglass modal timeout