### PR TITLE
Sheep stare fix

### DIFF
--- a/common/status-effects/sheep-stare.ts
+++ b/common/status-effects/sheep-stare.ts
@@ -23,14 +23,11 @@ const SheepStareEffect: StatusEffect<PlayerComponent> = {
 		observer: ObserverComponent,
 	) {
 		let coinFlipResult: CoinFlipResult | null = null
-		const activeHermit = player.getActiveHermit()
 
 		observer.subscribe(player.hooks.beforeAttack, (attack) => {
-			if (!attack.isAttacker(activeHermit?.entity)) return
-
 			// No need to flip a coin for multiple attacks
 			if (!coinFlipResult) {
-				if (!activeHermit) return
+				if (!player.getActiveHermit()) return
 				const coinFlip = flipCoin(
 					player.opponentPlayer,
 					effect.creator,


### PR DESCRIPTION
Not sure why the effect was written like this, but the active Hermit used to be "locked in" before the effect was applied causing it to not work when used with knockback. I removed that check because even if you could attack with a non-active Hermit, I'm not sure why they wouldn't be affected by sheep stare.