### PR TITLE
Fix errors in logs

### DIFF
--- a/common/cards/alter-egos-iii/hermits/spookystress-rare.ts
+++ b/common/cards/alter-egos-iii/hermits/spookystress-rare.ts
@@ -51,7 +51,12 @@ class SpookyStressRare extends Card {
 			if (!waterBucketAttached) return
 
 			game.components
-				.filter(RowComponent, query.not(query.row.active), query.row.opponentPlayer)
+				.filter(
+					RowComponent,
+					query.row.opponentPlayer,
+					query.not(query.row.active),
+					query.row.hasHermit
+				)
 				.forEach((row) => {
 					const newAttack = game.newAttack({
 						attacker: component.entity,

--- a/common/cards/alter-egos-iii/hermits/spookystress-rare.ts
+++ b/common/cards/alter-egos-iii/hermits/spookystress-rare.ts
@@ -55,7 +55,7 @@ class SpookyStressRare extends Card {
 					RowComponent,
 					query.row.opponentPlayer,
 					query.not(query.row.active),
-					query.row.hasHermit
+					query.row.hermitSlotOccupied
 				)
 				.forEach((row) => {
 					const newAttack = game.newAttack({

--- a/common/cards/alter-egos/hermits/goatfather-rare.ts
+++ b/common/cards/alter-egos/hermits/goatfather-rare.ts
@@ -56,7 +56,7 @@ class GoatfatherRare extends Card {
 				.filter(
 					RowComponent,
 					query.row.opponentPlayer,
-					query.row.hasHermit,
+					query.row.hermitSlotOccupied,
 					(_game, row) =>
 						opponentActiveHermit !== null &&
 						opponentActiveHermit.slot.inRow() &&

--- a/common/cards/alter-egos/hermits/goatfather-rare.ts
+++ b/common/cards/alter-egos/hermits/goatfather-rare.ts
@@ -56,10 +56,11 @@ class GoatfatherRare extends Card {
 				.filter(
 					RowComponent,
 					query.row.opponentPlayer,
+					query.row.hasHermit,
 					(_game, row) =>
 						opponentActiveHermit !== null &&
 						opponentActiveHermit.slot.inRow() &&
-						row.index > opponentActiveHermit?.slot.row.index
+						row.index > opponentActiveHermit.slot.row.index
 				)
 				.forEach((row) => {
 					const newAttack = game.newAttack({

--- a/common/cards/alter-egos/single-use/anvil.ts
+++ b/common/cards/alter-egos/single-use/anvil.ts
@@ -20,17 +20,17 @@ class Anvil extends Card {
 			'Do 30hp damage to the Hermit directly opposite your active Hermit on the game board, and 10hp damage to each Hermit below it.',
 		hasAttack: true,
 		attackPreview: (game) => {
-			const targetAmount = this.getTargetHermis(game, game.currentPlayer).length - 1
+			const targetAmount = this.getTargetHermits(game, game.currentPlayer).length - 1
 			if (targetAmount === 0) return '$A30$'
 			return `$A30$ + $A10$ x ${targetAmount}`
 		},
 	}
 
-	getTargetHermis(game: GameModel, player: PlayerComponent) {
+	getTargetHermits(game: GameModel, player: PlayerComponent) {
 		return game.components.filter(
 			RowComponent,
 			query.row.opponentPlayer,
-			query.row.hasHermit,
+			query.row.hermitSlotOccupied,
 			(_game, row) => player.activeRow !== null && row.index >= player.activeRow?.index
 		)
 	}
@@ -39,7 +39,7 @@ class Anvil extends Card {
 		const {player} = component
 
 		observer.subscribe(player.hooks.getAttack, () => {
-			return this.getTargetHermis(game, player).reduce((attacks: null | AttackModel, row) => {
+			return this.getTargetHermits(game, player).reduce((attacks: null | AttackModel, row) => {
 				if (!row.getHermit()) return attacks
 
 				const newAttack = game

--- a/common/cards/default/effects/shield.ts
+++ b/common/cards/default/effects/shield.ts
@@ -34,14 +34,18 @@ class Shield extends Card {
 		})
 
 		observer.subscribe(player.hooks.afterDefence, (attack) => {
-			if (damageBlocked > 0) {
+			if (damageBlocked > 0 && attack.isTargeting(component)) {
+				// attack.isTargeting asserts `attack.target !== null` and `attack.targetEntity !== null`
 				component.discard()
 				const hermitName = game.components.find(
 					CardComponent,
 					query.card.slot(query.slot.hermit),
-					query.card.row(query.row.entity(attack.target?.entity))
+					query.card.row(query.row.entity(attack.targetEntity))
+				)?.props.name
+				game.battleLog.addEntry(
+					player.entity,
+					`$p${hermitName}'s$ $eShield$ on row #${attack.target!.index + 1} was broken`
 				)
-				game.battleLog.addEntry(player.entity, `$p${hermitName}'s$ $eShield$ was broken`)
 			}
 		})
 	}

--- a/common/components/query/row.ts
+++ b/common/components/query/row.ts
@@ -18,12 +18,17 @@ export const currentPlayer: ComponentQuery<RowComponent> = (game, pos) =>
 export const opponentPlayer: ComponentQuery<RowComponent> = (game, pos) =>
 	player(game.opponentPlayer.entity)(game, pos)
 
+/** Check if a row has a Hermit card attached (effect cards do not count) */
 export const hasHermit: ComponentQuery<RowComponent> = (game, row) =>
 	game.components.exists(
 		CardComponent,
 		query.card.isHermit,
 		query.card.slot(query.slot.rowIs(row.entity))
 	)
+
+/** Check if a row has a card attached to its hermit slot */
+export const hermitSlotOccupied: ComponentQuery<RowComponent> = (game, row) =>
+	game.components.exists(CardComponent, query.card.slot(query.slot.rowIs(row.entity)))
 
 export function hasCard(cardEntity: CardEntity): ComponentQuery<RowComponent> {
 	return (game, row) => {

--- a/common/models/battle-log-model.ts
+++ b/common/models/battle-log-model.ts
@@ -166,13 +166,13 @@ export class BattleLogModel {
 				return reducer
 			}
 
-			if (!attack.attacker || !attack.target) return reducer
+			if (!attack.attacker || !subAttack.target) return reducer
 
 			if (subAttack.getDamage() === 0) return reducer
 
 			const attackerInfo = attack.attacker
 
-			const targetFormatting = attack.target.player.id === attack.player.id ? 'p' : 'o'
+			const targetFormatting = subAttack.target.player.id === attack.player.id ? 'p' : 'o'
 
 			const weaknessAttack = attacks.find((a) => a.isType('weakness'))
 			const weaknessDamage =
@@ -193,11 +193,11 @@ export class BattleLogModel {
 			const logMessage = subAttack.getLog({
 				attacker: `$p${attackerInfo.props.name}$`,
 				player: attack.player.playerName,
-				opponent: attack.target.player.playerName,
+				opponent: attack.player.opponentPlayer.playerName,
 				target: `$${targetFormatting}${this.genCardName(
-					attack.target.player,
-					attack.target.getHermit(),
-					attack.target
+					subAttack.target.player,
+					subAttack.target.getHermit(),
+					subAttack.target
 				)}$`,
 				attackName: `$v${attackName}$`,
 				damage: `$b${subAttack.calculateDamage() + weaknessDamage}hp$`,


### PR DESCRIPTION
- Shield now logs the name of Hermit and row # when broken
- Multi-target attacks show correct target damaged by each sub-attack
- Rare Goatfather and Spooky Stress no longer attack empty rows
- Anvil no longer ignores rows with Armor Stand below the active