### PR TITLE
Fix Chroma Keyed Resetting on all Attacks

### DIFF
--- a/common/status-effects/chroma-keyed.ts
+++ b/common/status-effects/chroma-keyed.ts
@@ -24,7 +24,12 @@ class ChromaKeyedEffect extends CardStatusEffect {
 		let chromaUsedThisTurn = true
 
 		observer.subscribe(target.player.hooks.onAttack, (attack: AttackModel) => {
-			if (attack.isAttacker(target.entity) && attack.type === 'primary') {
+			if (
+				[
+					attack.isAttacker(target.entity) && attack.type === 'primary',
+					!attack.isAttacker(target.entity) && attack.isType('primary', 'secondary'),
+				].some(Boolean)
+			) {
 				effect.remove()
 				return
 			}

--- a/common/status-effects/chroma-keyed.ts
+++ b/common/status-effects/chroma-keyed.ts
@@ -24,15 +24,18 @@ class ChromaKeyedEffect extends CardStatusEffect {
 		let chromaUsedThisTurn = true
 
 		observer.subscribe(target.player.hooks.onAttack, (attack: AttackModel) => {
-			if (!attack.isAttacker(target.entity) || attack.type !== 'secondary') {
+			if (attack.isAttacker(target.entity) && attack.type === 'primary') {
 				effect.remove()
 				return
 			}
+
 			if (effect.counter === null) return
 
-			attack.reduceDamage(effect.entity, effect.counter * 10)
-			effect.counter++
-			chromaUsedThisTurn = true
+			if (attack.isAttacker(target.entity) && attack.type === 'secondary') {
+				attack.reduceDamage(effect.entity, effect.counter * 10)
+				effect.counter++
+				chromaUsedThisTurn = true
+			}
 		})
 
 		observer.subscribe(target.player.hooks.onTurnEnd, () => {


### PR DESCRIPTION
After this, chroma key only resets when you use a primary or secondary from not Beetljoest or use Beetljoest's primary.