### PR TITLE
Improve royal protection description clarity

### DIFF
--- a/common/status-effects/royal-protection.ts
+++ b/common/status-effects/royal-protection.ts
@@ -16,7 +16,7 @@ class RoyalProtectionEffect extends CardStatusEffect {
 		icon: 'royal_protection',
 		name: 'Royal Protection',
 		description:
-			'Any attacks targeting a Hermit under Royal Protection are prevented.',
+			'Any damage dealt to a Hermit under Royal Protection is prevented.',
 		applyLog: (values) => `${values.target} was granted $eRoyal Protection$`,
 	}
 
@@ -28,6 +28,9 @@ class RoyalProtectionEffect extends CardStatusEffect {
 	): void {
 		observer.subscribe(target.player.hooks.beforeDefence, (attack) => {
 			if (!attack.isTargeting(target)) return
+
+			// Do not block backlash attacks
+			if (attack.isBacklash) return
 
 			attack.multiplyDamage(effect.entity, 0).lockDamage(effect.entity)
 		})


### PR DESCRIPTION
- Improves clarity of Royal Protection description
- Fixes a bug where Royal Protection would not block backlash attacks (Fortunately nobody to my knowledge ran prankster/speedrunner before this was found. Lol!)