### PR TITLE
Fix Anvil attack preview and logs

### DIFF
--- a/common/cards/alter-egos/single-use/anvil.ts
+++ b/common/cards/alter-egos/single-use/anvil.ts
@@ -32,9 +32,14 @@ const Anvil: SingleUse = {
 		'Do 30hp damage to the Hermit directly opposite your active Hermit on the game board, and 10hp damage to each Hermit below it.',
 	hasAttack: true,
 	attackPreview: (game) => {
-		const targetAmount = getTargetHermits(game, game.currentPlayer).length - 1
-		if (targetAmount === 0) return '$A30$'
-		return `$A30$ + $A10$ x ${targetAmount}`
+		const targets = getTargetHermits(game, game.currentPlayer)
+		if (targets.length === 0) return '0'
+		if (targets[0].index === game.currentPlayer.activeRow!.index) {
+			return targets.length === 1
+				? '$A30$'
+				: `$A30$ + $A10$ x ${targets.length - 1}`
+		}
+		return `$A10$ x ${targets.length}`
 	},
 	onAttach(
 		game: GameModel,
@@ -44,7 +49,7 @@ const Anvil: SingleUse = {
 		const {player} = component
 
 		observer.subscribe(player.hooks.getAttack, () => {
-			return getTargetHermits(game, player).reduce(
+			const attack = getTargetHermits(game, player).reduce(
 				(attacks: null | AttackModel, row) => {
 					if (!row.getHermit()) return attacks
 
@@ -53,10 +58,12 @@ const Anvil: SingleUse = {
 							attacker: component.entity,
 							target: row.entity,
 							type: 'effect',
-							log: (values) =>
-								row.index === player.activeRow?.index
-									? `${values.defaultLog} to attack ${values.target} for ${values.damage} damage`
-									: `, ${values.target} for ${values.damage} damage`,
+							log:
+								attacks === null
+									? (values) =>
+											`${values.defaultLog} to attack ${values.target} for ${values.damage} damage`
+									: (values) =>
+											`, ${values.target} for ${values.damage} damage`,
 						})
 						.addDamage(
 							component.entity,
@@ -71,10 +78,22 @@ const Anvil: SingleUse = {
 				},
 				null,
 			)
+			if (attack === null) {
+				// No valid targets
+				game.battleLog.addEntry(
+					component.player.entity,
+					`$p{You|${component.player.playerName}}$ used $eAnvil$ and missed`,
+				)
+				applySingleUse(game)
+			}
+			return attack
 		})
 
-		observer.subscribe(player.hooks.afterAttack, (_attack) => {
-			applySingleUse(game, component.slot)
+		observer.subscribe(player.hooks.onAttack, (attack) => {
+			if (attack.isAttacker(component.entity)) {
+				applySingleUse(game, component.slot)
+				observer.unsubscribe(player.hooks.onAttack)
+			}
 		})
 	},
 }

--- a/common/cards/alter-egos/single-use/anvil.ts
+++ b/common/cards/alter-egos/single-use/anvil.ts
@@ -33,7 +33,7 @@ const Anvil: SingleUse = {
 	hasAttack: true,
 	attackPreview: (game) => {
 		const targets = getTargetHermits(game, game.currentPlayer)
-		if (targets.length === 0) return '0'
+		if (targets.length === 0) return '$A0$'
 		if (targets[0].index === game.currentPlayer.activeRow!.index) {
 			return targets.length === 1
 				? '$A30$'


### PR DESCRIPTION
- Fixes attack preview and log if there is not a hermit opposite the user's active row
- Fixes Anvil returning to player's hand if used by itself and did not deal damage
- Adds log for Anvil being used without dealing damage