### PR TITLE
Prevent coin flip animations after forfeits

### DIFF
--- a/server/src/routines/matchmaking.ts
+++ b/server/src/routines/matchmaking.ts
@@ -53,8 +53,8 @@ function* gameManager(game: GameModel) {
 				gameState.timer.turnRemaining = 0
 				gameState.timer.turnStartTime = getTimerForSeconds(0)
 				if (!game.endInfo.reason) {
-					// Remove coin flips from state if game was terminated before game end
-					// This prevents clients from showing previous flips that weren't cleared yet
+					// Remove coin flips from state if game was terminated before game end to prevent
+					// clients replaying animations after a forfeit, disconnect, or excessive game duration
 					playerIds.forEach((playerId) => (gameState.players[playerId].coinFlips = []))
 				}
 			}

--- a/server/src/routines/matchmaking.ts
+++ b/server/src/routines/matchmaking.ts
@@ -52,6 +52,10 @@ function* gameManager(game: GameModel) {
 			if (gameState) {
 				gameState.timer.turnRemaining = 0
 				gameState.timer.turnStartTime = getTimerForSeconds(0)
+				if (!game.endInfo.reason) {
+					// Remove coin flips from state if game was terminated before game end
+					playerIds.forEach((playerId) => (gameState.players[playerId].coinFlips = []))
+				}
 			}
 			const outcome = getGamePlayerOutcome(game, result, player.id)
 			broadcast([player], 'GAME_END', {

--- a/server/src/routines/matchmaking.ts
+++ b/server/src/routines/matchmaking.ts
@@ -54,6 +54,7 @@ function* gameManager(game: GameModel) {
 				gameState.timer.turnStartTime = getTimerForSeconds(0)
 				if (!game.endInfo.reason) {
 					// Remove coin flips from state if game was terminated before game end
+					// This prevents clients from showing previous flips that weren't cleared yet
 					playerIds.forEach((playerId) => (gameState.players[playerId].coinFlips = []))
 				}
 			}


### PR DESCRIPTION
Prevent showing coin flip animations when players forfeit, disconnect, or the game lasts for an excessive duration