### PR TITLE
Fix potential bug with new rare skizz test

### DIFF
--- a/tests/game/skizzleman-rare.test.ts
+++ b/tests/game/skizzleman-rare.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, test} from '@jest/globals'
 import Anvil from 'common/cards/alter-egos/single-use/anvil'
-import IronArmor from 'common/cards/default/effects/iron-armor'
+import GoldArmor from 'common/cards/default/effects/gold-armor'
 import Thorns from 'common/cards/default/effects/thorns'
 import EthosLabCommon from 'common/cards/default/hermits/ethoslab-common'
 import SkizzlemanRare from 'common/cards/season-x/hermits/skizzleman-rare'
@@ -83,12 +83,12 @@ describe('Test Skizzleman Rare', () => {
 	test("Gaslight doesn't trigger if the hermit takes no damage", () => {
 		testGame(
 			{
-				playerOneDeck: [EthosLabCommon, EthosLabCommon, IronArmor],
+				playerOneDeck: [EthosLabCommon, EthosLabCommon, GoldArmor],
 				playerTwoDeck: [SkizzlemanRare, Anvil],
 				saga: function* (game) {
 					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
 					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 1)
-					yield* playCardFromHand(game, IronArmor, 'attach', 1)
+					yield* playCardFromHand(game, GoldArmor, 'attach', 1)
 					yield* endTurn(game)
 
 					yield* playCardFromHand(game, SkizzlemanRare, 'hermit', 0)


### PR DESCRIPTION
I was worried that my new test could potentially return a false negative if the iron armor was bugged and blocked the whole 20 damage from gaslight, even after the ten from anvil. Gold armor should never do that if there isn't some very obvious bug.