### PR TITLE
Improve the implementation of Invisibility Potion

### DIFF
--- a/common/cards/default/single-use/invisibility-potion.ts
+++ b/common/cards/default/single-use/invisibility-potion.ts
@@ -1,11 +1,5 @@
 import {GameModel} from '../../../models/game-model'
-import * as query from '../../../components/query'
-import {
-	CardComponent,
-	ObserverComponent,
-	SlotComponent,
-	StatusEffectComponent,
-} from '../../../components'
+import {CardComponent, ObserverComponent, StatusEffectComponent} from '../../../components'
 import {flipCoin} from '../../../utils/coinFlips'
 import Card from '../../base/card'
 import {SingleUse} from '../../base/types'
@@ -16,8 +10,6 @@ import {
 } from '../../../status-effects/invisibility-potion'
 
 class InvisibilityPotion extends Card {
-	applyTo = query.every(query.slot.opponent, query.slot.active, query.slot.hermit)
-
 	props: SingleUse = {
 		...singleUse,
 		id: 'invisibility_potion',
@@ -35,10 +27,6 @@ class InvisibilityPotion extends Card {
 				name: 'missed',
 			},
 		],
-		attachCondition: query.every(
-			singleUse.attachCondition,
-			query.exists(SlotComponent, this.applyTo)
-		),
 		log: (values) => `${values.defaultLog}, and ${values.coinFlip}`,
 	}
 

--- a/common/status-effects/invisibility-potion.ts
+++ b/common/status-effects/invisibility-potion.ts
@@ -6,22 +6,19 @@ export class InvisibilityPotionHeadsEffect extends PlayerStatusEffect {
 	props: StatusEffectProps = {
 		...systemStatusEffect,
 		icon: 'invisibility-potion-heads',
-		name: 'Invisibility Potion - Heads',
+		name: 'Hidden!',
 		description: "Your opponent's next attack will miss.",
 	}
 
 	override onApply(
-		game: GameModel,
+		_game: GameModel,
 		effect: StatusEffectComponent,
 		player: PlayerComponent,
 		observer: ObserverComponent
 	) {
 		observer.subscribe(player.hooks.beforeDefence, (attack) => {
-			if (attack.isType('weakness', 'effect', 'status-effect')) return
+			if (!attack.isType('primary', 'secondary')) return
 			attack.multiplyDamage(effect.entity, 0)
-		})
-
-		observer.subscribe(player.hooks.afterDefence, () => {
 			effect.remove()
 		})
 	}
@@ -31,22 +28,19 @@ export class InvisibilityPotionTailsEffect extends PlayerStatusEffect {
 	props: StatusEffectProps = {
 		...systemStatusEffect,
 		icon: 'invisibility-potion-tails',
-		name: 'Invisibility Potion - Tails',
+		name: 'Spotted!',
 		description: "Your opponent's next attack will deal double damage.",
 	}
 
 	override onApply(
-		game: GameModel,
+		_game: GameModel,
 		effect: StatusEffectComponent,
 		player: PlayerComponent,
 		observer: ObserverComponent
 	) {
 		observer.subscribe(player.hooks.beforeDefence, (attack) => {
-			if (attack.isType('weakness', 'effect', 'status-effect')) return
+			if (!attack.isType('primary', 'secondary')) return
 			attack.multiplyDamage(effect.entity, 2)
-		})
-
-		observer.subscribe(player.hooks.afterDefence, () => {
 			effect.remove()
 		})
 	}


### PR DESCRIPTION
Fixes a bug where invisibility would trigger on any attack. Additionally removes the attach condition because it was not needed and renames the status effects to follow the theme of invisibility potion.