### PR TITLE
Update Web Session Properly

### DIFF
--- a/client/src/app/deck/deck-select.tsx
+++ b/client/src/app/deck/deck-select.tsx
@@ -97,7 +97,7 @@ function SelectDeck({
 
 	// MENU LOGIC
 	const backToMenu = () => {
-		if (validateDeck(loadedDeck.cards)) {
+		if (!validateDeck(loadedDeck.cards).valid) {
 			return setShowValidateDeckModal(true)
 		}
 

--- a/client/src/app/deck/deck-select.tsx
+++ b/client/src/app/deck/deck-select.tsx
@@ -97,7 +97,7 @@ function SelectDeck({
 
 	// MENU LOGIC
 	const backToMenu = () => {
-		if (!validateDeck(loadedDeck.cards).valid) {
+		if (validateDeck(loadedDeck.cards)) {
 			return setShowValidateDeckModal(true)
 		}
 

--- a/client/src/logic/session/session-reducer.ts
+++ b/client/src/logic/session/session-reducer.ts
@@ -2,6 +2,7 @@ import {PlayerId} from 'common/models/player-model'
 import {ToastT} from 'common/types/app'
 import {PlayerDeckT} from 'common/types/deck'
 import {LocalMessage, localMessages} from 'logic/messages'
+import {saveSession, updateSession} from './session-saga'
 
 type SessionState = {
 	playerName: string
@@ -30,11 +31,7 @@ const defaultState: SessionState = {
 	toast: {open: false, title: '', description: '', image: ''},
 	updates: {},
 }
-
-const loginReducer = (
-	state = defaultState,
-	action: LocalMessage,
-): SessionState => {
+function updateState(state = defaultState, action: LocalMessage) {
 	switch (action.type) {
 		case localMessages.LOGIN:
 			return {...state, connecting: true, errorType: undefined}
@@ -89,6 +86,15 @@ const loginReducer = (
 		default:
 			return state
 	}
+}
+
+const loginReducer = (
+	state = defaultState,
+	action: LocalMessage,
+): SessionState => {
+	let newState = updateState(state, action)
+	updateSession(newState)
+	return newState
 }
 
 export default loginReducer

--- a/client/src/logic/session/session-reducer.ts
+++ b/client/src/logic/session/session-reducer.ts
@@ -2,7 +2,7 @@ import {PlayerId} from 'common/models/player-model'
 import {ToastT} from 'common/types/app'
 import {PlayerDeckT} from 'common/types/deck'
 import {LocalMessage, localMessages} from 'logic/messages'
-import {saveSession, updateSession} from './session-saga'
+import {updateSession} from './session-saga'
 
 type SessionState = {
 	playerName: string

--- a/client/src/logic/session/session-saga.ts
+++ b/client/src/logic/session/session-saga.ts
@@ -51,6 +51,14 @@ const saveSession = (playerInfo: PlayerInfo) => {
 	sessionStorage.setItem('playerDeck', JSON.stringify(playerInfo.playerDeck))
 }
 
+export const updateSession = (session: {
+	minecraftName: string
+	playerDeck: PlayerDeckT
+}) => {
+	sessionStorage.setItem('minecraftName', session.minecraftName)
+	sessionStorage.setItem('playerDeck', JSON.stringify(session.playerDeck))
+}
+
 const clearSession = () => {
 	sessionStorage.removeItem('playerName')
 	sessionStorage.removeItem('censoredPlayerName')
@@ -169,7 +177,7 @@ export function* loginSaga() {
 
 		const activeDeckName = getActiveDeckName()
 		const activeDeck = activeDeckName ? getSavedDeck(activeDeckName) : null
-		const activeDeckValid = !!activeDeck && !validateDeck(activeDeck.cards)
+		const activeDeckValid = !!activeDeck && validateDeck(activeDeck.cards)
 
 		// if active deck is not valid, generate and save a starter deck
 		if (urlDeck) {


### PR DESCRIPTION
Update web session when items are saved locally. This fixes an issue where the selected player's deck was not saved when reloading the page.