### PR TITLE
Call onActiveRowChange with no previous active row

### DIFF
--- a/common/components/player-component.ts
+++ b/common/components/player-component.ts
@@ -127,7 +127,10 @@ export class PlayerComponent {
 		>
 		/** Hook called when the active row is changed. */
 		onActiveRowChange: GameHook<
-			(oldActiveHermit: CardComponent, newActiveHermit: CardComponent) => void
+			(
+				oldActiveHermit: CardComponent | null,
+				newActiveHermit: CardComponent,
+			) => void
 		>
 		/** Hook called when the `slot.locked` combinator is called.
 		 * Returns a combinator that verifies if the slot is locked or not.
@@ -302,6 +305,13 @@ export class PlayerComponent {
 					'Should not be able to change from an active row with no hermits or to an active row with no hermits.',
 				)
 			this.hooks.onActiveRowChange.call(oldHermit, newHermit)
+		} else {
+			let newHermit = newRow.getHermit()
+			if (!newHermit)
+				throw new Error(
+					'Should not be able to change from no active row to an active row with no hermits.',
+				)
+			this.hooks.onActiveRowChange.call(null, newHermit)
 		}
 
 		return true


### PR DESCRIPTION
Fixes issues where hook was not called when players selected a new active row after their active hermit was knocked out