### PR TITLE
Consider slots as empty if the hermit is dead

### DIFF
--- a/common/components/query/slot.ts
+++ b/common/components/query/slot.ts
@@ -1,4 +1,4 @@
-import {ComponentQuery, card, effect} from '.'
+import {ComponentQuery} from '.'
 import {CardComponent, RowComponent, SlotComponent, StatusEffectComponent} from '..'
 import {CardClass} from '../../cards/base/card'
 import {PlayerEntity, RowEntity, SlotEntity} from '../../entities'
@@ -23,7 +23,10 @@ export function player(player: PlayerEntity | null): ComponentQuery<SlotComponen
 
 /** Return true if the spot is empty. */
 export const empty: ComponentQuery<SlotComponent> = (game, pos) => {
-	return !game.components.exists(CardComponent, card.slotEntity(pos.entity))
+	let card = game.components.find(CardComponent, query.card.slotEntity(pos.entity))
+	if (!card) return true
+	if (card.isHermit() && !card.isAlive()) return true
+	return false
 }
 
 /** Return true if the card is attached to a hermit slot. */
@@ -100,7 +103,11 @@ export const entity = (entity: SlotEntity | null | undefined): ComponentQuery<Sl
 
 export const has = (...cards: Array<CardClass>): ComponentQuery<SlotComponent> => {
 	return (game, pos) => {
-		return game.components.exists(CardComponent, card.is(...cards), card.slotEntity(pos.entity))
+		return game.components.exists(
+			CardComponent,
+			query.card.is(...cards),
+			query.card.slotEntity(pos.entity)
+		)
 	}
 }
 
@@ -128,8 +135,8 @@ export function hasStatusEffect(
 	return (game, pos) => {
 		return game.components.exists(
 			StatusEffectComponent,
-			effect.is(statusEffect),
-			effect.targetIsCardAnd(card.slotEntity(pos.entity))
+			query.effect.is(statusEffect),
+			query.effect.targetIsCardAnd(query.card.slotEntity(pos.entity))
 		)
 	}
 }


### PR DESCRIPTION
This fixes an issue with Tango where he would force the opponent to switch to an inactive hermit if they just died.