### PR TITLE
Force coin flip by default in tests

### DIFF
--- a/tests/game/utils.ts
+++ b/tests/game/utils.ts
@@ -198,7 +198,7 @@ const defaultGameSettings = {
 	extraStartingCards: [],
 	disableDamage: false,
 	noItemRequirements: false,
-	forceCoinFlip: false,
+	forceCoinFlip: true,
 	shuffleDeck: false,
 	logErrorsToStderr: false,
 	logBoardState: true,


### PR DESCRIPTION
This will remove any random chance in tests. This may fix the poultryman test randomly failing.