### PR TITLE
Verify Slot is Empty When Playing a Card

### DIFF
--- a/server/src/routines/turn-actions/play-card.ts
+++ b/server/src/routines/turn-actions/play-card.ts
@@ -25,6 +25,12 @@ function* playCardSaga(
 		throw new Error('A slot that is not on the board can not be picked: ' + pickedSlot)
 	}
 
+	// You are not supposed to be able to select a slot with a card in it, but network issues can allow
+	// this to happen.
+	if (pickedSlot.getCard()) {
+		return 'FAILURE_INVALID_DATA'
+	}
+
 	const row = pickedSlot.row
 	const rowIndex = pickedSlot.index
 	const player = pickedSlot.player


### PR DESCRIPTION
This should hopefully fix the flint and steel bug where the card is randomly played twice when you played on bad internet.