### PR TITLE
Fix Joehills/Cleo interaction and other unintuitive interactions

### DIFF
--- a/common/cards/default/hermits/joehills-rare.ts
+++ b/common/cards/default/hermits/joehills-rare.ts
@@ -4,7 +4,7 @@ import {flipCoin} from '../../../utils/coinFlips'
 import Card from '../../base/card'
 import {hermit} from '../../base/defaults'
 import {Hermit} from '../../base/types'
-import {effect} from '../../../components/query'
+import * as query from '../../../components/query'
 import UsedClockEffect from '../../../status-effects/used-clock'
 import TurnSkippedEffect from '../../../status-effects/turn-skipped'
 import {MultiturnSecondaryAttackDisabledEffect} from '../../../status-effects/multiturn-attack-disabled'
@@ -50,8 +50,8 @@ class JoeHillsRare extends Card {
 			if (
 				game.components.exists(
 					StatusEffectComponent,
-					effect.is(UsedClockEffect),
-					effect.targetEntity(component.entity)
+					query.effect.is(UsedClockEffect),
+					query.effect.targetEntity(component.entity)
 				)
 			) {
 				return
@@ -66,9 +66,14 @@ class JoeHillsRare extends Card {
 
 			game.components.new(StatusEffectComponent, TurnSkippedEffect).apply(opponentPlayer.entity)
 			game.components.new(StatusEffectComponent, UsedClockEffect).apply(player.entity)
+
 			game.components
-				.new(StatusEffectComponent, MultiturnSecondaryAttackDisabledEffect)
-				.apply(component.entity)
+				.filter(CardComponent, query.card.currentPlayer, query.card.is(JoeHillsRare))
+				.forEach((joe) =>
+					game.components
+						.new(StatusEffectComponent, MultiturnSecondaryAttackDisabledEffect)
+						.apply(joe.entity)
+				)
 		})
 	}
 }


### PR DESCRIPTION
When Timeskip is used, it now blocks the secondary for all Joehills the player has on the board. This fixing some unintuitive interactiosn with Timeskip being able to be used but it not being able to fix a turn. This also fixes the interaction with Cleo, where her secondary would be blocked instead of Joe.