### PR TITLE
Move Egg To After Attack

### DIFF
--- a/common/cards/alter-egos/single-use/egg.ts
+++ b/common/cards/alter-egos/single-use/egg.ts
@@ -60,7 +60,7 @@ class Egg extends Card {
 			})
 		})
 
-		observer.subscribe(player.hooks.onAttack, (attack) => {
+		observer.subscribe(player.hooks.afterAttack, (attack) => {
 			if (!afkHermitSlot?.inRow()) return
 			const activeHermit = player.getActiveHermit()
 			if (!attack.isAttacker(activeHermit?.entity)) return


### PR DESCRIPTION
This fixes a bug where Joel can not steal an item from an egged hermit 
