### PR TITLE
Add setting to disable card slot highlighting

### DIFF
--- a/client/src/app/game/board/board-row.tsx
+++ b/client/src/app/game/board/board-row.tsx
@@ -7,8 +7,8 @@ import {
 	LocalStatusEffectInstance,
 } from 'common/types/server-requests'
 import {getGameState, getSelectedCard} from 'logic/game/game-selectors'
-import {useSelector} from 'react-redux'
 import {getSettings} from 'logic/local-settings/local-settings-selectors'
+import {useSelector} from 'react-redux'
 import HealthSlot from './board-health'
 import Slot from './board-slot'
 import StatusEffectContainer from './board-status-effects'

--- a/client/src/app/game/board/board-row.tsx
+++ b/client/src/app/game/board/board-row.tsx
@@ -8,6 +8,7 @@ import {
 } from 'common/types/server-requests'
 import {getGameState, getSelectedCard} from 'logic/game/game-selectors'
 import {useSelector} from 'react-redux'
+import {getSettings} from 'logic/local-settings/local-settings-selectors'
 import HealthSlot from './board-health'
 import Slot from './board-slot'
 import StatusEffectContainer from './board-status-effects'
@@ -46,10 +47,12 @@ const BoardRow = ({
 	active,
 	statusEffects,
 }: BoardRowProps) => {
+	const settings = useSelector(getSettings)
 	const localGameState = useSelector(getGameState)
 	const selectedCard = useSelector(getSelectedCard)
 
 	let shouldDim = !!(
+		settings.slotHighlightingEnabled &&
 		(selectedCard || localGameState?.currentPickableSlots) &&
 		localGameState?.turn.currentPlayerEntity === localGameState?.playerEntity
 	)

--- a/client/src/app/game/board/board-slot.tsx
+++ b/client/src/app/game/board/board-slot.tsx
@@ -14,6 +14,7 @@ import {
 	getSelectedCard,
 } from 'logic/game/game-selectors'
 import {useSelector} from 'react-redux'
+import {getSettings} from 'logic/local-settings/local-settings-selectors'
 import StatusEffectContainer from './board-status-effects'
 import css from './board.module.scss'
 
@@ -36,6 +37,7 @@ const Slot = ({
 	statusEffects,
 	cssId,
 }: SlotProps) => {
+	const settings = useSelector(getSettings)
 	const cardsCanBePlacedIn = useSelector(getCardsCanBePlacedIn)
 	const pickRequestPickableCard = useSelector(getPickRequestPickableSlots)
 	const selectedCard = useSelector(getSelectedCard)
@@ -94,8 +96,8 @@ const Slot = ({
 			disabled={!isClickable}
 			id={css[cssId || 'slot']}
 			className={classnames(css.slot, {
-				[css.pickable]: isPickable && somethingPickable,
-				[css.unpickable]: !isPickable && somethingPickable,
+				[css.pickable]: isPickable && somethingPickable && settings.slotHighlightingEnabled,
+				[css.unpickable]: !isPickable && somethingPickable && settings.slotHighlightingEnabled,
 				[css.available]: isClickable,
 				[css[type]]: true,
 				[css.empty]: !card,

--- a/client/src/app/game/board/board-slot.tsx
+++ b/client/src/app/game/board/board-slot.tsx
@@ -13,8 +13,8 @@ import {
 	getPickRequestPickableSlots,
 	getSelectedCard,
 } from 'logic/game/game-selectors'
-import {useSelector} from 'react-redux'
 import {getSettings} from 'logic/local-settings/local-settings-selectors'
+import {useSelector} from 'react-redux'
 import StatusEffectContainer from './board-status-effects'
 import css from './board.module.scss'
 
@@ -96,8 +96,10 @@ const Slot = ({
 			disabled={!isClickable}
 			id={css[cssId || 'slot']}
 			className={classnames(css.slot, {
-				[css.pickable]: isPickable && somethingPickable && settings.slotHighlightingEnabled,
-				[css.unpickable]: !isPickable && somethingPickable && settings.slotHighlightingEnabled,
+				[css.pickable]:
+					isPickable && somethingPickable && settings.slotHighlightingEnabled,
+				[css.unpickable]:
+					!isPickable && somethingPickable && settings.slotHighlightingEnabled,
 				[css.available]: isClickable,
 				[css[type]]: true,
 				[css.empty]: !card,

--- a/client/src/app/main-menu/game-settings.tsx
+++ b/client/src/app/main-menu/game-settings.tsx
@@ -104,7 +104,8 @@ function GameSettings({setMenuSection}: Props) {
 					Profanity Filter: {getDescriptor(settings.profanityFilterEnabled)}
 				</Button>
 				<Button variant="stone" onClick={handleSlotHighlightingChange}>
-					Card Slot Highlighting: {getDescriptor(settings.slotHighlightingEnabled)}
+					Card Slot Highlighting:{' '}
+					{getDescriptor(settings.slotHighlightingEnabled)}
 				</Button>
 				<div className={css.minecraftNameArea}>
 					<div className={css.left}>

--- a/client/src/app/main-menu/game-settings.tsx
+++ b/client/src/app/main-menu/game-settings.tsx
@@ -53,6 +53,15 @@ function GameSettings({setMenuSection}: Props) {
 			},
 		})
 	}
+	const handleSlotHighlightingChange = () => {
+		dispatch({
+			type: localMessages.SETTINGS_SET,
+			setting: {
+				key: 'slotHighlightingEnabled',
+				value: !settings.slotHighlightingEnabled,
+			},
+		})
+	}
 	const handleMinecraftName = (ev: React.SyntheticEvent<HTMLFormElement>) => {
 		ev.preventDefault()
 		const username = ev.currentTarget.minecraftName.value.trim()
@@ -93,6 +102,9 @@ function GameSettings({setMenuSection}: Props) {
 				</Button>
 				<Button variant="stone" onClick={handleProfanityChange}>
 					Profanity Filter: {getDescriptor(settings.profanityFilterEnabled)}
+				</Button>
+				<Button variant="stone" onClick={handleSlotHighlightingChange}>
+					Card Slot Highlighting: {getDescriptor(settings.slotHighlightingEnabled)}
 				</Button>
 				<div className={css.minecraftNameArea}>
 					<div className={css.left}>

--- a/client/src/logic/local-settings/local-settings-reducer.ts
+++ b/client/src/logic/local-settings/local-settings-reducer.ts
@@ -12,6 +12,7 @@ export type LocalSettings = {
 	showAdvancedTooltips: boolean
 	chatPosition: {x: number; y: number}
 	chatSize: {w: number; h: number}
+	slotHighlightingEnabled: boolean
 	panoramaEnabled: boolean
 	panorama: string
 	gameSide: string
@@ -34,6 +35,7 @@ const defaultSettings: LocalSettings = {
 	showAdvancedTooltips: true,
 	chatPosition: {x: 0, y: 0},
 	chatSize: {w: 0, h: 0},
+	slotHighlightingEnabled: true,
 	panoramaEnabled: true,
 	panorama: 'hermit-hill',
 	gameSide: 'Left',


### PR DESCRIPTION
Deals with issue https://github.com/hc-tcg/hc-tcg/issues/705. Adds a new button to the game settings screen that controls whether unpickable board slots are dimmed (and pickable highlighted) when a card is selected from the user's hand. The setting is on by default.