### PR TITLE
Fix deathloop reviving hermits that aren't the target and remove status effects

### DIFF
--- a/common/status-effects/death-loop.ts
+++ b/common/status-effects/death-loop.ts
@@ -2,6 +2,7 @@ import {CardProps} from '../cards/base/types'
 import {StatusEffectComponent, CardComponent, ObserverComponent} from '../components'
 import {GameModel} from '../models/game-model'
 import {CardStatusEffect, StatusEffectProps, systemStatusEffect} from './status-effect'
+import * as query from '../components/query'
 
 export class DeathloopReady extends CardStatusEffect {
 	props: StatusEffectProps = {
@@ -36,6 +37,14 @@ export class DeathloopReady extends CardStatusEffect {
 					(_game, effect) =>
 						effect.target?.entity === targetHermit.entity &&
 						effect.statusEffect.props.icon === 'revived_by_deathloop'
+				)
+				.forEach((effect) => effect.remove())
+
+			game.components
+				.filter(
+					StatusEffectComponent,
+					query.effect.targetEntity(target.entity),
+					query.effect.type('normal', 'damage')
 				)
 				.forEach((effect) => effect.remove())
 

--- a/common/status-effects/death-loop.ts
+++ b/common/status-effects/death-loop.ts
@@ -23,8 +23,10 @@ export class DeathloopReady extends CardStatusEffect {
 		observer.subscribeBefore(opponentPlayer.hooks.afterAttack, (attack) => {
 			const row = attack.target
 			if (!row || row.health === null || row.health > 0) return
-			const target = row.getHermit()
-			if (!target) return
+			const targetHermit = row.getHermit()
+			if (!targetHermit) return
+
+			if (targetHermit.entity !== target.entity) return
 
 			row.health = 50
 
@@ -32,17 +34,19 @@ export class DeathloopReady extends CardStatusEffect {
 				.filter(
 					StatusEffectComponent,
 					(_game, effect) =>
-						effect.target?.entity === target.entity &&
+						effect.target?.entity === targetHermit.entity &&
 						effect.statusEffect.props.icon === 'revived_by_deathloop'
 				)
 				.forEach((effect) => effect.remove())
 
 			game.battleLog.addEntry(
 				player.entity,
-				`Using $vDeathloop$, $p${target.props.name}$ revived with $g50hp$`
+				`Using $vDeathloop$, $p${targetHermit.props.name}$ revived with $g50hp$`
 			)
 
-			game.components.new(StatusEffectComponent, RevivedByDeathloopEffect).apply(target.entity)
+			game.components
+				.new(StatusEffectComponent, RevivedByDeathloopEffect)
+				.apply(targetHermit.entity)
 			effect.remove()
 		})
 


### PR DESCRIPTION
This PR makes it so deathloop removes both buffs and debuffs. I think we will need other changes to the game to fix that.