### PR TITLE
Fix Poultry Man returning Egg late

### DIFF
--- a/common/cards/alter-egos-iii/hermits/poultryman-rare.ts
+++ b/common/cards/alter-egos-iii/hermits/poultryman-rare.ts
@@ -52,16 +52,7 @@ const PoultryManRare: Hermit = {
 					query.card.is(Egg),
 				)
 
-				if (singleUse) {
-					observer.subscribeWithPriority(
-						player.hooks.afterAttack,
-						afterAttack.UPDATE_POST_ATTACK_STATE,
-						() => {
-							singleUse.draw(player.entity)
-							observer.unsubscribe(player.hooks.afterAttack)
-						},
-					)
-				}
+				singleUse?.draw()
 			},
 		)
 	},

--- a/tests/game/poultryman-rare.test.ts
+++ b/tests/game/poultryman-rare.test.ts
@@ -1,10 +1,18 @@
 import {describe, expect, test} from '@jest/globals'
 import PoultryManRare from 'common/cards/alter-egos-iii/hermits/poultryman-rare'
+import BadOmen from 'common/cards/alter-egos/single-use/bad-omen'
 import Egg from 'common/cards/alter-egos/single-use/egg'
 import EthosLabCommon from 'common/cards/default/hermits/ethoslab-common'
 import GoldenAxe from 'common/cards/default/single-use/golden-axe'
 import query from 'common/components/query'
-import {attack, endTurn, pick, playCardFromHand, testGame} from './utils'
+import {
+	applyEffect,
+	attack,
+	endTurn,
+	pick,
+	playCardFromHand,
+	testGame,
+} from './utils'
 
 describe('Test Poutry Man Rare', () => {
 	test('Poultry Man only recycles Egg.', () => {
@@ -43,6 +51,44 @@ describe('Test Poutry Man Rare', () => {
 					yield* attack(game, 'secondary')
 
 					// Hand should only contain Egg.
+					expect(game.currentPlayer.getHand()?.length).toBe(1)
+				},
+			},
+			{startWithAllCards: true, noItemRequirements: true},
+		)
+	})
+
+	test('Poultry Man recycles Egg on tails.', () => {
+		testGame(
+			{
+				playerOneDeck: [EthosLabCommon, EthosLabCommon, BadOmen],
+				playerTwoDeck: [PoultryManRare, Egg],
+				saga: function* (game) {
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 1)
+
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, PoultryManRare, 'hermit', 0)
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, BadOmen, 'single_use')
+					yield* applyEffect(game)
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, Egg, 'single_use')
+					yield* attack(game, 'secondary')
+
+					yield* pick(
+						game,
+						query.slot.opponent,
+						query.slot.hermit,
+						query.slot.rowIndex(1),
+					)
+
+					expect(game.opponentPlayer.activeRow?.index).toBe(1)
+
+					// Hand should contain Egg.
 					expect(game.currentPlayer.getHand()?.length).toBe(1)
 				},
 			},


### PR DESCRIPTION
- Fixes rare Poultry Man secondary not returning Egg until `player.hooks.afterAttack` was run again

_This caused `poultryman-rare.test.ts` to fail when Egg flipped tails and did not attack target hermit, Egg was not in hand yet._