### PR TITLE
Rework settings to be more intuitive for develops and players

### DIFF
--- a/client/src/app/app.tsx
+++ b/client/src/app/app.tsx
@@ -65,10 +65,10 @@ function App() {
 		return (
 			<Background
 				panorama={settings.panorama}
-				disabled={!settings.panoramaEnabled}
+				disabled={!settings.enablePanorama}
 			/>
 		)
-	}, [settings.panoramaEnabled])
+	}, [settings.enablePanorama])
 
 	return (
 		<main>

--- a/client/src/app/app.tsx
+++ b/client/src/app/app.tsx
@@ -65,10 +65,10 @@ function App() {
 		return (
 			<Background
 				panorama={settings.panorama}
-				disabled={!settings.enablePanorama}
+				disabled={!settings.panoramaEnabled}
 			/>
 		)
-	}, [settings.enablePanorama])
+	}, [settings.panoramaEnabled])
 
 	return (
 		<main>

--- a/client/src/app/game/chat/chat.tsx
+++ b/client/src/app/game/chat/chat.tsx
@@ -17,7 +17,7 @@ function clamp(n: number, min: number, max: number): number {
 function Chat() {
 	const dispatch = useMessageDispatch()
 	const settings = useSelector(getSettings)
-	const chatMessages = settings.enableChat ? useSelector(getChatMessages) : []
+	const chatMessages = settings.chatEnabled ? useSelector(getChatMessages) : []
 	const playerId = useSelector(getPlayerId)
 	const opponentName = useSelector(getOpponentName)
 	const chatPosSetting = settings.chatPosition
@@ -31,7 +31,7 @@ function Chat() {
 		dispatch({
 			type: localMessages.SETTINGS_SET,
 			setting: {
-				key: 'showChat',
+				key: 'showChatWindow',
 				value: false,
 			},
 		})
@@ -73,7 +73,7 @@ function Chat() {
 		}
 	})
 
-	if (!settings.showChat) return null
+	if (!settings.showChatWindow) return null
 
 	const handleNewMessage = (ev: SyntheticEvent<HTMLFormElement>) => {
 		ev.preventDefault()
@@ -90,7 +90,7 @@ function Chat() {
 		dispatch({
 			type: localMessages.SETTINGS_SET,
 			setting: {
-				key: 'showChat',
+				key: 'showChatWindow',
 				value: false,
 			},
 		})
@@ -187,7 +187,7 @@ function Chat() {
 								>
 									{FormattedText(line.message, {
 										isOpponent,
-										censorProfanity: settings.enableProfanityFilter,
+										censorProfanity: settings.profanityFilterEnabled,
 									})}
 								</span>
 							</div>

--- a/client/src/app/game/chat/chat.tsx
+++ b/client/src/app/game/chat/chat.tsx
@@ -17,7 +17,7 @@ function clamp(n: number, min: number, max: number): number {
 function Chat() {
 	const dispatch = useMessageDispatch()
 	const settings = useSelector(getSettings)
-	const chatMessages = !settings.disableChat ? useSelector(getChatMessages) : []
+	const chatMessages = settings.enableChat ? useSelector(getChatMessages) : []
 	const playerId = useSelector(getPlayerId)
 	const opponentName = useSelector(getOpponentName)
 	const chatPosSetting = settings.chatPosition
@@ -187,7 +187,7 @@ function Chat() {
 								>
 									{FormattedText(line.message, {
 										isOpponent,
-										censorProfanity: settings.profanityFilter,
+										censorProfanity: settings.enableProfanityFilter,
 									})}
 								</span>
 							</div>

--- a/client/src/app/game/game.tsx
+++ b/client/src/app/game/game.tsx
@@ -122,7 +122,7 @@ function Game() {
 			dispatch({
 				type: localMessages.SETTINGS_SET,
 				setting: {
-					key: 'showChat',
+					key: 'showChatWindow',
 					value: false,
 				},
 			})
@@ -131,20 +131,20 @@ function Game() {
 		if (e.key === 'c' || e.key === 'C') {
 			// We do not do anything if the chat is opened because then you couldn't type the C key.
 			// Users can still use ESC to close the window.
-			if (!settings.showChat) {
+			if (!settings.showChatWindow) {
 				e.stopImmediatePropagation()
 				e.preventDefault()
 				dispatch({
 					type: localMessages.SETTINGS_SET,
 					setting: {
-						key: 'showChat',
+						key: 'showChatWindow',
 						value: true,
 					},
 				})
 			}
 		}
 
-		if (!settings.showChat) {
+		if (!settings.showChatWindow) {
 			if (e.key === 'a' || e.key === 'A') {
 				dispatch({type: localMessages.GAME_MODAL_OPENED_SET, id: 'attack'})
 			}

--- a/client/src/app/game/player-info/player-info.tsx
+++ b/client/src/app/game/player-info/player-info.tsx
@@ -25,7 +25,7 @@ function PlayerInfo({player, direction}: Props) {
 	if (!gameState) throw new Error('This should not happen')
 
 	const getName = (player: LocalPlayerState) => {
-		if (!settings.enableProfanityFilter) return player.playerName
+		if (!settings.profanityFilterEnabled) return player.playerName
 		return player.censoredPlayerName
 	}
 

--- a/client/src/app/game/player-info/player-info.tsx
+++ b/client/src/app/game/player-info/player-info.tsx
@@ -25,7 +25,7 @@ function PlayerInfo({player, direction}: Props) {
 	if (!gameState) throw new Error('This should not happen')
 
 	const getName = (player: LocalPlayerState) => {
-		if (!settings.profanityFilter) return player.playerName
+		if (!settings.enableProfanityFilter) return player.playerName
 		return player.censoredPlayerName
 	}
 

--- a/client/src/app/game/toolbar/chat-item.tsx
+++ b/client/src/app/game/toolbar/chat-item.tsx
@@ -21,30 +21,30 @@ function ChatItem() {
 	const [lastSeen, setLastSeen] = useState<number>(latestOpponentMessageTime)
 	const dispatch = useMessageDispatch()
 
-	if (settings.showChat && lastSeen !== latestOpponentMessageTime) {
+	if (settings.showChatWindow && lastSeen !== latestOpponentMessageTime) {
 		setLastSeen(latestOpponentMessageTime)
 	}
 
 	const toggleChat = () => {
-		settings.showChat
+		settings.showChatWindow
 			? dispatch({
 					type: localMessages.SETTINGS_SET,
 					setting: {
-						key: 'showChat',
+						key: 'showChatWindow',
 						value: false,
 					},
 				})
 			: dispatch({
 					type: localMessages.SETTINGS_SET,
 					setting: {
-						key: 'showChat',
+						key: 'showChatWindow',
 						value: true,
 					},
 				})
 	}
 
 	const newMessage =
-		!settings.showChat &&
+		!settings.showChatWindow &&
 		lastSeen !== latestOpponentMessageTime &&
 		latestOpponentMessageTime !== 0
 

--- a/client/src/app/game/toolbar/toolbar.tsx
+++ b/client/src/app/game/toolbar/toolbar.tsx
@@ -53,7 +53,7 @@ function Toolbar() {
 			</button>
 
 			{/* Toggle Chat */}
-			{!settings.disableChat && <ChatItem />}
+			{settings.enableChat && <ChatItem />}
 
 			{/* Toggle Tooltips */}
 			<TooltipsItem />

--- a/client/src/app/game/toolbar/toolbar.tsx
+++ b/client/src/app/game/toolbar/toolbar.tsx
@@ -53,7 +53,7 @@ function Toolbar() {
 			</button>
 
 			{/* Toggle Chat */}
-			{settings.enableChat && <ChatItem />}
+			{settings.chatEnabled && <ChatItem />}
 
 			{/* Toggle Tooltips */}
 			<TooltipsItem />

--- a/client/src/app/main-menu/data-settings.tsx
+++ b/client/src/app/main-menu/data-settings.tsx
@@ -19,6 +19,7 @@ function DataSettings({setMenuSection}: Props) {
 	}
 
 	const handleReset = (
+		title: string,
 		prompt: string,
 		whenDonePrompt: string,
 		reset: () => void,
@@ -30,7 +31,7 @@ function DataSettings({setMenuSection}: Props) {
 					<div className={css.resetModal}>
 						<Button
 							className={css.resetModalButton}
-							variant="stone"
+							variant="default"
 							onClick={closeModal}
 						>
 							Ok
@@ -42,18 +43,19 @@ function DataSettings({setMenuSection}: Props) {
 
 		return () => {
 			setModal(
-				<Modal title={prompt} closeModal={closeModal} centered>
+				<Modal title={title} closeModal={closeModal} centered>
+					<p className={css.resetModalDescription}>{prompt}</p>
 					<div className={css.resetModal}>
 						<Button
 							className={css.resetModalButton}
-							variant="stone"
+							variant="default"
 							onClick={handleYes}
 						>
 							Yes
 						</Button>
 						<Button
 							className={css.resetModalButton}
-							variant="stone"
+							variant="default"
 							onClick={() => setModal(null)}
 						>
 							No
@@ -81,7 +83,19 @@ function DataSettings({setMenuSection}: Props) {
 				<Button
 					variant="stone"
 					onClick={handleReset(
-						'Are you sure you want to reset the chat window positioin?',
+						'Reset Settings',
+						'Are you sure you want to reset your settings to the default values?',
+						'Your settings have been reset.',
+						() => dispatch({type: localMessages.ALL_SETTINGS_RESET}),
+					)}
+				>
+					Reset Settings
+				</Button>
+				<Button
+					variant="stone"
+					onClick={handleReset(
+						'Reset Chat Window',
+						'Are you sure you want to reset the chat window position?',
 						'The chat window has been reset.',
 						resetChatWindow,
 					)}
@@ -91,6 +105,7 @@ function DataSettings({setMenuSection}: Props) {
 				<Button
 					variant="stone"
 					onClick={handleReset(
+						'Reset Stats',
 						'Are you sure you want to reset your stats?',
 						'Your stats have been reset.',
 						() => dispatch({type: localMessages.FIREBASE_STATS_RESET}),

--- a/client/src/app/main-menu/game-settings.tsx
+++ b/client/src/app/main-menu/game-settings.tsx
@@ -17,8 +17,8 @@ function GameSettings({setMenuSection}: Props) {
 		dispatch({
 			type: localMessages.SETTINGS_SET,
 			setting: {
-				key: 'enableConfirmationDialogs',
-				value: !settings.enableConfirmationDialogs,
+				key: 'confirmationDialogsEnabled',
+				value: !settings.confirmationDialogsEnabled,
 			},
 		})
 	}
@@ -39,8 +39,8 @@ function GameSettings({setMenuSection}: Props) {
 		dispatch({
 			type: localMessages.SETTINGS_SET,
 			setting: {
-				key: 'enableChat',
-				value: !settings.enableChat,
+				key: 'chatEnabled',
+				value: !settings.chatEnabled,
 			},
 		})
 	}
@@ -48,8 +48,8 @@ function GameSettings({setMenuSection}: Props) {
 		dispatch({
 			type: localMessages.SETTINGS_SET,
 			setting: {
-				key: 'enableProfanityFilter',
-				value: !settings.enableProfanityFilter,
+				key: 'profanityFilterEnabled',
+				value: !settings.profanityFilterEnabled,
 			},
 		})
 	}
@@ -86,36 +86,36 @@ function GameSettings({setMenuSection}: Props) {
 				</Button>
 				<Button variant="stone" onClick={handleDialogsChange}>
 					Confirmation Dialogs:{' '}
-					{getDescriptor(settings.enableConfirmationDialogs)}
+					{getDescriptor(settings.confirmationDialogsEnabled)}
 				</Button>
 				<Button variant="stone" onClick={handleChatChange}>
-					In-Game Chat: {getDescriptor(settings.enableChat)}
+					In-Game Chat: {getDescriptor(settings.chatEnabled)}
 				</Button>
 				<Button variant="stone" onClick={handleProfanityChange}>
-					Profanity Filter: {getDescriptor(settings.enableProfanityFilter)}
+					Profanity Filter: {getDescriptor(settings.profanityFilterEnabled)}
 				</Button>
 				<div className={css.minecraftNameArea}>
-					<div className={css.upper}>
-						<h3>In-Game Player head</h3>
+					<div className={css.left}>
 						<img
 							className={css.playerHead}
 							src={`https://mc-heads.net/head/${settings.minecraftName}/left`}
 							alt="player head"
 						/>
 					</div>
-					<form className={css.playerHeadForm} onSubmit={handleMinecraftName}>
-						<div className={css.customInput}>
-							<input
-								maxLength={16}
-								name="minecraftName"
-								placeholder=" "
-								autoFocus
-								id="minecraft-name"
-							></input>
-							<label htmlFor="minecraft-name">Minecraft Username</label>
-						</div>
-						<Button variant="stone">Select</Button>
-					</form>
+					<div className={css.right}>
+						<p>Select in-game player head</p>
+						<form className={css.playerHeadForm} onSubmit={handleMinecraftName}>
+							<div className={css.customInput}>
+								<input
+									maxLength={16}
+									name="minecraftName"
+									placeholder="Minecraft Username"
+									id="minecraft-name"
+								></input>
+							</div>
+							<Button variant="stone">Select</Button>
+						</form>
+					</div>
 				</div>
 			</div>
 		</MenuLayout>

--- a/client/src/app/main-menu/game-settings.tsx
+++ b/client/src/app/main-menu/game-settings.tsx
@@ -17,8 +17,8 @@ function GameSettings({setMenuSection}: Props) {
 		dispatch({
 			type: localMessages.SETTINGS_SET,
 			setting: {
-				key: 'confirmationDialogs',
-				value: !settings.confirmationDialogs,
+				key: 'enableConfirmationDialogs',
+				value: !settings.enableConfirmationDialogs,
 			},
 		})
 	}
@@ -39,8 +39,8 @@ function GameSettings({setMenuSection}: Props) {
 		dispatch({
 			type: localMessages.SETTINGS_SET,
 			setting: {
-				key: 'disableChat',
-				value: !settings.disableChat,
+				key: 'enableChat',
+				value: !settings.enableChat,
 			},
 		})
 	}
@@ -48,8 +48,8 @@ function GameSettings({setMenuSection}: Props) {
 		dispatch({
 			type: localMessages.SETTINGS_SET,
 			setting: {
-				key: 'profanityFilter',
-				value: !settings.profanityFilter,
+				key: 'enableProfanityFilter',
+				value: !settings.enableProfanityFilter,
 			},
 		})
 	}
@@ -85,17 +85,18 @@ function GameSettings({setMenuSection}: Props) {
 					Game Side: {settings.gameSide.toString()}
 				</Button>
 				<Button variant="stone" onClick={handleDialogsChange}>
-					Confirmation Dialogs: {getDescriptor(settings.confirmationDialogs)}
+					Confirmation Dialogs:{' '}
+					{getDescriptor(settings.enableConfirmationDialogs)}
 				</Button>
 				<Button variant="stone" onClick={handleChatChange}>
-					Hide Chat: {getDescriptor(settings.disableChat)}
+					In-Game Chat: {getDescriptor(settings.enableChat)}
 				</Button>
 				<Button variant="stone" onClick={handleProfanityChange}>
-					Profanity Filter: {getDescriptor(settings.profanityFilter)}
+					Profanity Filter: {getDescriptor(settings.enableProfanityFilter)}
 				</Button>
 				<div className={css.minecraftNameArea}>
 					<div className={css.upper}>
-						<h3>Ingame Player head</h3>
+						<h3>In-Game Player head</h3>
 						<img
 							className={css.playerHead}
 							src={`https://mc-heads.net/head/${settings.minecraftName}/left`}

--- a/client/src/app/main-menu/main-menu.module.scss
+++ b/client/src/app/main-menu/main-menu.module.scss
@@ -135,7 +135,8 @@ nav {
 }
 
 .stats {
-	background: var(--gray-800);
+	text-shadow: 0.1vh 0.1vh 0.2vh black, -0.1vh -0.1vh 0.2vh black;
+	background: hsla(0deg, 0%, 0%, 55%);
 	border-radius: 0.5vh;
 	padding: 1vh 2vh;
 }
@@ -192,44 +193,46 @@ nav {
 }
 
 .minecraftNameArea {
-	background: var(--gray-800);
+	background: hsla(0deg, 0%, 0%, 55%);
 	border-radius: 0.5vh;
 	display: flex;
-	flex-direction: column;
+	flex-direction: row;
 	align-items: center;
 
-	.upper {
+	.left {
 		display: flex;
 		justify-content: center;
 		align-items: center;
-		margin: 2vh 0;
-
-		> h3 {
-			font-size: 2.5vh;
-			color: var(--text-light);
-			margin-right: 2vh;
-			filter: drop-shadow(1px 1px 0 var(--text-dark));
-		}
+		margin: 4vh;
 
 		.playerHead {
-			width: 8vh;
-			height: 8vh;
-			filter: drop-shadow(0 0 2px var(--text-light));
+			width: 15vh;
+			height: 15vh;
+			filter: drop-shadow(2px 2px 0 white) drop-shadow(2px -2px 0 white)
+				drop-shadow(-2px 2px 0 white) drop-shadow(-2px -2px 0 white);
 		}
 	}
 
-	.playerHeadForm {
-		width: 100%;
-		display: flex;
-		padding: 2vh;
-
-		> * {
+	.right {
+		p {
+			padding: 0.5vh;
+			color: var(--text-light);
 			font-size: 2vh;
-			line-height: 100%;
+			filter: drop-shadow(1px 1px 0 var(--text-dark));
 		}
 
-		.customInput {
-			width: 90%;
+		.playerHeadForm {
+			width: 100%;
+			display: flex;
+
+			> * {
+				font-size: 2vh;
+				line-height: 100%;
+			}
+
+			.customInput {
+				width: 90%;
+			}
 		}
 	}
 }

--- a/client/src/app/main-menu/main-menu.module.scss
+++ b/client/src/app/main-menu/main-menu.module.scss
@@ -192,6 +192,16 @@ nav {
 	}
 }
 
+.settingDescriptor {
+	background: hsla(0deg, 0%, 0%, 55%);
+	border-radius: 0.5vh;
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	padding: 1vh;
+	color: var(--text-light);
+}
+
 .minecraftNameArea {
 	background: hsla(0deg, 0%, 0%, 55%);
 	border-radius: 0.5vh;
@@ -249,11 +259,16 @@ nav {
 	display: flex;
 	flex-direction: row;
 	justify-content: center;
+	gap: 0.5vh;
+	margin: 0.5vh;
+}
+
+.resetModalDescription {
+	padding: 1vh;
 }
 
 .resetModalButton {
-	margin: 1vh;
-	min-width: 45%;
+	width: 50%;
 }
 
 /* DESKTOP */

--- a/client/src/app/main-menu/main-menu.module.scss
+++ b/client/src/app/main-menu/main-menu.module.scss
@@ -13,8 +13,8 @@
 	right: 1vh;
 	display: grid;
 	grid-template-areas:
-		'name icon'
-		'deck icon';
+		"name icon"
+		"deck icon";
 	font-size: 1.5vh;
 	background-color: hsla(0deg, 0%, 0%, 35%);
 	padding: 0.75vh 1vh 0.75vh 1.5vh;
@@ -62,12 +62,12 @@ nav {
 	display: grid;
 	gap: 1vh;
 	grid-template-areas:
-		'public'
-		'private-create'
-		'private-join'
-		'deck'
-		'settings'
-		'logout';
+		"public"
+		"private-create"
+		"private-join"
+		"deck"
+		"settings"
+		"logout";
 	animation: fadeIn 250ms ease-in-out forwards;
 }
 
@@ -126,6 +126,12 @@ nav {
 	gap: 1vh;
 	width: 100%;
 	margin-bottom: 2vh;
+}
+
+.settingsBox {
+	display: flex;
+	flex-direction: row;
+	gap: 1vh;
 }
 
 .stats {
@@ -255,10 +261,10 @@ nav {
 		gap: 2vh;
 		grid-template-columns: 1fr 1fr;
 		grid-template-areas:
-			'public public'
-			'private-create private-join'
-			'deck deck'
-			'logout settings';
+			"public public"
+			"private-create private-join"
+			"deck deck"
+			"logout settings";
 	}
 }
 

--- a/client/src/app/main-menu/settings.tsx
+++ b/client/src/app/main-menu/settings.tsx
@@ -50,8 +50,8 @@ function Settings({setMenuSection}: Props) {
 		dispatch({
 			type: localMessages.SETTINGS_SET,
 			setting: {
-				key: 'panoramaEnabled',
-				value: !settings.panoramaEnabled,
+				key: 'enablePanorama',
+				value: !settings.enablePanorama,
 			},
 		})
 	}
@@ -99,7 +99,7 @@ function Settings({setMenuSection}: Props) {
 						Sound: {getBoolDescriptor(!settings.muted)}
 					</Button>
 					<Button variant="stone" onClick={handlePanoramaToggle}>
-						Panorama: {getBoolDescriptor(settings.panoramaEnabled)}
+						Panorama: {getBoolDescriptor(settings.enablePanorama)}
 					</Button>
 					<Button variant="stone" onClick={handleGameSettings}>
 						Game Settings

--- a/client/src/app/main-menu/settings.tsx
+++ b/client/src/app/main-menu/settings.tsx
@@ -72,6 +72,9 @@ function Settings({setMenuSection}: Props) {
 		setUpdatesOpen(true)
 	}
 
+	const totalGamesPlayed = stats.w + stats.fw + stats.l + stats.fl
+	const winrate = ((stats.w + stats.fw) / totalGamesPlayed) * 100
+
 	return (
 		<>
 			{updatesOpen ? (
@@ -88,31 +91,36 @@ function Settings({setMenuSection}: Props) {
 				returnText="Main Menu"
 				className={css.settingsMenu}
 			>
-				<div className={css.settings}>
-					<Slider value={settings.musicVolume} onInput={handleMusicChange}>
-						Music Volume: {getPercentDescriptor(settings.musicVolume)}
-					</Slider>
-					<Slider value={settings.soundVolume} onInput={handleSoundChange}>
-						Sound Effect Volume: {getPercentDescriptor(settings.soundVolume)}
-					</Slider>
-					<Button variant="stone" onClick={handleMuteSound}>
-						Sound: {getBoolDescriptor(!settings.muted)}
-					</Button>
-					<Button variant="stone" onClick={handlePanoramaToggle}>
-						Panorama: {getBoolDescriptor(settings.enablePanorama)}
-					</Button>
-					<Button variant="stone" onClick={handleGameSettings}>
-						Game Settings
-					</Button>
-					<Button variant="stone" onClick={handleDataSettings}>
-						Data Management
-					</Button>
-					<Button variant="stone" onClick={handleCredits}>
-						Credits
-					</Button>
-					<Button variant="stone" onClick={handleUpdates}>
-						Updates
-					</Button>
+				<h2>Settings</h2>
+				<div className={css.settingsBox}>
+					<div className={css.settings}>
+						<Slider value={settings.musicVolume} onInput={handleMusicChange}>
+							Music Volume: {getPercentDescriptor(settings.musicVolume)}
+						</Slider>
+						<Slider value={settings.soundVolume} onInput={handleSoundChange}>
+							Sound Effect Volume: {getPercentDescriptor(settings.soundVolume)}
+						</Slider>
+						<Button variant="stone" onClick={handleMuteSound}>
+							Sound: {getBoolDescriptor(!settings.muted)}
+						</Button>
+						<Button variant="stone" onClick={handlePanoramaToggle}>
+							Panorama: {getBoolDescriptor(settings.enablePanorama)}
+						</Button>
+					</div>
+					<div className={css.settings}>
+						<Button variant="stone" onClick={handleGameSettings}>
+							Game Settings
+						</Button>
+						<Button variant="stone" onClick={handleDataSettings}>
+							Data Management
+						</Button>
+						<Button variant="stone" onClick={handleCredits}>
+							Credits
+						</Button>
+						<Button variant="stone" onClick={handleUpdates}>
+							Updates
+						</Button>
+					</div>
 				</div>
 
 				<h2>Statistics</h2>
@@ -141,6 +149,10 @@ function Settings({setMenuSection}: Props) {
 						<div className={css.stat}>
 							<span>Forfeit Losses</span>
 							<span>{stats.fl}</span>
+						</div>
+						<div className={css.stat}>
+							<span>Winrate</span>
+							<span>{totalGamesPlayed > 0 ? winrate + '%' : 'N/A'}</span>
 						</div>
 					</div>
 				</div>

--- a/client/src/app/main-menu/settings.tsx
+++ b/client/src/app/main-menu/settings.tsx
@@ -50,8 +50,8 @@ function Settings({setMenuSection}: Props) {
 		dispatch({
 			type: localMessages.SETTINGS_SET,
 			setting: {
-				key: 'enablePanorama',
-				value: !settings.enablePanorama,
+				key: 'panoramaEnabled',
+				value: !settings.panoramaEnabled,
 			},
 		})
 	}
@@ -104,7 +104,7 @@ function Settings({setMenuSection}: Props) {
 							Sound: {getBoolDescriptor(!settings.muted)}
 						</Button>
 						<Button variant="stone" onClick={handlePanoramaToggle}>
-							Panorama: {getBoolDescriptor(settings.enablePanorama)}
+							Panorama: {getBoolDescriptor(settings.panoramaEnabled)}
 						</Button>
 					</div>
 					<div className={css.settings}>

--- a/client/src/components/slider/slider.module.scss
+++ b/client/src/components/slider/slider.module.scss
@@ -1,6 +1,6 @@
 .slider {
 	overflow: hidden;
-	height: 5vh;
+	height: 5.5vh;
 	position: relative;
 	min-width: 240px;
 }

--- a/client/src/logic/game/game-selectors.ts
+++ b/client/src/logic/game/game-selectors.ts
@@ -55,7 +55,7 @@ export const getOpponentName = (state: RootState) => {
 	const opponent = opponentId && gameState?.players[opponentId]
 
 	if (!opponent) return
-	if (!settings.profanityFilter) return opponent.playerName
+	if (!settings.enableProfanityFilter) return opponent.playerName
 	return opponent.censoredPlayerName
 }
 

--- a/client/src/logic/game/game-selectors.ts
+++ b/client/src/logic/game/game-selectors.ts
@@ -55,7 +55,7 @@ export const getOpponentName = (state: RootState) => {
 	const opponent = opponentId && gameState?.players[opponentId]
 
 	if (!opponent) return
-	if (!settings.enableProfanityFilter) return opponent.playerName
+	if (!settings.profanityFilterEnabled) return opponent.playerName
 	return opponent.censoredPlayerName
 }
 

--- a/client/src/logic/game/tasks/action-modals-saga.ts
+++ b/client/src/logic/game/tasks/action-modals-saga.ts
@@ -54,7 +54,7 @@ function* endTurnActionSaga(): SagaIterator {
 		const settings = yield* select(getSettings)
 		if (
 			availableActions.some((action) => ActionMap[action] !== null) &&
-			settings.enableConfirmationDialogs
+			settings.confirmationDialogsEnabled
 		) {
 			yield put<LocalMessage>({
 				type: localMessages.GAME_MODAL_OPENED_SET,

--- a/client/src/logic/game/tasks/action-modals-saga.ts
+++ b/client/src/logic/game/tasks/action-modals-saga.ts
@@ -54,7 +54,7 @@ function* endTurnActionSaga(): SagaIterator {
 		const settings = yield* select(getSettings)
 		if (
 			availableActions.some((action) => ActionMap[action] !== null) &&
-			settings.confirmationDialogs
+			settings.enableConfirmationDialogs
 		) {
 			yield put<LocalMessage>({
 				type: localMessages.GAME_MODAL_OPENED_SET,

--- a/client/src/logic/game/tasks/slot-saga.ts
+++ b/client/src/logic/game/tasks/slot-saga.ts
@@ -79,7 +79,7 @@ function* pickWithoutSelectedSaga(
 			id: 'attack',
 		})
 	} else {
-		if (settings.enableConfirmationDialogs) {
+		if (settings.confirmationDialogsEnabled) {
 			yield* put<LocalMessage>({
 				type: localMessages.GAME_MODAL_OPENED_SET,
 				id: 'change-hermit-modal',

--- a/client/src/logic/game/tasks/slot-saga.ts
+++ b/client/src/logic/game/tasks/slot-saga.ts
@@ -79,7 +79,7 @@ function* pickWithoutSelectedSaga(
 			id: 'attack',
 		})
 	} else {
-		if (!settings.confirmationDialogs) {
+		if (settings.enableConfirmationDialogs) {
 			yield* put<LocalMessage>({
 				type: localMessages.GAME_MODAL_OPENED_SET,
 				id: 'change-hermit-modal',

--- a/client/src/logic/local-settings/local-settings-reducer.ts
+++ b/client/src/logic/local-settings/local-settings-reducer.ts
@@ -4,15 +4,15 @@ export type LocalSettings = {
 	soundVolume: number
 	musicVolume: number
 	muted: boolean
-	enableProfanityFilter: boolean
-	showChat: boolean
-	enableChat: boolean
-	enableConfirmationDialogs: boolean
+	profanityFilterEnabled: boolean
+	showChatWindow: boolean
+	chatEnabled: boolean
+	confirmationDialogsEnabled: boolean
 	showBattleLogs: boolean
 	showAdvancedTooltips: boolean
 	chatPosition: {x: number; y: number}
 	chatSize: {w: number; h: number}
-	enablePanorama: boolean
+	panoramaEnabled: boolean
 	panorama: string
 	gameSide: string
 	minecraftName: string
@@ -26,15 +26,15 @@ const defaultSettings: LocalSettings = {
 	soundVolume: 100,
 	musicVolume: 75,
 	muted: false,
-	enableProfanityFilter: true,
-	enableChat: true,
-	enableConfirmationDialogs: true,
-	showChat: false,
+	profanityFilterEnabled: true,
+	chatEnabled: true,
+	confirmationDialogsEnabled: true,
+	showChatWindow: false,
 	showBattleLogs: false,
 	showAdvancedTooltips: true,
 	chatPosition: {x: 0, y: 0},
 	chatSize: {w: 0, h: 0},
-	enablePanorama: true,
+	panoramaEnabled: true,
 	panorama: 'hermit-hill',
 	gameSide: 'Left',
 	minecraftName: 'alex',

--- a/client/src/logic/local-settings/local-settings-reducer.ts
+++ b/client/src/logic/local-settings/local-settings-reducer.ts
@@ -37,7 +37,7 @@ const defaultSettings: LocalSettings = {
 	panoramaEnabled: true,
 	panorama: 'hermit-hill',
 	gameSide: 'Left',
-	minecraftName: 'alex',
+	minecraftName: '',
 }
 
 const getSettings = (): LocalSettings => {
@@ -70,6 +70,8 @@ const localSettingsReducer = (
 				...state,
 				[action.key]: defaultState[action.key as keyof LocalSettings],
 			}
+		case localMessages.ALL_SETTINGS_RESET:
+			return defaultSettings
 		default:
 			return state
 	}

--- a/client/src/logic/local-settings/local-settings-reducer.ts
+++ b/client/src/logic/local-settings/local-settings-reducer.ts
@@ -4,15 +4,15 @@ export type LocalSettings = {
 	soundVolume: number
 	musicVolume: number
 	muted: boolean
-	profanityFilter: boolean
+	enableProfanityFilter: boolean
 	showChat: boolean
-	disableChat: boolean
-	confirmationDialogs: boolean
+	enableChat: boolean
+	enableConfirmationDialogs: boolean
 	showBattleLogs: boolean
 	showAdvancedTooltips: boolean
 	chatPosition: {x: number; y: number}
 	chatSize: {w: number; h: number}
-	panoramaEnabled: boolean
+	enablePanorama: boolean
 	panorama: string
 	gameSide: string
 	minecraftName: string
@@ -26,15 +26,15 @@ const defaultSettings: LocalSettings = {
 	soundVolume: 100,
 	musicVolume: 75,
 	muted: false,
-	profanityFilter: true,
-	disableChat: false,
-	confirmationDialogs: true,
+	enableProfanityFilter: true,
+	enableChat: true,
+	enableConfirmationDialogs: true,
 	showChat: false,
 	showBattleLogs: false,
 	showAdvancedTooltips: true,
 	chatPosition: {x: 0, y: 0},
 	chatSize: {w: 0, h: 0},
-	panoramaEnabled: true,
+	enablePanorama: true,
 	panorama: 'hermit-hill',
 	gameSide: 'Left',
 	minecraftName: 'alex',

--- a/client/src/logic/messages.ts
+++ b/client/src/logic/messages.ts
@@ -77,6 +77,7 @@ export const localMessages = messages({
 	FIREBASE_STATS: null,
 	SETTINGS_SET: null,
 	SETTINGS_RESET: null,
+	ALL_SETTINGS_RESET: null,
 	SOUND_PLAY: null,
 	SOUND_SECTION_CHANGE: null,
 })
@@ -195,6 +196,7 @@ type Messages = [
 	},
 	{type: typeof localMessages.SETTINGS_SET; setting: LocalSetting},
 	{type: typeof localMessages.SETTINGS_RESET; key: keyof LocalSettings},
+	{type: typeof localMessages.ALL_SETTINGS_RESET},
 	{type: typeof localMessages.SOUND_PLAY; path: string},
 	{type: typeof localMessages.SOUND_SECTION_CHANGE; section: any},
 ]


### PR DESCRIPTION
- Renames some settings, and changes all of them that used `disabled` to `enabled`
- Fixes a bug where confirmation dialogues would follow the opposite of what the setting was set to
- Changes "Ingame" to "In-Game" on the settings screen, since the spelling was wrong before
- Makes other changes for visual consistency
- Adds a button to reset settings

Unfortunately, this will bring some settings back to the default again but it is possible for us to add a button in "Data Management" to fix this if needed