### PR TITLE
Improve calculation of game winner

### DIFF
--- a/common/models/game-model.ts
+++ b/common/models/game-model.ts
@@ -114,8 +114,8 @@ export class GameModel {
 	public afterGameEnd: Hook<string, () => void>
 
 	public endInfo: {
-		deadPlayerEntities: Array<string>
-		winner: string | null
+		deadPlayerEntities: Array<PlayerEntity>
+		winner: PlayerId | null
 		outcome: GameEndOutcomeT | null
 		reason: GameEndReasonT | null
 	}

--- a/server/src/routines/background/connection-status.ts
+++ b/server/src/routines/background/connection-status.ts
@@ -54,7 +54,7 @@ export function* statusChangedSaga(
 	const opponentId = getOpponentId(game, playerId)
 	const connectionStatus = game.players[playerId]?.socket.connected
 
-	if (!game.players[opponentId]) return
+	if (!opponentId || !game.players[opponentId]) return
 
 	broadcast([game.players[opponentId]], {
 		type: serverMessages.OPPONENT_CONNECTION,

--- a/server/src/routines/matchmaking.ts
+++ b/server/src/routines/matchmaking.ts
@@ -90,7 +90,9 @@ function* gameManager(game: GameModel) {
 			// kill a game after two hours
 			timeout: delay(1000 * 60 * 60),
 			// kill game when a player is disconnected for too long
-			playerRemoved: take(
+			playerRemoved: take<
+				LocalMessageTable[typeof localMessages.PLAYER_REMOVED]
+			>(
 				(action: any) =>
 					action.type === localMessages.PLAYER_REMOVED &&
 					playerIds.includes(
@@ -98,7 +100,7 @@ function* gameManager(game: GameModel) {
 							.player.id,
 					),
 			),
-			forfeit: take(
+			forfeit: take<RecievedClientMessage<typeof clientMessages.FORFEIT>>(
 				(action: any) =>
 					action.type === clientMessages.FORFEIT &&
 					playerIds.includes(
@@ -121,7 +123,7 @@ function* gameManager(game: GameModel) {
 						.forEach((player) => (player.coinFlips = []))
 				}
 			}
-			const outcome = getGamePlayerOutcome(game, result, viewer.player.id)
+			const outcome = getGamePlayerOutcome(game, result, viewer)
 			// assert(game.endInfo.reason, 'Games can not end without a reason')
 			broadcast([viewer.player], {
 				type: serverMessages.GAME_END,

--- a/server/src/utils/index.ts
+++ b/server/src/utils/index.ts
@@ -4,11 +4,14 @@ import {
 	StatusEffectComponent,
 } from 'common/components'
 import query from 'common/components/query'
+import {ViewerComponent} from 'common/components/viewer-component'
 import {GameModel} from 'common/models/game-model'
 
 export const getOpponentId = (game: GameModel, playerId: string) => {
-	const players = game.getPlayers()
-	return players.filter((p) => p.id !== playerId)[0]?.id
+	const players = game.components
+		.filter(ViewerComponent, (_game, viewer) => !viewer.spectator)
+		.map((viewer) => viewer.player)
+	return players.filter((p) => p.id !== playerId)[0]?.id || null
 }
 
 export function printHooksState(game: GameModel) {

--- a/server/src/utils/win-conditions.ts
+++ b/server/src/utils/win-conditions.ts
@@ -1,3 +1,4 @@
+import assert from 'assert'
 import {ViewerComponent} from 'common/components/viewer-component'
 import {GameModel} from 'common/models/game-model'
 import {PlayerId} from 'common/models/player-model'
@@ -8,7 +9,6 @@ import {
 import {GamePlayerEndOutcomeT} from 'common/types/game-state'
 import {LocalMessageTable, localMessages} from 'messages'
 import {getOpponentId} from '../utils'
-import assert from 'assert'
 
 ////////////////////////////////////////
 // @TODO sort this whole thing out properly

--- a/server/src/utils/win-conditions.ts
+++ b/server/src/utils/win-conditions.ts
@@ -69,6 +69,7 @@ export const getGamePlayerOutcome = (
 	return 'you_won'
 }
 
+/** Gets the winning player's id if both players have corresponding PlayerModels */
 export const getWinner = (game: GameModel, endResult: EndResult) => {
 	if (Object.hasOwn(endResult, 'timeout')) return null
 	if (Object.hasOwn(endResult, 'forfeit')) {

--- a/server/src/utils/win-conditions.ts
+++ b/server/src/utils/win-conditions.ts
@@ -1,14 +1,38 @@
 import {ViewerComponent} from 'common/components/viewer-component'
 import {GameModel} from 'common/models/game-model'
 import {PlayerId} from 'common/models/player-model'
+import {
+	RecievedClientMessage,
+	clientMessages,
+} from 'common/socket-messages/client-messages'
 import {GamePlayerEndOutcomeT} from 'common/types/game-state'
+import {LocalMessageTable, localMessages} from 'messages'
 import {getOpponentId} from '../utils'
 
 ////////////////////////////////////////
 // @TODO sort this whole thing out properly
 /////////////////////////////////////////
 
-export const getGameOutcome = (game: GameModel, endResult: any) => {
+type EndResult = {
+	gameEnd?: unknown
+	timeout?: true
+	playerRemoved?: LocalMessageTable[typeof localMessages.PLAYER_REMOVED]
+	forfeit?: RecievedClientMessage<typeof clientMessages.FORFEIT>
+}
+
+function getPlayerIdFromViewer(
+	game: GameModel,
+	viewer: ViewerComponent,
+): PlayerId | undefined {
+	return game.components.find(
+		ViewerComponent,
+		(_game, value) =>
+			!value.spectator &&
+			value.playerOnLeftEntity === viewer.playerOnLeftEntity,
+	)?.playerId
+}
+
+export const getGameOutcome = (game: GameModel, endResult: EndResult) => {
 	if (Object.hasOwn(endResult, 'timeout')) return 'timeout'
 	if (Object.hasOwn(endResult, 'forfeit')) return 'forfeit'
 	if (Object.hasOwn(endResult, 'playerRemoved')) return 'forfeit'
@@ -18,40 +42,37 @@ export const getGameOutcome = (game: GameModel, endResult: any) => {
 
 export const getGamePlayerOutcome = (
 	game: GameModel,
-	endResult: any,
-	playerId: PlayerId,
+	endResult: EndResult,
+	viewer: ViewerComponent,
 ): GamePlayerEndOutcomeT => {
 	if (Object.hasOwn(endResult, 'timeout')) return 'timeout'
 	if (Object.hasOwn(endResult, 'forfeit')) {
-		const triggerPlayerId = endResult.forfeit.playerId
-		return triggerPlayerId === playerId ? 'forfeit_loss' : 'forfeit_win'
+		const triggerPlayerId = endResult.forfeit!.playerId
+		return triggerPlayerId === getPlayerIdFromViewer(game, viewer)
+			? 'forfeit_loss'
+			: 'forfeit_win'
 	}
 	if (Object.hasOwn(endResult, 'playerRemoved')) {
-		const triggerPlayerId = endResult.playerRemoved.player.id
-		return triggerPlayerId === playerId ? 'leave_loss' : 'leave_win'
+		const triggerPlayerId = endResult.playerRemoved!.player.id
+		return triggerPlayerId === getPlayerIdFromViewer(game, viewer)
+			? 'leave_loss'
+			: 'leave_win'
 	}
 	if (game.endInfo.deadPlayerEntities.length === 2) return 'tie'
 	const deadPlayerEntity = game.endInfo.deadPlayerEntities[0]
 	if (!deadPlayerEntity) return 'unknown'
 
-	let deadPlayer = game.components.find(
-		ViewerComponent,
-		(_game, viewer) =>
-			!viewer.spectator && viewer.playerOnLeft.entity === deadPlayerEntity,
-	)
-	if (!deadPlayer) return 'unknown'
-
-	if (deadPlayer.playerId === playerId) return 'you_lost'
+	if (deadPlayerEntity === viewer.playerOnLeftEntity) return 'you_lost'
 	return 'you_won'
 }
 
-export const getWinner = (game: GameModel, endResult: any) => {
+export const getWinner = (game: GameModel, endResult: EndResult) => {
 	if (Object.hasOwn(endResult, 'timeout')) return null
 	if (Object.hasOwn(endResult, 'forfeit')) {
-		return getOpponentId(game, endResult.forfeit.playerId)
+		return getOpponentId(game, endResult.forfeit!.playerId)
 	}
 	if (Object.hasOwn(endResult, 'playerRemoved')) {
-		return getOpponentId(game, endResult.playerRemoved.player.id)
+		return getOpponentId(game, endResult.playerRemoved!.player.id)
 	}
 	if (game.endInfo.deadPlayerEntities.length === 2) return null
 	const deadPlayerEntity = game.endInfo.deadPlayerEntities[0]

--- a/server/src/utils/win-conditions.ts
+++ b/server/src/utils/win-conditions.ts
@@ -8,6 +8,7 @@ import {
 import {GamePlayerEndOutcomeT} from 'common/types/game-state'
 import {LocalMessageTable, localMessages} from 'messages'
 import {getOpponentId} from '../utils'
+import assert from 'assert'
 
 ////////////////////////////////////////
 // @TODO sort this whole thing out properly
@@ -47,13 +48,15 @@ export const getGamePlayerOutcome = (
 ): GamePlayerEndOutcomeT => {
 	if (Object.hasOwn(endResult, 'timeout')) return 'timeout'
 	if (Object.hasOwn(endResult, 'forfeit')) {
-		const triggerPlayerId = endResult.forfeit!.playerId
+		assert(endResult.forfeit)
+		const triggerPlayerId = endResult.forfeit.playerId
 		return triggerPlayerId === getPlayerIdFromViewer(game, viewer)
 			? 'forfeit_loss'
 			: 'forfeit_win'
 	}
 	if (Object.hasOwn(endResult, 'playerRemoved')) {
-		const triggerPlayerId = endResult.playerRemoved!.player.id
+		assert(endResult.playerRemoved)
+		const triggerPlayerId = endResult.playerRemoved.player.id
 		return triggerPlayerId === getPlayerIdFromViewer(game, viewer)
 			? 'leave_loss'
 			: 'leave_win'
@@ -69,10 +72,12 @@ export const getGamePlayerOutcome = (
 export const getWinner = (game: GameModel, endResult: EndResult) => {
 	if (Object.hasOwn(endResult, 'timeout')) return null
 	if (Object.hasOwn(endResult, 'forfeit')) {
-		return getOpponentId(game, endResult.forfeit!.playerId)
+		assert(endResult.forfeit)
+		return getOpponentId(game, endResult.forfeit.playerId)
 	}
 	if (Object.hasOwn(endResult, 'playerRemoved')) {
-		return getOpponentId(game, endResult.playerRemoved!.player.id)
+		assert(endResult.playerRemoved)
+		return getOpponentId(game, endResult.playerRemoved.player.id)
 	}
 	if (game.endInfo.deadPlayerEntities.length === 2) return null
 	const deadPlayerEntity = game.endInfo.deadPlayerEntities[0]


### PR DESCRIPTION
Decking out is now only considered if both players are still alive
- Fixes running out of cards causing losses to be ties or vice versa
- Improves `getGamePlayerOutcome` to support future PvE and spectator games