### PR TITLE
Add Test To Prevent Ghost Queues

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -29,8 +29,10 @@ export default defineConfig({
 		baseURL: 'http://localhost:9000',
 
 		/* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-		trace: 'on-first-retry',
+		trace: process.env.CI ? 'on-first-retry' : 'on',
 	},
+
+	timeout: 15000,
 
 	/* Configure projects for major browsers */
 	projects: [
@@ -66,7 +68,7 @@ export default defineConfig({
 
 	/* Run your local dev server before starting the tests */
 	webServer: {
-		command: 'npm run start',
+		command: 'npm run server',
 		url: 'http://localhost:9000/',
 		reuseExistingServer: true,
 	},

--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -1,6 +1,7 @@
 import {Express} from 'express'
 import {cards, deckCost, getCardsInDeck} from './cards'
 import {requestUrlRoot} from './utils'
+import root from 'serverRoot'
 
 export function addApi(app: Express) {
 	app.get('/api/cards', (req, res) => {
@@ -14,4 +15,10 @@ export function addApi(app: Express) {
 	app.post('/api/deck/cost', (req, res) => {
 		res.send(deckCost(req.body))
 	})
+
+	if (process.env.NODE_ENV !== 'production') {
+		app.get('/debug/root-state/queue', (_req, res) => {
+			res.send(root.queue)
+		})
+	}
 }

--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -1,7 +1,7 @@
 import {Express} from 'express'
+import root from 'serverRoot'
 import {cards, deckCost, getCardsInDeck} from './cards'
 import {requestUrlRoot} from './utils'
-import root from 'serverRoot'
 
 export function addApi(app: Express) {
 	app.get('/api/cards', (req, res) => {

--- a/tests/e2e/reload.spec.ts
+++ b/tests/e2e/reload.spec.ts
@@ -34,7 +34,9 @@ test('player does not stay in queue after reloading the page', async ({
 	})
 
 	let playerId = page.evaluate(() => global.getState().session.playerId)
-	await page.getByText(/Public Game/).click()
+	// Close the update notification if it exists
+	await page.getByText('Close').click()
+	await page.getByText('Public Game').click()
 
 	let queue = await (
 		await fetch('http://localhost:9000/debug/root-state/queue')

--- a/tests/e2e/reload.spec.ts
+++ b/tests/e2e/reload.spec.ts
@@ -28,24 +28,28 @@ test('player does not stay in queue after reloading the page', async ({
 	await page.getByPlaceholder(' ').fill('Test Player')
 	await page.getByPlaceholder(' ').press('Enter')
 
-	await page.waitForFunction(() => global.getState().session.connected)
+	await page.waitForFunction(() => {
+		console.log(global.getState().session.connected)
+		return global.getState().session.connected
+	})
 
 	let playerId = page.evaluate(() => global.getState().session.playerId)
 	await page.getByText('Public Game').click()
 
-	let game = await (
+	let queue= await (
 		await fetch('http://localhost:9000/debug/root-state/queue')
 	).json()
 
-	expect(game).toContain(playerId)
+	expect(queue).toContain(playerId)
 
 	await page.reload()
 	await page.waitForFunction(() => global.getState().session.connected)
 
 	// We should be automatically removed from the queue.
-	game = await (
+	queue= await (
 		await fetch('http://localhost:9000/debug/root-state/queue')
 	).json()
-	expect(game).not.toContain(playerId)
+	expect(queue).not.toContain(playerId)
+	expect(queue).not.toContain(playerId)
 	expect(page.evaluate(() => global.getState().matching.status)).toBe(null)
 })

--- a/tests/e2e/reload.spec.ts
+++ b/tests/e2e/reload.spec.ts
@@ -53,5 +53,7 @@ test('player does not stay in queue after reloading the page', async ({
 	).json()
 	expect(queue).not.toContain(playerId)
 	expect(queue).not.toContain(playerId)
-	expect(await page.evaluate(() => global.getState().matchmaking.status)).toBe(null)
+	expect(await page.evaluate(() => global.getState().matchmaking.status)).toBe(
+		null,
+	)
 })

--- a/tests/e2e/reload.spec.ts
+++ b/tests/e2e/reload.spec.ts
@@ -53,5 +53,5 @@ test('player does not stay in queue after reloading the page', async ({
 	).json()
 	expect(queue).not.toContain(playerId)
 	expect(queue).not.toContain(playerId)
-	expect(page.evaluate(() => global.getState().matching.status)).toBe(null)
+	expect(await page.evaluate(() => global.getState().matching.status)).toBe(null)
 })

--- a/tests/e2e/reload.spec.ts
+++ b/tests/e2e/reload.spec.ts
@@ -34,9 +34,9 @@ test('player does not stay in queue after reloading the page', async ({
 	})
 
 	let playerId = page.evaluate(() => global.getState().session.playerId)
-	await page.getByText('Public Game').click()
+	await page.getByText(/Public Game/).click()
 
-	let queue= await (
+	let queue = await (
 		await fetch('http://localhost:9000/debug/root-state/queue')
 	).json()
 
@@ -46,7 +46,7 @@ test('player does not stay in queue after reloading the page', async ({
 	await page.waitForFunction(() => global.getState().session.connected)
 
 	// We should be automatically removed from the queue.
-	queue= await (
+	queue = await (
 		await fetch('http://localhost:9000/debug/root-state/queue')
 	).json()
 	expect(queue).not.toContain(playerId)

--- a/tests/e2e/reload.spec.ts
+++ b/tests/e2e/reload.spec.ts
@@ -53,5 +53,5 @@ test('player does not stay in queue after reloading the page', async ({
 	).json()
 	expect(queue).not.toContain(playerId)
 	expect(queue).not.toContain(playerId)
-	expect(await page.evaluate(() => global.getState().matching.status)).toBe(null)
+	expect(await page.evaluate(() => global.getState().matchmaking.status)).toBe(null)
 })

--- a/tests/e2e/reload.spec.ts
+++ b/tests/e2e/reload.spec.ts
@@ -33,7 +33,7 @@ test('player does not stay in queue after reloading the page', async ({
 		return global.getState().session.connected
 	})
 
-	let playerId = page.evaluate(() => global.getState().session.playerId)
+	let playerId = await page.evaluate(() => global.getState().session.playerId)
 	// Close the update notification if it exists
 	await page.getByText('Close').click()
 	await page.getByText('Public Game').click()


### PR DESCRIPTION
Adds a test to confirm that players are removed from the queue when they leave or reload the site.