### PR TITLE
Fix minor issues with the deck builder

### DIFF
--- a/client/src/app/deck/deck-select.tsx
+++ b/client/src/app/deck/deck-select.tsx
@@ -105,11 +105,15 @@ function SelectDeck({
 	const [showValidateDeckModal, setShowValidateDeckModal] =
 		useState<boolean>(false)
 	const [showOverwriteModal, setShowOverwriteModal] = useState<boolean>(false)
-	const [tagFilter, setTagFilter] = useState<Tag>({
-		name: 'No Filter',
-		color: '#ffffff',
-		key: '0',
-	})
+	const [tagFilter, setTagFilter] = useState<Tag>(
+		settings.lastSelectedTag
+			? keysToTags([settings.lastSelectedTag])[0]
+			: {
+					name: 'No Filter',
+					color: '#ffffff',
+					key: '0',
+				},
+	)
 
 	const tagsDropdownOptions = [
 		{name: 'No Filter', color: '#ffffff'},
@@ -283,9 +287,16 @@ function SelectDeck({
 							color: '#ffffff',
 							key: '0',
 						})
+						dispatch({
+							type: localMessages.SETTINGS_SET,
+							setting: {
+								key: 'lastSelectedTag',
+								value: null,
+							},
+						})
 						return
 					}
-					const parsedOption = JSON.parse(option)
+					const parsedOption = JSON.parse(option) as Tag
 					console.log(parsedOption)
 					setFilteredDecks(
 						sortedDecks.filter(
@@ -299,6 +310,13 @@ function SelectDeck({
 						),
 					)
 					setTagFilter(parsedOption)
+					dispatch({
+						type: localMessages.SETTINGS_SET,
+						setting: {
+							key: 'lastSelectedTag',
+							value: parsedOption.key,
+						},
+					})
 				}}
 			/>
 			<div

--- a/client/src/app/deck/deck.module.scss
+++ b/client/src/app/deck/deck.module.scss
@@ -646,3 +646,9 @@
 		width: 100%;
 	}
 }
+
+@media (max-width: 440px) {
+	.mobileDeckPreview {
+		width: 30%;
+	}
+}

--- a/client/src/app/deck/layout/deck-layout.module.scss
+++ b/client/src/app/deck/layout/deck-layout.module.scss
@@ -118,6 +118,7 @@ header {
 		height: auto;
 		width: auto;
 		border: 2px black solid;
+		height: 100%;
 	}
 
 	.body {

--- a/client/src/app/deck/layout/deck-main.module.scss
+++ b/client/src/app/deck/layout/deck-main.module.scss
@@ -45,10 +45,12 @@
 	.mobile {
 		display: inherit;
 		visibility: inherit;
+		height: 100%;
 	}
 
 	.deck {
 		border: none;
+		height: 100%;
 	}
 
 	.desktop {

--- a/client/src/components/card/mobile-card-component.tsx
+++ b/client/src/components/card/mobile-card-component.tsx
@@ -54,10 +54,20 @@ const MobileCardComponent = (props: CardReactProps) => {
 							/>
 						)}
 						{cards[0].props.category === 'item' && (
-							<img
-								className={css.headInList}
-								src={`/images/types/type-${cards[0].props.id.split('_')[1]}.png`}
-							/>
+							<div>
+								<img
+									className={css.headInList}
+									src={`/images/types/type-${cards[0].props.id.split('_')[1]}.png`}
+								/>
+								{small && (
+									<div
+										className={classNames(
+											css.rarityStar,
+											css[cards[0].props.rarity],
+										)}
+									></div>
+								)}
+							</div>
 						)}
 
 						{!small && (

--- a/client/src/logic/local-settings/local-settings-reducer.ts
+++ b/client/src/logic/local-settings/local-settings-reducer.ts
@@ -18,6 +18,7 @@ export type LocalSettings = {
 	gameSide: string
 	minecraftName: string
 	deckSortingMethod: 'Alphabetical' | 'First Tag'
+	lastSelectedTag: string | null
 }
 
 export type LocalSetting = {
@@ -42,6 +43,7 @@ const defaultSettings: LocalSettings = {
 	gameSide: 'Left',
 	minecraftName: '',
 	deckSortingMethod: 'Alphabetical',
+	lastSelectedTag: null,
 }
 
 const getSettings = (): LocalSettings => {


### PR DESCRIPTION
- Tag filter is now persistent, even after leaving the page or reloading
- The deck builder now takes up the full screen on mobile in all circumstances
- Double items now show differently than single items
- Space is more efficiently used when only one column of cards can be shown.