### PR TITLE
remove card pointer events on mobile

### DIFF
--- a/client/src/components/card-list/card-list.module.scss
+++ b/client/src/components/card-list/card-list.module.scss
@@ -1,3 +1,5 @@
+@use 'sass:math';
+
 $gap: 0;
 $speed: 200ms;
 $card-size: 118px;
@@ -21,7 +23,13 @@ $card-size: 118px;
 .autoscale {
 	@for $i from 1 through 20 {
 		@container cardList (width > calc(#{$i} * #{$card-size})) {
-			width: calc(100% / #{$i});
+			@if $i > 3 {
+				width: calc(100% / #{$i});
+			} @else if $i == 2 {
+				width: 33%;
+			} @else if $i == 1 {
+				width: 50%;
+			}
 		}
 	}
 }

--- a/client/src/components/card/card.module.scss
+++ b/client/src/components/card/card.module.scss
@@ -19,6 +19,12 @@
 	}
 }
 
+.noPointerEvents {
+	@media (orientation: portrait) {
+		pointer-events: none;
+	}
+}
+
 .selected {
 	&:not(:disabled) {
 		outline: 3px solid hsl(192deg, 56%, 58%);

--- a/client/src/components/card/card.tsx
+++ b/client/src/components/card/card.tsx
@@ -44,7 +44,9 @@ const Card = (props: CardReactProps) => {
 				})}
 				onClick={unpickable ? () => {} : onClick}
 			>
+				<div className={css.noPointerEvents}>
 				{card}
+				</div>
 			</button>
 		</Tooltip>
 	)

--- a/client/src/components/card/card.tsx
+++ b/client/src/components/card/card.tsx
@@ -44,9 +44,7 @@ const Card = (props: CardReactProps) => {
 				})}
 				onClick={unpickable ? () => {} : onClick}
 			>
-				<div className={css.noPointerEvents}>
-				{card}
-				</div>
+				<div className={css.noPointerEvents}>{card}</div>
 			</button>
 		</Tooltip>
 	)


### PR DESCRIPTION
This PR makes it so you can actually use the deck editor on mobile and makes it so there is 3 columns on the deck editor. 