### PR TITLE
Change sound settings words to be more obvious

### DIFF
--- a/client/src/app/main-menu/settings.tsx
+++ b/client/src/app/main-menu/settings.tsx
@@ -66,13 +66,13 @@ function Settings({setMenuSection}: Props) {
 			>
 				<div className={css.settings}>
 					<Slider value={settings.musicVolume} onInput={handleMusicChange}>
-						Music: {getPercDescriptor(settings.musicVolume)}
+						Music Volume: {getPercDescriptor(settings.musicVolume)}
 					</Slider>
 					<Slider value={settings.soundVolume} onInput={handleSoundChange}>
-						Sounds: {getPercDescriptor(settings.soundVolume)}
+						Sound Effect Volume: {getPercDescriptor(settings.soundVolume)}
 					</Slider>
 					<Button variant="stone" onClick={handleMuteSound}>
-						Muted: {getBoolDescriptor(settings.muted)}
+						Sound: {getBoolDescriptor(!settings.muted)}
 					</Button>
 					<Button variant="stone" onClick={handlePanoramaToggle}>
 						Panorama: {getBoolDescriptor(settings.panoramaEnabled)}


### PR DESCRIPTION
Before, I think it was a bit confusing how muting worked. I've changed it to be more obvious about which option is muted and which is unmuted