### PR TITLE
Fix turn skip message on mobile to keep end turn button

### DIFF
--- a/client/src/app/game/actions/actions.module.scss
+++ b/client/src/app/game/actions/actions.module.scss
@@ -147,6 +147,17 @@
 	}
 }
 
+.turnSkipMessageContainer {
+	display: grid;
+	grid-auto-flow: column;
+	grid-auto-columns: 50%;
+}
+
+.turnSkipEndTurnButton {
+	display: flex;
+	width: 100%;
+}
+
 @media (orientation: landscape) {
 	.mobile {
 		display: none;

--- a/client/src/app/game/actions/mobile-actions.tsx
+++ b/client/src/app/game/actions/mobile-actions.tsx
@@ -51,7 +51,6 @@ const MobileActions = ({onClick, localGameState, id}: Props) => {
 	const Status = () => {
 		const waitingForOpponent =
 			availableActions.includes('WAIT_FOR_OPPONENT_ACTION') && availableActions.length === 1
-		const endTurn = availableActions.includes('END_TURN')
 		const changeHermit = availableActions.includes('CHANGE_ACTIVE_HERMIT')
 
 		// TODO: Show coin flip results for longer amount of time
@@ -67,8 +66,6 @@ const MobileActions = ({onClick, localGameState, id}: Props) => {
 			message = "Waiting for opponent's action..."
 		} else if (changeHermit && availableActions.length === 1) {
 			message = 'Select a new active Hermit'
-		} else if (endTurn && changeHermit && availableActions.length === 2) {
-			message = 'Switch to a new Hermit or end your turn'
 		}
 
 		if (message == '') return null

--- a/client/src/app/game/actions/mobile-actions.tsx
+++ b/client/src/app/game/actions/mobile-actions.tsx
@@ -48,10 +48,23 @@ const MobileActions = ({onClick, localGameState, id}: Props) => {
 		}
 	}
 
+	let endTurnButton = (
+		<Button
+			variant={!availableActions.includes('END_TURN') ? 'default' : 'error'}
+			size="medium"
+			className={css.mobileButton}
+			onClick={handleEndTurn}
+			disabled={!availableActions.includes('END_TURN')}
+		>
+			End Turn
+		</Button>
+	)
+
 	const Status = () => {
 		const waitingForOpponent =
 			availableActions.includes('WAIT_FOR_OPPONENT_ACTION') && availableActions.length === 1
 		const changeHermit = availableActions.includes('CHANGE_ACTIVE_HERMIT')
+		const endTurn = availableActions.includes('END_TURN')
 
 		// TODO: Show coin flip results for longer amount of time
 		if (currentCoinFlip) {
@@ -66,6 +79,13 @@ const MobileActions = ({onClick, localGameState, id}: Props) => {
 			message = "Waiting for opponent's action..."
 		} else if (changeHermit && availableActions.length === 1) {
 			message = 'Select a new active Hermit'
+		} else if (endTurn && changeHermit && availableActions.length === 2) {
+			return (
+				<div className={css.turnSkipMessageContainer}>
+					<div>Switch to a new Hermit or end your turn</div>
+					<div className={css.turnSkipEndTurnButton}>{endTurnButton}</div>
+				</div>
+			)
 		}
 
 		if (message == '') return null
@@ -118,22 +138,14 @@ const MobileActions = ({onClick, localGameState, id}: Props) => {
 			<div className={css.buttons}>
 				<Button
 					variant="default"
-					size="small"
+					size="medium"
 					className={css.mobileButton}
 					onClick={handleAttack}
 					disabled={!attackOptions}
 				>
 					Attack
 				</Button>
-				<Button
-					variant={!availableActions.includes('END_TURN') ? 'default' : 'error'}
-					size="small"
-					className={css.mobileButton}
-					onClick={handleEndTurn}
-					disabled={!availableActions.includes('END_TURN')}
-				>
-					End Turn
-				</Button>
+				{endTurnButton}
 			</div>
 		)
 	}


### PR DESCRIPTION
There was an issue where people were forced to switch their active hermit or wait for their turn to time out.