### PR TITLE
Fix gaslight activating when it shouldn't have

### DIFF
--- a/common/status-effects/gas-light.ts
+++ b/common/status-effects/gas-light.ts
@@ -44,11 +44,7 @@ export class GasLightEffect extends CardStatusEffect {
 			if (attack.calculateDamage() === 0) return
 
 			// We have an extra take because status effects are executed at the end of the turn.
-			if (
-				attack.type === 'status-effect' &&
-				attack.calculateDamage() > 0 &&
-				target.slot.inRow()
-			) {
+			if (attack.type === 'status-effect' && target.slot.inRow()) {
 				let attack = game
 					.newAttack(newGasLightAttack(effect, target.slot.row.entity))
 					.addDamage(effect.entity, 20)

--- a/common/status-effects/gas-light.ts
+++ b/common/status-effects/gas-light.ts
@@ -41,12 +41,14 @@ export class GasLightEffect extends CardStatusEffect {
 
 		observer.subscribe(player.hooks.afterDefence, (attack) => {
 			if (!attack.isTargeting(target)) return
-
-			// If the attack does no damage (after armor) gaslight doesn't activate
 			if (attack.calculateDamage() === 0) return
 
 			// We have an extra take because status effects are executed at the end of the turn.
-			if (attack.type === 'status-effect' && target.slot.inRow()) {
+			if (
+				attack.type === 'status-effect' &&
+				attack.calculateDamage() > 0 &&
+				target.slot.inRow()
+			) {
 				let attack = game
 					.newAttack(newGasLightAttack(effect, target.slot.row.entity))
 					.addDamage(effect.entity, 20)

--- a/common/status-effects/gas-light.ts
+++ b/common/status-effects/gas-light.ts
@@ -42,6 +42,9 @@ export class GasLightEffect extends CardStatusEffect {
 		observer.subscribe(player.hooks.afterDefence, (attack) => {
 			if (!attack.isTargeting(target)) return
 
+			// If the attack does no damage (after armor) gaslight doesn't activate
+			if (attack.calculateDamage() === 0) return
+
 			// We have an extra take because status effects are executed at the end of the turn.
 			if (attack.type === 'status-effect' && target.slot.inRow()) {
 				let attack = game


### PR DESCRIPTION
Gaslight still activates when an attack does 0 damage. If an attack does zero damage, after armor, gaslight should not activate according to the description 