### PR TITLE
Fix anvil and hyperspace logs

### DIFF
--- a/common/cards/alter-egos/hermits/renbob-rare.ts
+++ b/common/cards/alter-egos/hermits/renbob-rare.ts
@@ -9,6 +9,8 @@ import Card from '../../base/card'
 import {hermit} from '../../base/defaults'
 import {Hermit} from '../../base/types'
 
+const EMPTY_ROW = '$o$bINVALID_VALUE$$'
+
 class RenbobRare extends Card {
 	props: Hermit = {
 		...hermit,
@@ -56,6 +58,14 @@ class RenbobRare extends Card {
 					query.row.index(component.slot.row.index),
 				)?.entity || null,
 			)
+			attack.updateLog((values) => {
+				if (values.previousLog === undefined) return ''
+				return values.target === EMPTY_ROW
+					? values.previousLog
+							.replace(`${values.target} `, '')
+							.replace(`for ${values.damage} damage`, 'and missed')
+					: values.previousLog
+			})
 		})
 	}
 }

--- a/common/cards/alter-egos/hermits/renbob-rare.ts
+++ b/common/cards/alter-egos/hermits/renbob-rare.ts
@@ -9,7 +9,7 @@ import Card from '../../base/card'
 import {hermit} from '../../base/defaults'
 import {Hermit} from '../../base/types'
 
-const EMPTY_ROW = '$o$bINVALID_VALUE$$'
+const EMPTY_ROW = '$o$bINVALID VALUE$$'
 
 class RenbobRare extends Card {
 	props: Hermit = {

--- a/common/cards/alter-egos/single-use/anvil.ts
+++ b/common/cards/alter-egos/single-use/anvil.ts
@@ -28,7 +28,9 @@ class Anvil extends Card {
 			const targets = this.getTargetHermits(game, game.currentPlayer)
 			if (targets.length === 0) return '0'
 			if (targets[0].index === game.currentPlayer.activeRow!.index) {
-				return targets.length === 1 ? '$A30$' : `$A30$ + ${targets.length - 1}`
+				return targets.length === 1
+					? '$A30$'
+					: `$A30$ + $A10$ x ${targets.length - 1}`
 			}
 			return `$A10$ x ${targets.length}`
 		},


### PR DESCRIPTION
- Anvil shows correct damage preview when there is not a hermit opposite your active
- Fixes Hyperspace log when it does not damage a hermit
- Fixes Anvil logs when it does no damage or there is not a hermit opposite your active