### PR TITLE
Fix Evil X Disabling Secondary Attacks At Incorrect Times

### DIFF
--- a/common/cards/alter-egos/hermits/evilxisuma_rare.ts
+++ b/common/cards/alter-egos/hermits/evilxisuma_rare.ts
@@ -52,13 +52,6 @@ const EvilXisumaRare: Hermit = {
 	) {
 		const {player, opponentPlayer} = component
 
-		observer.subscribe(player.hooks.blockedActions, (blockedActions) => {
-			if (!game.components.exists(CardComponent, opponentActiveHermitQuery)) {
-				blockedActions.push('SECONDARY_ATTACK')
-			}
-			return blockedActions
-		})
-
 		observer.subscribe(player.hooks.afterAttack, (attack) => {
 			if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 				return

--- a/tests/game/clock.test.ts
+++ b/tests/game/clock.test.ts
@@ -9,17 +9,17 @@ import UsedClockEffect from 'common/status-effects/used-clock'
 import {applyEffect, endTurn, playCardFromHand, testGame} from './utils'
 
 function* testClockHelperSaga(game: GameModel) {
-	yield* playCardFromHand(game, EthosLabCommon, 0)
+	yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
 
 	yield* endTurn(game)
 
-	yield* playCardFromHand(game, EthosLabCommon, 0)
+	yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
 
 	// Clock can not be played on turn one.
 	yield* endTurn(game)
 	yield* endTurn(game)
 
-	yield* playCardFromHand(game, Clock)
+	yield* playCardFromHand(game, Clock, 'single_use')
 
 	yield* applyEffect(game)
 

--- a/tests/game/dwarfimpulse-rare.test.ts
+++ b/tests/game/dwarfimpulse-rare.test.ts
@@ -19,22 +19,22 @@ import {
 } from './utils'
 
 function* testDwarfImpulseHelperSaga(game: GameModel) {
-	yield* playCardFromHand(game, DwarfImpulseRare, 0)
+	yield* playCardFromHand(game, DwarfImpulseRare, 'hermit', 0)
 
 	yield* endTurn(game)
 
-	yield* playCardFromHand(game, FiveAMPearlRare, 0)
-	yield* playCardFromHand(game, TangoTekCommon, 1)
-	yield* playCardFromHand(game, EthosLabCommon, 2)
+	yield* playCardFromHand(game, FiveAMPearlRare, 'hermit', 0)
+	yield* playCardFromHand(game, TangoTekCommon, 'hermit', 1)
+	yield* playCardFromHand(game, EthosLabCommon, 'hermit', 2)
 
-	yield* playCardFromHand(game, Wolf, 0)
-	yield* playCardFromHand(game, LightningRod, 2)
+	yield* playCardFromHand(game, Wolf, 'attach', 0)
+	yield* playCardFromHand(game, LightningRod, 'attach', 2)
 
 	yield* changeActiveHermit(game, 1)
 
 	yield* endTurn(game)
 
-	yield* playCardFromHand(game, GoldenAxe)
+	yield* playCardFromHand(game, GoldenAxe, 'single_use')
 
 	yield* attack(game, 'secondary')
 

--- a/tests/game/evilxisuma-rare.test.ts
+++ b/tests/game/evilxisuma-rare.test.ts
@@ -12,12 +12,13 @@ import {
 	playCardFromHand,
 	testGame,
 } from './utils'
+import ArmorStand from 'common/cards/alter-egos/effects/armor-stand'
 
 function* testEvilXDisablesForOneTurn(game: GameModel) {
-	yield* playCardFromHand(game, EvilXisumaRare, 0)
+	yield* playCardFromHand(game, EvilXisumaRare, 'hermit', 0)
 	yield* endTurn(game)
 
-	yield* playCardFromHand(game, EthosLabCommon, 0)
+	yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
 	yield* endTurn(game)
 
 	yield* attack(game, 'secondary')
@@ -61,6 +62,25 @@ describe('Test Evil X', () => {
 				playerTwoDeck: [EthosLabCommon],
 			},
 			{startWithAllCards: true, forceCoinFlip: true, noItemRequirements: true},
+		)
+	})
+	test('Test Evil X secondary does not open popup if there are no opponent active hermits', () => {
+		testGame(
+			{
+				playerOneDeck: [ArmorStand],
+				playerTwoDeck: [EvilXisumaRare],
+				saga: function* (game: GameModel) {
+					yield* playCardFromHand(game, ArmorStand, 'hermit', 0)
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, EvilXisumaRare, 'hermit', 0)
+					yield* attack(game, 'secondary')
+
+					// We expect that there is no modal requests because Evil X found that the opponent has no attacks to disable.
+					expect(game.state.modalRequests).toStrictEqual([])
+				},
+			},
+			{noItemRequirements: true, startWithAllCards: true, forceCoinFlip: true},
 		)
 	})
 })

--- a/tests/game/evilxisuma-rare.test.ts
+++ b/tests/game/evilxisuma-rare.test.ts
@@ -1,4 +1,5 @@
 import {describe, expect, test} from '@jest/globals'
+import ArmorStand from 'common/cards/alter-egos/effects/armor-stand'
 import EvilXisumaRare from 'common/cards/alter-egos/hermits/evilxisuma_rare'
 import EthosLabCommon from 'common/cards/default/hermits/ethoslab-common'
 import {StatusEffectComponent} from 'common/components'
@@ -12,7 +13,6 @@ import {
 	playCardFromHand,
 	testGame,
 } from './utils'
-import ArmorStand from 'common/cards/alter-egos/effects/armor-stand'
 
 function* testEvilXDisablesForOneTurn(game: GameModel) {
 	yield* playCardFromHand(game, EvilXisumaRare, 'hermit', 0)

--- a/tests/game/impulse-rare.test.ts
+++ b/tests/game/impulse-rare.test.ts
@@ -9,12 +9,12 @@ import {GameModel} from 'common/models/game-model'
 import {attack, endTurn, playCardFromHand, testGame} from './utils'
 
 function* testOneHermit(game: GameModel) {
-	yield* playCardFromHand(game, EthosLabCommon, 0)
+	yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
 
 	yield* endTurn(game)
 
-	yield* playCardFromHand(game, ImpulseSVRare, 0)
-	yield* playCardFromHand(game, BdoubleO100Common, 1)
+	yield* playCardFromHand(game, ImpulseSVRare, 'hermit', 0)
+	yield* playCardFromHand(game, BdoubleO100Common, 'hermit', 1)
 
 	yield* attack(game, 'secondary')
 
@@ -24,14 +24,14 @@ function* testOneHermit(game: GameModel) {
 }
 
 function* testManyHermits(game: GameModel) {
-	yield* playCardFromHand(game, EthosLabCommon, 0)
+	yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
 
 	yield* endTurn(game)
 
-	yield* playCardFromHand(game, ImpulseSVRare, 0)
-	yield* playCardFromHand(game, BdoubleO100Common, 1)
-	yield* playCardFromHand(game, BdoubleO100Common, 2)
-	yield* playCardFromHand(game, TangoTekRare, 3)
+	yield* playCardFromHand(game, ImpulseSVRare, 'hermit', 0)
+	yield* playCardFromHand(game, BdoubleO100Common, 'hermit', 1)
+	yield* playCardFromHand(game, BdoubleO100Common, 'hermit', 2)
+	yield* playCardFromHand(game, TangoTekRare, 'hermit', 3)
 
 	yield* attack(game, 'secondary')
 

--- a/tests/game/loyalty.test.ts
+++ b/tests/game/loyalty.test.ts
@@ -6,18 +6,18 @@ import {GameModel} from 'common/models/game-model'
 import {attack, endTurn, playCardFromHand, testGame} from './utils'
 
 function* testLoyaltyHelperSaga(game: GameModel) {
-	yield* playCardFromHand(game, EthosLabCommon, 0)
-	yield* playCardFromHand(game, Loyalty, 0)
-	yield* playCardFromHand(game, BalancedItem, 0, 0)
+	yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
+	yield* playCardFromHand(game, Loyalty, 'attach', 0)
+	yield* playCardFromHand(game, BalancedItem, 'item', 0, 0)
 
 	yield* endTurn(game)
 
-	yield* playCardFromHand(game, EthosLabCommon, 0)
+	yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
 
 	yield* endTurn(game)
 
-	yield* playCardFromHand(game, EthosLabCommon, 1)
-	yield* playCardFromHand(game, BalancedItem, 1, 0)
+	yield* playCardFromHand(game, EthosLabCommon, 'hermit', 1)
+	yield* playCardFromHand(game, BalancedItem, 'item', 1, 0)
 
 	yield* endTurn(game)
 

--- a/tests/game/utils.ts
+++ b/tests/game/utils.ts
@@ -1,12 +1,8 @@
-import {Attach, Card, Hermit, Item, SingleUse} from 'common/cards/base/types'
+import {Card, Item} from 'common/cards/base/types'
 import {PlayerComponent, SlotComponent} from 'common/components'
 import query, {ComponentQuery} from 'common/components/query'
 import {GameModel, GameSettings} from 'common/models/game-model'
-import { SlotTypeT } from 'common/types/cards'
-<<<<<<< HEAD
-=======
-import {CardCategoryT} from 'common/types/cards'
->>>>>>> 9baf7c1d (Fix evil X)
+import {SlotTypeT} from 'common/types/cards'
 import {LocalModalResult} from 'common/types/server-requests'
 import {
 	attackToAttackAction,

--- a/tests/game/utils.ts
+++ b/tests/game/utils.ts
@@ -59,7 +59,7 @@ export function playCardFromHand(
 ): any
 export function playCardFromHand(
 	game: GameModel,
-	card: Item,
+	card: Card,
 	slotType: 'item',
 	row: number,
 	index: number,

--- a/tests/game/utils.ts
+++ b/tests/game/utils.ts
@@ -2,6 +2,11 @@ import {Attach, Card, Hermit, Item, SingleUse} from 'common/cards/base/types'
 import {PlayerComponent, SlotComponent} from 'common/components'
 import query, {ComponentQuery} from 'common/components/query'
 import {GameModel, GameSettings} from 'common/models/game-model'
+import { SlotTypeT } from 'common/types/cards'
+<<<<<<< HEAD
+=======
+import {CardCategoryT} from 'common/types/cards'
+>>>>>>> 9baf7c1d (Fix evil X)
 import {LocalModalResult} from 'common/types/server-requests'
 import {
 	attackToAttackAction,
@@ -45,21 +50,28 @@ export function* endTurn(game: GameModel) {
 }
 
 /** Play a card from your hand to a row on the game board */
-export function playCardFromHand(game: GameModel, card: SingleUse): any
 export function playCardFromHand(
 	game: GameModel,
-	card: Hermit | Attach,
+	card: Card,
+	slotType: 'single_use',
+): any
+export function playCardFromHand(
+	game: GameModel,
+	card: Card,
+	slotType: 'hermit' | 'attach',
 	row: number,
 ): any
 export function playCardFromHand(
 	game: GameModel,
 	card: Item,
+	slotType: 'item',
 	row: number,
 	index: number,
 ): any
 export function* playCardFromHand(
 	game: GameModel,
 	card: Card,
+	slotType: SlotTypeT,
 	row?: number,
 	index?: number,
 ) {
@@ -73,7 +85,7 @@ export function* playCardFromHand(
 			(slot.inRow() && slot.row.index === row),
 		(_game, slot) =>
 			index === undefined || (slot.inRow() && slot.index === index),
-		(_game, slot) => slot.type === cardComponent.props.category,
+		(_game, slot) => slot.type === slotType,
 	)!
 
 	yield* put<LocalMessage>({

--- a/tests/game/zombie-cleo-rare.test.ts
+++ b/tests/game/zombie-cleo-rare.test.ts
@@ -7,11 +7,11 @@ import {GameModel} from 'common/models/game-model'
 import {attack, endTurn, playCardFromHand, testGame} from './utils'
 
 function* testPrimaryDoesNotCrash(game: GameModel) {
-	yield* playCardFromHand(game, ZombieCleoRare, 0)
+	yield* playCardFromHand(game, ZombieCleoRare, 'hermit', 0)
 
 	yield* endTurn(game)
 
-	yield* playCardFromHand(game, EthosLabCommon, 0)
+	yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
 
 	yield* endTurn(game)
 


### PR DESCRIPTION
Evil X would disable his own secondary attack when it could not disable an opponents attack. He also did this when he was not active. This behavior does not match with other cards in the game so it now does not remove the option for the attack and only removes the ability.