### PR TITLE
Fix Weakness

### DIFF
--- a/common/status-effects/weakness.ts
+++ b/common/status-effects/weakness.ts
@@ -29,11 +29,9 @@ class WeaknessEffect extends CardStatusEffect {
 			if (effect.counter === 0) effect.remove()
 		})
 
-		observer.subscribe(player.hooks.onDefence, (attack) => {
-			if (attack.targetEntity !== effect.targetEntity || attack.createWeakness === 'never') {
-				return
-			}
-
+		observer.subscribe(player.hooks.beforeDefence, (attack) => {
+			if (!target.slot.inRow()) return
+			if (attack.targetEntity !== target.slot.rowEntity || attack.createWeakness === 'never') return
 			attack.createWeakness = 'always'
 		})
 	}


### PR DESCRIPTION
Weakness now correctly applies.
I noticed a bug where Shade E E can not deal extra weakness damage if he gets his bonus damage but im not sure why so I didn't fix it in this PR.