### PR TITLE
Fix Timeskip effect query

### DIFF
--- a/common/cards/default/hermits/joehills-rare.ts
+++ b/common/cards/default/hermits/joehills-rare.ts
@@ -60,7 +60,7 @@ class JoeHillsRare extends Card {
 				game.components.exists(
 					StatusEffectComponent,
 					query.effect.is(UsedClockEffect),
-					query.effect.targetEntity(component.entity),
+					query.effect.targetEntity(player.entity),
 				)
 			) {
 				return


### PR DESCRIPTION
Timeskip can no longer flip a coin to skip a turn if Clock was played on the same turn or the player's previous turn