### PR TITLE
Jopacity fixes

### DIFF
--- a/common/cards/default/hermits/docm77-rare.ts
+++ b/common/cards/default/hermits/docm77-rare.ts
@@ -48,7 +48,7 @@ const Docm77Rare: Hermit = {
 				if (coinFlip[0] === 'heads') {
 					attack.addDamage(component.entity, this.secondary.damage)
 				} else {
-					attack.multiplyDamage(component.entity, 0.5)
+					attack.removeDamage(component.entity, this.secondary.damage / 2)
 				}
 			},
 		)

--- a/common/models/attack-model.ts
+++ b/common/models/attack-model.ts
@@ -162,7 +162,7 @@ export class AttackModel {
 
 	// Setters / modifier methods
 
-	/** Increases the damage the attack does */
+	/** Increases the base damage the attack does */
 	public addDamage(source: AttackerEntity, amount: number) {
 		if (this.damageLocked) return this
 		this.damage += amount
@@ -172,7 +172,17 @@ export class AttackModel {
 		return this
 	}
 
-	/** Reduces the damage the attack does */
+	/** Reduces the base damage of the attack (before multiplication) */
+	public removeDamage(source: AttackerEntity, amount: number) {
+		if (this.damageLocked) return this
+		this.damage -= amount
+
+		this.addHistory(source, 'remove_damage', amount)
+
+		return this
+	}
+
+	/** Reduces the total damage the attack does */
 	public reduceDamage(source: AttackerEntity, amount: number) {
 		if (this.damageLocked) return this
 		this.damageReduction += amount

--- a/common/status-effects/chroma-keyed.ts
+++ b/common/status-effects/chroma-keyed.ts
@@ -45,7 +45,7 @@ const ChromaKeyedEffect: Counter<CardComponent> = {
 				if (effect.counter === null) return
 
 				if (attack.isAttacker(target.entity) && attack.type === 'secondary') {
-					attack.reduceDamage(effect.entity, effect.counter * 10)
+					attack.removeDamage(effect.entity, effect.counter * 10)
 					effect.counter++
 					chromaUsedThisTurn = true
 				}

--- a/common/types/attack.ts
+++ b/common/types/attack.ts
@@ -79,6 +79,7 @@ export type AttackDefs =
 
 export type AttackHistoryType =
 	| 'add_damage'
+	| 'remove_damage'
 	| 'reduce_damage'
 	| 'multiply_damage'
 	| 'lock_damage'

--- a/tests/game/beetlejhost-rare.test.ts
+++ b/tests/game/beetlejhost-rare.test.ts
@@ -1,11 +1,14 @@
 import {describe, expect, test} from '@jest/globals'
 import BeetlejhostRare from 'common/cards/alter-egos-iii/hermits/beetlejhost-rare'
+import BadOmen from 'common/cards/alter-egos/single-use/bad-omen'
 import EthosLabCommon from 'common/cards/default/hermits/ethoslab-common'
 import GeminiTayCommon from 'common/cards/default/hermits/geminitay-common'
+import InvisibilityPotion from 'common/cards/default/single-use/invisibility-potion'
 import {RowComponent, StatusEffectComponent} from 'common/components'
 import query from 'common/components/query'
 import ChromaKeyedEffect from 'common/status-effects/chroma-keyed'
 import {
+	applyEffect,
 	attack,
 	changeActiveHermit,
 	endTurn,
@@ -157,6 +160,45 @@ describe('Test Beetlejhost Rare', () => {
 				},
 			},
 			{startWithAllCards: true, noItemRequirements: true},
+		)
+	})
+	test('Test Jopacity with Invisibility tails', () => {
+		testGame(
+			{
+				playerOneDeck: [GeminiTayCommon, InvisibilityPotion],
+				playerTwoDeck: [BeetlejhostRare, BadOmen],
+				saga: function* (game) {
+					yield* playCardFromHand(game, GeminiTayCommon, 'hermit', 0)
+
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, BeetlejhostRare, 'hermit', 0)
+					yield* playCardFromHand(game, BadOmen, 'single_use')
+					yield* applyEffect(game)
+
+					yield* attack(game, 'secondary')
+
+					expect(game.opponentPlayer.activeRow?.health).toBe(
+						GeminiTayCommon.health - BeetlejhostRare.secondary.damage,
+					)
+
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, InvisibilityPotion, 'single_use')
+					yield* applyEffect(game)
+
+					yield* endTurn(game)
+
+					yield* attack(game, 'secondary')
+
+					expect(game.opponentPlayer.activeRow?.health).toBe(
+						GeminiTayCommon.health -
+							BeetlejhostRare.secondary.damage -
+							(BeetlejhostRare.secondary.damage - 10) * 2,
+					)
+				},
+			},
+			{startWithAllCards: true, noItemRequirements: true, forceCoinFlip: true},
 		)
 	})
 })

--- a/tests/game/zombie-cleo-rare.test.ts
+++ b/tests/game/zombie-cleo-rare.test.ts
@@ -8,6 +8,7 @@ import SmallishbeansCommon from 'common/cards/season-x/hermits/smallishbeans-com
 import {RowComponent, StatusEffectComponent} from 'common/components'
 import query from 'common/components/query'
 import {GameModel} from 'common/models/game-model'
+import ChromaKeyedEffect from 'common/status-effects/chroma-keyed'
 import {MultiturnSecondaryAttackDisabledEffect} from 'common/status-effects/multiturn-attack-disabled'
 import {
 	attack,
@@ -196,6 +197,15 @@ function* testPuppetingJopacity(game: GameModel) {
 			(BeetlejhostRare.secondary.damage - 10) -
 			SmallishbeansCommon.secondary.damage,
 	)
+
+	yield* endTurn(game)
+	expect(
+		game.components.find(
+			StatusEffectComponent,
+			query.effect.is(ChromaKeyedEffect),
+			query.effect.targetIsCardAnd(query.card.currentPlayer),
+		),
+	).toBe(null)
 }
 
 describe('Test Zombie Cleo', () => {

--- a/tests/game/zombie-cleo-rare.test.ts
+++ b/tests/game/zombie-cleo-rare.test.ts
@@ -198,7 +198,6 @@ function* testPuppetingJopacity(game: GameModel) {
 			SmallishbeansCommon.secondary.damage,
 	)
 
-	yield* endTurn(game)
 	expect(
 		game.components.find(
 			StatusEffectComponent,

--- a/tests/game/zombie-cleo-rare.test.ts
+++ b/tests/game/zombie-cleo-rare.test.ts
@@ -1,8 +1,10 @@
 import {describe, expect, test} from '@jest/globals'
 import BoomerBdubsRare from 'common/cards/alter-egos-ii/hermits/boomerbdubs-rare'
 import ArchitectFalseRare from 'common/cards/alter-egos-iii/hermits/architectfalse-rare'
+import BeetlejhostRare from 'common/cards/alter-egos-iii/hermits/beetlejhost-rare'
 import EthosLabCommon from 'common/cards/default/hermits/ethoslab-common'
 import ZombieCleoRare from 'common/cards/default/hermits/zombiecleo-rare'
+import SmallishbeansCommon from 'common/cards/season-x/hermits/smallishbeans-common'
 import {RowComponent, StatusEffectComponent} from 'common/components'
 import query from 'common/components/query'
 import {GameModel} from 'common/models/game-model'
@@ -140,6 +142,62 @@ function* testPuppetryCanceling(game: GameModel) {
 	)
 }
 
+function* testPuppetingJopacity(game: GameModel) {
+	yield* playCardFromHand(game, SmallishbeansCommon, 'hermit', 0)
+
+	yield* endTurn(game)
+
+	yield* playCardFromHand(game, ZombieCleoRare, 'hermit', 0)
+	yield* playCardFromHand(game, BeetlejhostRare, 'hermit', 1)
+	yield* playCardFromHand(game, SmallishbeansCommon, 'hermit', 2)
+
+	yield* attack(game, 'secondary')
+	yield* pick(
+		game,
+		query.slot.currentPlayer,
+		query.slot.hermit,
+		query.slot.rowIndex(1),
+	)
+	yield* finishModalRequest(game, {pick: 'secondary'})
+
+	yield* endTurn(game)
+	yield* endTurn(game)
+
+	yield* attack(game, 'secondary')
+	yield* pick(
+		game,
+		query.slot.currentPlayer,
+		query.slot.hermit,
+		query.slot.rowIndex(1),
+	)
+	yield* finishModalRequest(game, {pick: 'secondary'})
+
+	expect(game.opponentPlayer.activeRow?.health).toBe(
+		SmallishbeansCommon.health -
+			BeetlejhostRare.secondary.damage -
+			(BeetlejhostRare.secondary.damage - 10),
+	)
+
+	yield* endTurn(game)
+	yield* endTurn(game)
+
+	yield* attack(game, 'secondary')
+	yield* pick(
+		game,
+		query.slot.currentPlayer,
+		query.slot.hermit,
+		query.slot.rowIndex(2),
+	)
+	yield* finishModalRequest(game, {pick: 'secondary'})
+
+	expect(game.opponentPlayer.activeRow?.health).toBe(
+		SmallishbeansCommon.health -
+			BeetlejhostRare.secondary.damage -
+			(BeetlejhostRare.secondary.damage - 10) -
+			SmallishbeansCommon.secondary.damage,
+	)
+}
+
 describe('Test Zombie Cleo', () => {
 	test('Test Zombie Cleo Primary Does Not Crash Server', () => {
 		testGame(
@@ -171,6 +229,17 @@ describe('Test Zombie Cleo', () => {
 				playerTwoDeck: [ZombieCleoRare, ZombieCleoRare, BoomerBdubsRare],
 			},
 			{startWithAllCards: true, noItemRequirements: true, forceCoinFlip: true},
+		)
+	})
+
+	test('Test using Puppetry on Jopacity', () => {
+		testGame(
+			{
+				saga: testPuppetingJopacity,
+				playerOneDeck: [SmallishbeansCommon],
+				playerTwoDeck: [ZombieCleoRare, BeetlejhostRare, SmallishbeansCommon],
+			},
+			{startWithAllCards: true, noItemRequirements: true},
 		)
 	})
 })


### PR DESCRIPTION
- Fixes Jopacity dealing too much damage when opponent's Invisibility flips tails
- Fixes Puppetry/Role Play continuing to deal reduced damage until a primary is used after using Jopacity