### PR TITLE
Remove active row check for coinflips

### DIFF
--- a/common/utils/coinFlips.ts
+++ b/common/utils/coinFlips.ts
@@ -22,15 +22,6 @@ export function flipCoin(
 	currentPlayer: PlayerComponent | null = null,
 ): Array<CoinFlipResult> {
 	const forceHeads = playerTossingCoin.game.settings.forceCoinFlip
-	const activeRowIndex = playerTossingCoin.game.components.get(
-		playerTossingCoin.activeRowEntity,
-	)
-	if (activeRowIndex === null) {
-		console.log(
-			`${card.props.numericId} attempted to flip coin with no active row!, that shouldn't be possible`,
-		)
-		return []
-	}
 
 	let coinFlips: Array<CoinFlipResult> = []
 	for (let i = 0; i < times; i++) {


### PR DESCRIPTION
- Fixes Trap Hole effect not flipping for Gem's second single-use effect if opponent's active was knocked-out
- Fixes Egg not flipping for damage if player's active was knocked-out by their attack