### PR TITLE
Add Tests For Unique IDs

### DIFF
--- a/common/status-effects/index.ts
+++ b/common/status-effects/index.ts
@@ -40,7 +40,7 @@ import TurnSkippedEffect from './turn-skipped'
 import UsedClockEffect from './used-clock'
 import WeaknessEffect from './weakness'
 
-const effectClasses: Array<StatusEffect> = [
+export const STATUS_EFFECTS_LIST: Array<StatusEffect> = [
 	/* Regualr status effects */
 	FireEffect,
 	PoisonEffect,
@@ -81,7 +81,7 @@ const effectClasses: Array<StatusEffect> = [
 ]
 
 export const STATUS_EFFECTS: Record<string, StatusEffect> =
-	effectClasses.reduce((result: Record<string, StatusEffect>, effect) => {
+	STATUS_EFFECTS_LIST.reduce((result: Record<string, StatusEffect>, effect) => {
 		result[effect.id] = effect
 		return result
 	}, {})

--- a/tests/common/unique-ids.test.ts
+++ b/tests/common/unique-ids.test.ts
@@ -1,0 +1,23 @@
+import {describe, expect, test} from '@jest/globals'
+
+import {CARDS_LIST} from 'common/cards'
+import {STATUS_EFFECTS_LIST} from 'common/status-effects'
+
+describe('Test unique IDs', () => {
+	test('Test cards have unique IDs', () => {
+		let cards: Array<string> = []
+
+		for (const card of CARDS_LIST) {
+			expect(cards).not.toContain(card.id)
+			cards.push(card.id)
+		}
+	})
+	test('Test status effects have unique IDs', () => {
+		let effects: Array<string> = []
+
+		for (const effect of STATUS_EFFECTS_LIST) {
+			expect(effects).not.toContain(effect.id)
+			effects.push(effect.id)
+		}
+	})
+})


### PR DESCRIPTION
In the past, IDs have accidentally been reused. This PR adds tests to prevent that from happening.