### PR TITLE
Attack request fixes

### DIFF
--- a/common/cards/alter-egos-ii/hermits/boomerbdubs-rare.ts
+++ b/common/cards/alter-egos-ii/hermits/boomerbdubs-rare.ts
@@ -7,6 +7,7 @@ import {
 import query from '../../../components/query'
 import {GameModel} from '../../../models/game-model'
 import FortuneEffect from '../../../status-effects/fortune'
+import {SelectCards} from '../../../types/modal-requests'
 import {beforeAttack} from '../../../types/priorities'
 import {flipCoin} from '../../../utils/coinFlips'
 import {hermit} from '../../base/defaults'
@@ -66,6 +67,41 @@ const BoomerBdubsRare: Hermit = {
 
 				if (!activeHermit) return
 
+				const followUpModal = {
+					player: player.entity,
+					modal: {
+						type: 'selectCards',
+						name: 'Boomer BDubs - Watch This',
+						description: 'Do you want to flip another coin for your attack?',
+						cards: [],
+						selectionSize: 0,
+						cancelable: false,
+						primaryButton: {
+							text: 'Yes',
+							variant: 'default',
+						},
+						secondaryButton: {
+							text: 'No',
+							variant: 'default',
+						},
+					},
+					onResult(modalResult) {
+						if (!modalResult?.result) return
+
+						const flip = flipCoin(player, activeHermit)[0]
+
+						if (flip === 'tails') {
+							flippedTails = true
+							return 'SUCCESS'
+						}
+
+						extraDamage += 20
+
+						game.addModalRequest(followUpModal)
+					},
+					onTimeout() {},
+				} satisfies SelectCards.Request
+
 				game.addModalRequest({
 					player: player.entity,
 					modal: {
@@ -97,10 +133,7 @@ const BoomerBdubsRare: Hermit = {
 
 						extraDamage += 20
 
-						player.hooks.getAttackRequests.call(
-							activeInstance,
-							hermitAttackType,
-						)
+						game.addModalRequest(followUpModal)
 
 						// After the first coin flip we remove fortune to prevent infinite coin flips.
 						game.components

--- a/common/status-effects/betrayed.ts
+++ b/common/status-effects/betrayed.ts
@@ -98,7 +98,10 @@ const BetrayedEffect: StatusEffect<PlayerComponent> = {
 			player.hooks.getAttackRequests,
 			(_activeInstance, _hermitAttackType) => {
 				// Only pick if there is afk to pick
-				if (!game.components.exists(SlotComponent, pickCondition)) return
+				if (!game.components.exists(SlotComponent, pickCondition)) {
+					pickedAfkHermit = null
+					return
+				}
 
 				game.addPickRequest({
 					player: player.entity,
@@ -109,7 +112,6 @@ const BetrayedEffect: StatusEffect<PlayerComponent> = {
 						pickedAfkHermit = pickedSlot
 					},
 					onTimeout() {
-						observer.unsubscribe(player.hooks.getAttackRequests)
 						const firstAfk = game.components.find(SlotComponent, pickCondition)
 						if (!firstAfk) return
 						pickedAfkHermit = firstAfk

--- a/tests/game/humancleo-rare.test.ts
+++ b/tests/game/humancleo-rare.test.ts
@@ -1,0 +1,88 @@
+import {describe, expect, test} from '@jest/globals'
+import HumanCleoRare from 'common/cards/alter-egos/hermits/humancleo-rare'
+import EnderPearl from 'common/cards/alter-egos/single-use/ender-pearl'
+import EthosLabCommon from 'common/cards/default/hermits/ethoslab-common'
+import VintageBeefCommon from 'common/cards/default/hermits/vintagebeef-common'
+import Crossbow from 'common/cards/default/single-use/crossbow'
+import {RowComponent} from 'common/components'
+import query from 'common/components/query'
+import {
+	attack,
+	changeActiveHermit,
+	endTurn,
+	pick,
+	playCardFromHand,
+	removeEffect,
+	testGame,
+} from './utils'
+
+describe('Test Human Cleo Betrayal', () => {
+	test('Test Betrayal with canceling to Ender Pearl knock-out', () => {
+		testGame(
+			{
+				playerOneDeck: [
+					EthosLabCommon,
+					VintageBeefCommon,
+					Crossbow,
+					EnderPearl,
+				],
+				playerTwoDeck: [HumanCleoRare],
+				saga: function* (game) {
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
+					yield* playCardFromHand(game, VintageBeefCommon, 'hermit', 1)
+
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, HumanCleoRare, 'hermit', 0)
+
+					yield* attack(game, 'secondary')
+
+					yield* endTurn(game)
+
+					game.components.find(
+						RowComponent,
+						query.row.currentPlayer,
+						query.row.active,
+					)!.health = 10 // Prepare active row to be knocked-out after using Ender Pearl
+
+					yield* playCardFromHand(game, Crossbow, 'single_use')
+
+					yield* attack(game, 'secondary')
+
+					yield* pick(
+						game,
+						query.slot.currentPlayer,
+						query.slot.hermit,
+						query.slot.rowIndex(1),
+					)
+
+					yield* removeEffect(game)
+
+					yield* playCardFromHand(game, EnderPearl, 'single_use')
+					yield* pick(
+						game,
+						query.slot.currentPlayer,
+						query.slot.hermit,
+						query.slot.rowIndex(2),
+					)
+
+					yield* changeActiveHermit(game, 1)
+
+					yield* attack(game, 'secondary')
+
+					expect(game.currentPlayer.activeRow?.health).toBe(
+						VintageBeefCommon.health,
+					)
+					expect(game.opponentPlayer.activeRow?.health).not.toBe(
+						HumanCleoRare.health,
+					)
+				},
+			},
+			{
+				startWithAllCards: true,
+				noItemRequirements: true,
+				forceCoinFlip: true,
+			},
+		)
+	})
+})

--- a/tests/game/utils.ts
+++ b/tests/game/utils.ts
@@ -106,6 +106,17 @@ export function* applyEffect(game: GameModel) {
 	})
 }
 
+/** Removes the effect card in the single use slot. This should be used to cancel effects that use the "should apply" modal or cancel an attack with pick requests. */
+export function* removeEffect(game: GameModel) {
+	yield* put<LocalMessage>({
+		type: localMessages.GAME_TURN_ACTION,
+		playerEntity: game.currentPlayer.entity,
+		action: {
+			type: 'REMOVE_EFFECT',
+		},
+	})
+}
+
 /** Attack with the current player. */
 export function* attack(
 	game: GameModel,


### PR DESCRIPTION
Includes changes from #874 not part of Puppetry behavior:
- rare Boomer Bdubs no longer adds duplicate requests after flipping heads for "Watch This"
- Betrayed effect no longer remembers selected AFK hermit after opponent cancels their attack