### PR TITLE
Split Redirect and Set Target to Fix Hypno

### DIFF
--- a/common/cards/alter-egos/effects/chainmail-armor.ts
+++ b/common/cards/alter-egos/effects/chainmail-armor.ts
@@ -28,7 +28,7 @@ class ChainmailArmor extends Card {
 			// only protect against su attacks and attacks which have been redirected by su cards
 			let suRedirect = false
 
-			const lastTargetChange = attack.getHistory('set_target').pop()
+			const lastTargetChange = attack.getHistory('redirect').pop()
 			if (lastTargetChange) {
 				// This attack has been redirected to us by a su card
 				suRedirect = true

--- a/common/cards/alter-egos/effects/lightning-rod.ts
+++ b/common/cards/alter-egos/effects/lightning-rod.ts
@@ -40,7 +40,7 @@ class LightningRod extends Card {
 			if (game.currentPlayer.entity !== opponentPlayer.entity) return
 			if (attack.target?.player.id !== player.id) return
 
-			attack.setTarget(component.entity, component.slot.row?.entity)
+			attack.redirect(component.entity, component.slot.row?.entity)
 			used = true
 		})
 

--- a/common/cards/alter-egos/hermits/renbob-rare.ts
+++ b/common/cards/alter-egos/hermits/renbob-rare.ts
@@ -38,7 +38,7 @@ class RenbobRare extends Card {
 		observer.subscribe(player.hooks.beforeAttack, (attack) => {
 			if (!attack.isAttacker(component.entity) || attack.type !== 'secondary') return
 			if (!component.slot.inRow()) return
-			attack.setTarget(
+			attack.redirect(
 				component.entity,
 				game.components.find(RowComponent, row.opponentPlayer, row.index(component.slot.row.index))
 					?.entity || null

--- a/common/cards/default/hermits/hypnotizd-rare.ts
+++ b/common/cards/default/hermits/hypnotizd-rare.ts
@@ -6,6 +6,8 @@ import {hermit} from '../../base/defaults'
 import {Hermit} from '../../base/types'
 import {CardComponent, ObserverComponent, SlotComponent} from '../../../components'
 import BetrayedEffect from '../../../status-effects/betrayed'
+import {AttackModel} from '../../../models/attack-model'
+import {HermitAttackType} from '../../../types/attack'
 
 /*
 - Has to support having two different afk targets (one for hypno, one for su effect like bow)

--- a/common/models/attack-model.ts
+++ b/common/models/attack-model.ts
@@ -184,10 +184,18 @@ export class AttackModel {
 		this.addHistory(attacker, 'set_attacker', attacker)
 		return this
 	}
-	/** Sets the target for this attack */
+
+	/** Sets the target for this attack. Unlike reidrect, this does not trigger Chainmail Armor. */
 	public setTarget(sourceId: AttackerEntity, target: RowEntity | null) {
 		this.targetEntity = target
 		this.addHistory(sourceId, 'set_target', target)
+		return this
+	}
+
+	/** Redirect the attack to another hermit. Unlike setTarget, this will trigger Chainmail Armor. */
+	public redirect(sourceId: AttackerEntity, target: RowEntity | null) {
+		this.targetEntity = target
+		this.addHistory(sourceId, 'redirect', target)
 		return this
 	}
 

--- a/common/status-effects/betrayed.ts
+++ b/common/status-effects/betrayed.ts
@@ -100,7 +100,7 @@ class BetrayedEffect extends PlayerStatusEffect {
 			observer.unsubscribe(player.hooks.beforeAttack)
 
 			if (pickedAfkHermit !== null && pickedAfkHermit.inRow()) {
-				attack.setTarget(effect.entity, pickedAfkHermit.row.entity)
+				attack.redirect(effect.entity, pickedAfkHermit.row.entity)
 			}
 
 			// They attacked now, they can end turn or change hermits with Chorus Fruit

--- a/common/status-effects/sheep-stare.ts
+++ b/common/status-effects/sheep-stare.ts
@@ -42,7 +42,7 @@ class SheepStareEffect extends PlayerStatusEffect {
 			if (!(attack.attacker instanceof CardComponent) || !attack.attacker.slot.inRow()) return
 
 			if (coinFlipResult === 'heads') {
-				attack.setTarget(effect.entity, attack.attacker.slot.rowEntity)
+				attack.redirect(effect.entity, attack.attacker.slot.rowEntity)
 			}
 		})
 

--- a/common/status-effects/target-block.ts
+++ b/common/status-effects/target-block.ts
@@ -21,7 +21,7 @@ export class TargetBlockEffect extends CardStatusEffect {
 		observer.subscribe(opponentPlayer.hooks.beforeAttack, (attack) => {
 			if (attack.isType('status-effect') || attack.isBacklash) return
 			if (!target.slot.inRow()) return
-			attack.setTarget(effect.entity, target.slot.row.entity)
+			attack.redirect(effect.entity, target.slot.row.entity)
 		})
 
 		observer.subscribe(opponentPlayer.hooks.onTurnEnd, () => {

--- a/common/types/attack.ts
+++ b/common/types/attack.ts
@@ -63,6 +63,7 @@ export type AttackHistoryType =
 	| 'lock_damage'
 	| 'set_attacker'
 	| 'set_target'
+	| 'redirect'
 
 export type AttackHistory = {
 	source: AttackerEntity


### PR DESCRIPTION
Redirecting and setting the target have a different meaning because of Chainmail Armor.