### PR TITLE
Consolidate hooks

### DIFF
--- a/common/cards/alter-egos-ii/hermits/boomerbdubs-rare.ts
+++ b/common/cards/alter-egos-ii/hermits/boomerbdubs-rare.ts
@@ -155,9 +155,10 @@ const BoomerBdubsRare: Hermit = {
 		)
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.MODIFY_DAMAGE,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 				if (flippedTails === true) {

--- a/common/cards/alter-egos-ii/hermits/fiveampearl-rare.ts
+++ b/common/cards/alter-egos-ii/hermits/fiveampearl-rare.ts
@@ -39,9 +39,10 @@ const FiveAMPearlRare: Hermit = {
 		const {player} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.MODIFY_DAMAGE,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 

--- a/common/cards/alter-egos-ii/hermits/iskallman-rare.ts
+++ b/common/cards/alter-egos-ii/hermits/iskallman-rare.ts
@@ -113,9 +113,10 @@ const IskallmanRare: Hermit = {
 
 		// Heals the afk hermit *before* we actually do damage
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.HERMIT_APPLY_ATTACK,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (
 					!attack.isAttacker(component.entity) ||
 					attack.type !== 'secondary' ||

--- a/common/cards/alter-egos-ii/hermits/overseer-rare.ts
+++ b/common/cards/alter-egos-ii/hermits/overseer-rare.ts
@@ -29,16 +29,17 @@ const OverseerRare: Hermit = {
 		power: 'Attack damage doubles versus Farm types.',
 	},
 	onAttach(
-		_game: GameModel,
+		game: GameModel,
 		component: CardComponent,
 		observer: ObserverComponent,
 	) {
 		const {player} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.MODIFY_DAMAGE,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 

--- a/common/cards/alter-egos-iii/hermits/architectfalse-rare.ts
+++ b/common/cards/alter-egos-iii/hermits/architectfalse-rare.ts
@@ -46,9 +46,10 @@ const ArchitectFalseRare: Hermit = {
 		const {player} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.HERMIT_APPLY_ATTACK,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (
 					!attack.isAttacker(component.entity) ||
 					attack.type !== 'secondary' ||

--- a/common/cards/alter-egos-iii/hermits/beetlejhost-rare.ts
+++ b/common/cards/alter-egos-iii/hermits/beetlejhost-rare.ts
@@ -54,9 +54,10 @@ const BeetlejhostRare: Hermit = {
 		const {player} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.MODIFY_DAMAGE,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				const chromaKeyed = findChromaKeyed(game, component)
 
 				if (
@@ -83,9 +84,10 @@ const BeetlejhostRare: Hermit = {
 		)
 
 		observer.subscribeWithPriority(
-			player.hooks.afterAttack,
+			game.globalHooks.afterAttack,
 			afterAttack.UPDATE_POST_ATTACK_STATE,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 

--- a/common/cards/alter-egos-iii/hermits/dwarfimpulse-rare.ts
+++ b/common/cards/alter-egos-iii/hermits/dwarfimpulse-rare.ts
@@ -115,18 +115,20 @@ const DwarfImpulseRare: Hermit = {
 		)
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.HERMIT_SET_TARGET,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!goldenAxeRedirect || !attack.isAttacker(goldenAxeEntity)) return
 				attack.setTarget(component.entity, goldenAxeRedirect)
 			},
 		)
 
 		observer.subscribeWithPriority(
-			player.hooks.afterAttack,
+			game.globalHooks.afterAttack,
 			afterAttack.UPDATE_POST_ATTACK_STATE,
-			(_attack) => {
+			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				goldenAxeRedirect = null
 				goldenAxeEntity = null
 			},

--- a/common/cards/alter-egos-iii/hermits/eviljevin-rare.ts
+++ b/common/cards/alter-egos-iii/hermits/eviljevin-rare.ts
@@ -39,9 +39,10 @@ const EvilJevinRare: Hermit = {
 		const {player} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.HERMIT_APPLY_ATTACK,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 

--- a/common/cards/alter-egos-iii/hermits/frenchralis-rare.ts
+++ b/common/cards/alter-egos-iii/hermits/frenchralis-rare.ts
@@ -29,16 +29,17 @@ const FrenchralisRare: Hermit = {
 		power: 'If you have one life remaining, this attack does double damage.',
 	},
 	onAttach(
-		_game: GameModel,
+		game: GameModel,
 		component: CardComponent,
 		observer: ObserverComponent,
 	) {
 		const {player} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.MODIFY_DAMAGE,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 

--- a/common/cards/alter-egos-iii/hermits/horseheadhypno-rare.ts
+++ b/common/cards/alter-egos-iii/hermits/horseheadhypno-rare.ts
@@ -39,9 +39,10 @@ const HorseHeadHypnoRare: Hermit = {
 		const {player} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.HERMIT_APPLY_ATTACK,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 

--- a/common/cards/alter-egos-iii/hermits/kingjoel-rare.ts
+++ b/common/cards/alter-egos-iii/hermits/kingjoel-rare.ts
@@ -60,9 +60,10 @@ const KingJoelRare: Hermit = {
 		let firstPickedCard: CardComponent | null = null
 
 		observer.subscribeWithPriority(
-			player.hooks.afterAttack,
+			game.globalHooks.afterAttack,
 			afterAttack.HERMIT_ATTACK_REQUESTS,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 

--- a/common/cards/alter-egos-iii/hermits/originalxb-rare.ts
+++ b/common/cards/alter-egos-iii/hermits/originalxb-rare.ts
@@ -42,9 +42,10 @@ const OriginalXBRare: Hermit = {
 		const {player, opponentPlayer} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.HERMIT_APPLY_ATTACK,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 

--- a/common/cards/alter-egos-iii/hermits/poepoeskizz-rare.ts
+++ b/common/cards/alter-egos-iii/hermits/poepoeskizz-rare.ts
@@ -43,9 +43,10 @@ const PoePoeSkizzRare: Hermit = {
 		const {player} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.afterAttack,
+			game.globalHooks.afterAttack,
 			afterAttack.HERMIT_ATTACK_REQUESTS,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 				if (!component.slot.inRow()) return

--- a/common/cards/alter-egos-iii/hermits/poultryman-rare.ts
+++ b/common/cards/alter-egos-iii/hermits/poultryman-rare.ts
@@ -40,9 +40,10 @@ const PoultryManRare: Hermit = {
 		const {player} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.afterAttack,
+			game.globalHooks.afterAttack,
 			afterAttack.HERMIT_REMOVE_SINGLE_USE,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 

--- a/common/cards/alter-egos-iii/hermits/princessgem-rare.ts
+++ b/common/cards/alter-egos-iii/hermits/princessgem-rare.ts
@@ -50,9 +50,10 @@ const PrincessGemRare: Hermit = {
 		const {player} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.afterAttack,
+			game.globalHooks.afterAttack,
 			afterAttack.HERMIT_ATTACK_REQUESTS,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 

--- a/common/cards/alter-egos-iii/hermits/shadeee-rare.ts
+++ b/common/cards/alter-egos-iii/hermits/shadeee-rare.ts
@@ -38,9 +38,10 @@ const ShadeEERare: Hermit = {
 		const {player, opponentPlayer} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.MODIFY_DAMAGE,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 

--- a/common/cards/alter-egos-iii/hermits/spookystress-rare.ts
+++ b/common/cards/alter-egos-iii/hermits/spookystress-rare.ts
@@ -45,9 +45,10 @@ const SpookyStressRare: Hermit = {
 		const {player} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.ADD_ATTACK,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 

--- a/common/cards/alter-egos-iii/hermits/steampunktango-rare.ts
+++ b/common/cards/alter-egos-iii/hermits/steampunktango-rare.ts
@@ -39,9 +39,10 @@ const SteampunkTangoRare: Hermit = {
 		const {player} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.MODIFY_DAMAGE,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 

--- a/common/cards/alter-egos-iii/hermits/wormman-rare.ts
+++ b/common/cards/alter-egos-iii/hermits/wormman-rare.ts
@@ -42,9 +42,10 @@ const WormManRare: Hermit = {
 		const {player} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.afterAttack,
+			game.globalHooks.afterAttack,
 			afterAttack.UPDATE_POST_ATTACK_STATE,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 

--- a/common/cards/alter-egos-iii/hermits/wormman-rare.ts
+++ b/common/cards/alter-egos-iii/hermits/wormman-rare.ts
@@ -69,7 +69,7 @@ const WormManRare: Hermit = {
 						(_oldActiveHermit, newActiveHermit) => {
 							if (newActiveHermit.entity !== attachedComponent.entity) return
 							attachedComponent.turnedOver = false
-							newObserver.unsubscribe(player.hooks.freezeSlots)
+							newObserver.unsubscribe(game.globalHooks.freezeSlots)
 						},
 					)
 

--- a/common/cards/alter-egos/effects/armor-stand.ts
+++ b/common/cards/alter-egos/effects/armor-stand.ts
@@ -29,10 +29,10 @@ const ArmorStand: Attach & HasHealth = {
 		observer: ObserverComponent,
 	) {
 		const {player} = component
-		observer.subscribe(player.hooks.freezeSlots, () => {
+		observer.subscribe(game.globalHooks.freezeSlots, () => {
 			if (!component.slot?.onBoard()) return query.nothing
 			return query.every(
-				query.slot.player(component.player.entity),
+				query.slot.player(player.entity),
 				query.slot.rowIs(component.slot.row?.entity),
 			)
 		})

--- a/common/cards/alter-egos/effects/chainmail-armor.ts
+++ b/common/cards/alter-egos/effects/chainmail-armor.ts
@@ -1,6 +1,6 @@
 import {CardComponent, ObserverComponent} from '../../../components'
 import {GameModel} from '../../../models/game-model'
-import {beforeDefence} from '../../../types/priorities'
+import {beforeAttack} from '../../../types/priorities'
 import {attach} from '../../base/defaults'
 import {Attach} from '../../base/types'
 
@@ -15,15 +15,13 @@ const ChainmailArmor: Attach = {
 	description:
 		'Prevents any damage from effect cards and any damage redirected by effect cards to the Hermit this card is attached to.',
 	onAttach(
-		_game: GameModel,
+		game: GameModel,
 		component: CardComponent,
 		observer: ObserverComponent,
 	) {
-		const {player} = component
-
 		observer.subscribeWithPriority(
-			player.hooks.beforeDefence,
-			beforeDefence.EFFECT_BLOCK_DAMAGE,
+			game.globalHooks.beforeAttack,
+			beforeAttack.EFFECT_BLOCK_DAMAGE,
 			(attack) => {
 				if (!attack.isTargeting(component)) {
 					return

--- a/common/cards/alter-egos/effects/command-block.ts
+++ b/common/cards/alter-egos/effects/command-block.ts
@@ -15,7 +15,7 @@ const CommandBlock: Attach = {
 	description:
 		'The Hermit this card is attached to can use items of any type. Once attached, this card can not be removed from this Hermit.',
 	onAttach(
-		_game: GameModel,
+		game: GameModel,
 		component: CardComponent,
 		observer: ObserverComponent,
 	) {
@@ -30,7 +30,7 @@ const CommandBlock: Attach = {
 			return availableEnergy.map(() => 'any')
 		})
 
-		observer.subscribe(player.hooks.freezeSlots, () => {
+		observer.subscribe(game.globalHooks.freezeSlots, () => {
 			if (!component.slot.inRow()) return query.nothing
 			return query.every(
 				query.slot.player(player.entity),

--- a/common/cards/alter-egos/effects/lightning-rod.ts
+++ b/common/cards/alter-egos/effects/lightning-rod.ts
@@ -41,9 +41,10 @@ const LightningRod: Attach = {
 		let used = false
 
 		observer.subscribeWithPriority(
-			opponentPlayer.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.LIGHTNING_ROD_REDIRECT,
 			(attack) => {
+				if (attack.player.entity !== opponentPlayer.entity) return
 				if (!component.slot?.onBoard() || !component.slot.row) return
 				if (attack.type === 'status-effect' || attack.isBacklash) return
 				if (game.currentPlayer.entity !== opponentPlayer.entity) return

--- a/common/cards/alter-egos/effects/thorns_ii.ts
+++ b/common/cards/alter-egos/effects/thorns_ii.ts
@@ -1,7 +1,7 @@
 import {CardComponent, ObserverComponent} from '../../../components'
 import query from '../../../components/query'
 import {GameModel} from '../../../models/game-model'
-import {beforeDefence, onTurnEnd} from '../../../types/priorities'
+import {beforeAttack, onTurnEnd} from '../../../types/priorities'
 import {attach} from '../../base/defaults'
 import {Attach} from '../../base/types'
 import DiamondArmor from '../../default/effects/diamond-armor'
@@ -24,12 +24,12 @@ const ThornsII: Attach = {
 		component: CardComponent,
 		observer: ObserverComponent,
 	) {
-		const {player, opponentPlayer} = component
+		const {opponentPlayer} = component
 		let hasTriggered = false
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeDefence,
-			beforeDefence.EFFECT_CREATE_BACKLASH,
+			game.globalHooks.beforeAttack,
+			beforeAttack.EFFECT_CREATE_BACKLASH,
 			(attack) => {
 				// If we have already triggered once this turn do not do so again
 				if (hasTriggered) return

--- a/common/cards/alter-egos/effects/thorns_ii.ts
+++ b/common/cards/alter-egos/effects/thorns_ii.ts
@@ -29,7 +29,7 @@ const ThornsII: Attach = {
 
 		observer.subscribeWithPriority(
 			game.globalHooks.beforeAttack,
-			beforeAttack.EFFECT_CREATE_BACKLASH,
+			beforeAttack.REACT_TO_DAMAGE,
 			(attack) => {
 				// If we have already triggered once this turn do not do so again
 				if (hasTriggered) return

--- a/common/cards/alter-egos/effects/thorns_iii.ts
+++ b/common/cards/alter-egos/effects/thorns_iii.ts
@@ -29,7 +29,7 @@ const ThornsIII: Attach = {
 
 		observer.subscribeWithPriority(
 			game.globalHooks.beforeAttack,
-			beforeAttack.EFFECT_CREATE_BACKLASH,
+			beforeAttack.REACT_TO_DAMAGE,
 			(attack) => {
 				// If we have already triggered once this turn do not do so again
 				if (hasTriggered) return

--- a/common/cards/alter-egos/effects/thorns_iii.ts
+++ b/common/cards/alter-egos/effects/thorns_iii.ts
@@ -1,7 +1,7 @@
 import {CardComponent, ObserverComponent} from '../../../components'
 import query from '../../../components/query'
 import {GameModel} from '../../../models/game-model'
-import {beforeDefence, onTurnEnd} from '../../../types/priorities'
+import {beforeAttack, onTurnEnd} from '../../../types/priorities'
 import {attach} from '../../base/defaults'
 import {Attach} from '../../base/types'
 import DiamondArmor from '../../default/effects/diamond-armor'
@@ -24,12 +24,12 @@ const ThornsIII: Attach = {
 		component: CardComponent,
 		observer: ObserverComponent,
 	) {
-		const {player, opponentPlayer} = component
+		const {opponentPlayer} = component
 		let hasTriggered = false
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeDefence,
-			beforeDefence.EFFECT_CREATE_BACKLASH,
+			game.globalHooks.beforeAttack,
+			beforeAttack.EFFECT_CREATE_BACKLASH,
 			(attack) => {
 				// If we have already triggered once this turn do not do so again
 				if (hasTriggered) return

--- a/common/cards/alter-egos/effects/turtle-shell.ts
+++ b/common/cards/alter-egos/effects/turtle-shell.ts
@@ -9,7 +9,7 @@ import query from '../../../components/query'
 import {PlayerEntity} from '../../../entities'
 import {GameModel, GameValue} from '../../../models/game-model'
 import LooseShellEffect from '../../../status-effects/loose-shell'
-import {beforeDefence, onTurnEnd} from '../../../types/priorities'
+import {beforeAttack, onTurnEnd} from '../../../types/priorities'
 import {attach} from '../../base/defaults'
 import {Attach} from '../../base/types'
 
@@ -236,8 +236,8 @@ const TurtleShell: Attach = {
 		})
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeDefence,
-			beforeDefence.EFFECT_BLOCK_DAMAGE,
+			game.globalHooks.beforeAttack,
+			beforeAttack.EFFECT_BLOCK_DAMAGE,
 			(attack) => {
 				if (!component.slot.inRow()) return
 				if (state === 'inactive' || game.currentPlayerEntity === player.entity)

--- a/common/cards/alter-egos/hermits/evilxisuma_rare.ts
+++ b/common/cards/alter-egos/hermits/evilxisuma_rare.ts
@@ -54,9 +54,10 @@ const EvilXisumaRare: Hermit = {
 		const {player, opponentPlayer} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.afterAttack,
+			game.globalHooks.afterAttack,
 			afterAttack.HERMIT_ATTACK_REQUESTS,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 

--- a/common/cards/alter-egos/hermits/goatfather-rare.ts
+++ b/common/cards/alter-egos/hermits/goatfather-rare.ts
@@ -42,9 +42,10 @@ const GoatfatherRare: Hermit = {
 	): void {
 		const {player, opponentPlayer} = component
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.ADD_ATTACK,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 

--- a/common/cards/alter-egos/hermits/helsknight-rare.ts
+++ b/common/cards/alter-egos/hermits/helsknight-rare.ts
@@ -42,9 +42,10 @@ const HelsknightRare: Hermit = {
 		const {player, opponentPlayer} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.HERMIT_APPLY_ATTACK,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 				game.components

--- a/common/cards/alter-egos/hermits/hotguy-rare.ts
+++ b/common/cards/alter-egos/hermits/hotguy-rare.ts
@@ -30,7 +30,7 @@ const HotguyRare: Hermit = {
 		power: 'When used with a Bow effect card, Bow damage doubles.',
 	},
 	onAttach(
-		_game: GameModel,
+		game: GameModel,
 		component: CardComponent,
 		observer: ObserverComponent,
 	) {
@@ -39,18 +39,20 @@ const HotguyRare: Hermit = {
 		let usingSecondaryAttack = false
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.HERMIT_APPLY_ATTACK,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity)) return
 				usingSecondaryAttack = attack.type === 'secondary'
 			},
 		)
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.MODIFY_DAMAGE,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!usingSecondaryAttack) return
 				if (
 					attack.attacker instanceof CardComponent &&
@@ -62,9 +64,10 @@ const HotguyRare: Hermit = {
 		)
 
 		observer.subscribeWithPriority(
-			player.hooks.afterAttack,
+			game.globalHooks.afterAttack,
 			afterAttack.UPDATE_POST_ATTACK_STATE,
-			(_attack) => {
+			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				usingSecondaryAttack = false
 			},
 		)

--- a/common/cards/alter-egos/hermits/humancleo-rare.ts
+++ b/common/cards/alter-egos/hermits/humancleo-rare.ts
@@ -43,9 +43,10 @@ const HumanCleoRare: Hermit = {
 		const {player, opponentPlayer} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.HERMIT_APPLY_ATTACK,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 

--- a/common/cards/alter-egos/hermits/jingler-rare.ts
+++ b/common/cards/alter-egos/hermits/jingler-rare.ts
@@ -39,9 +39,10 @@ const JinglerRare: Hermit = {
 		const {player, opponentPlayer} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.afterAttack,
+			game.globalHooks.afterAttack,
 			afterAttack.HERMIT_ATTACK_REQUESTS,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 

--- a/common/cards/alter-egos/hermits/llamadad-rare.ts
+++ b/common/cards/alter-egos/hermits/llamadad-rare.ts
@@ -30,16 +30,17 @@ const LlamadadRare: Hermit = {
 		power: 'Flip a coin.\nIf heads, do an additional 40hp damage.',
 	},
 	onAttach(
-		_game: GameModel,
+		game: GameModel,
 		component: CardComponent,
 		observer: ObserverComponent,
 	) {
 		const {player} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.MODIFY_DAMAGE,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 

--- a/common/cards/alter-egos/hermits/potatoboy-rare.ts
+++ b/common/cards/alter-egos/hermits/potatoboy-rare.ts
@@ -41,9 +41,10 @@ const PotatoBoyRare: Hermit = {
 		const {player} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.HERMIT_APPLY_ATTACK,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'primary')
 					return
 				game.components

--- a/common/cards/alter-egos/hermits/renbob-rare.ts
+++ b/common/cards/alter-egos/hermits/renbob-rare.ts
@@ -42,9 +42,10 @@ const RenbobRare: Hermit = {
 		const {player} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.HERMIT_SET_TARGET,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 				if (!component.slot.inRow()) return

--- a/common/cards/alter-egos/single-use/anvil.ts
+++ b/common/cards/alter-egos/single-use/anvil.ts
@@ -92,12 +92,13 @@ const Anvil: SingleUse = {
 		})
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.APPLY_SINGLE_USE_ATTACK,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (attack.isAttacker(component.entity)) {
 					applySingleUse(game, component.slot)
-					observer.unsubscribe(player.hooks.beforeAttack)
+					observer.unsubscribe(game.globalHooks.beforeAttack)
 				}
 			},
 		)

--- a/common/cards/alter-egos/single-use/egg.ts
+++ b/common/cards/alter-egos/single-use/egg.ts
@@ -42,16 +42,17 @@ const Egg: SingleUse = {
 		const {player, opponentPlayer} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.afterAttack,
+			game.globalHooks.afterAttack,
 			afterAttack.EFFECT_POST_ATTACK_REQUESTS,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				const activeHermit = player.getActiveHermit()
 				if (!attack.isAttacker(activeHermit?.entity)) return
 
 				applySingleUse(game)
 
 				// Do not apply single use more than once
-				observer.unsubscribe(player.hooks.afterAttack)
+				observer.unsubscribe(game.globalHooks.afterAttack)
 
 				if (!game.components.exists(SlotComponent, pickCondition)) return
 

--- a/common/cards/alter-egos/single-use/trident.ts
+++ b/common/cards/alter-egos/single-use/trident.ts
@@ -42,9 +42,10 @@ const Trident: SingleUse = {
 		})
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.APPLY_SINGLE_USE_ATTACK,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity)) return
 
 				coinflipResult = flipCoin(player, component)[0]

--- a/common/cards/default/effects/diamond-armor.ts
+++ b/common/cards/default/effects/diamond-armor.ts
@@ -1,6 +1,6 @@
 import {CardComponent, ObserverComponent} from '../../../components'
 import {GameModel} from '../../../models/game-model'
-import {beforeDefence} from '../../../types/priorities'
+import {beforeAttack} from '../../../types/priorities'
 import {attach} from '../../base/defaults'
 import {Attach} from '../../base/types'
 
@@ -15,7 +15,7 @@ const DiamondArmor: Attach = {
 	description:
 		'When the Hermit this card is attached to takes damage, that damage is reduced by up to 30hp each turn.',
 	onAttach(
-		_game: GameModel,
+		game: GameModel,
 		component: CardComponent,
 		observer: ObserverComponent,
 	) {
@@ -24,8 +24,8 @@ const DiamondArmor: Attach = {
 		let damageBlocked = 0
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeDefence,
-			beforeDefence.EFFECT_REDUCE_DAMAGE,
+			game.globalHooks.beforeAttack,
+			beforeAttack.EFFECT_REDUCE_DAMAGE,
 			(attack) => {
 				if (!attack.isTargeting(component) || attack.isType('status-effect'))
 					return

--- a/common/cards/default/effects/gold-armor.ts
+++ b/common/cards/default/effects/gold-armor.ts
@@ -1,6 +1,6 @@
 import {CardComponent, ObserverComponent} from '../../../components'
 import {GameModel} from '../../../models/game-model'
-import {beforeDefence} from '../../../types/priorities'
+import {beforeAttack} from '../../../types/priorities'
 import {attach} from '../../base/defaults'
 import {Attach} from '../../base/types'
 
@@ -15,7 +15,7 @@ const GoldArmor: Attach = {
 	description:
 		'When the Hermit this card is attached to takes damage, that damage is reduced by up to 10hp each turn.',
 	onAttach(
-		_game: GameModel,
+		game: GameModel,
 		component: CardComponent,
 		observer: ObserverComponent,
 	) {
@@ -24,8 +24,8 @@ const GoldArmor: Attach = {
 		let damageBlocked = 0
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeDefence,
-			beforeDefence.EFFECT_REDUCE_DAMAGE,
+			game.globalHooks.beforeAttack,
+			beforeAttack.EFFECT_REDUCE_DAMAGE,
 			(attack) => {
 				if (!attack.isTargeting(component) || attack.isType('status-effect'))
 					return

--- a/common/cards/default/effects/iron-armor.ts
+++ b/common/cards/default/effects/iron-armor.ts
@@ -1,6 +1,6 @@
 import {CardComponent, ObserverComponent} from '../../../components'
 import {GameModel} from '../../../models/game-model'
-import {beforeDefence} from '../../../types/priorities'
+import {beforeAttack} from '../../../types/priorities'
 import {attach} from '../../base/defaults'
 import {Attach} from '../../base/types'
 
@@ -15,7 +15,7 @@ const IronArmor: Attach = {
 	description:
 		'When the Hermit this card is attached to takes damage, that damage is reduced by up to 20hp each turn.',
 	onAttach(
-		_game: GameModel,
+		game: GameModel,
 		component: CardComponent,
 		observer: ObserverComponent,
 	) {
@@ -24,8 +24,8 @@ const IronArmor: Attach = {
 		let damageBlocked = 0
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeDefence,
-			beforeDefence.EFFECT_REDUCE_DAMAGE,
+			game.globalHooks.beforeAttack,
+			beforeAttack.EFFECT_REDUCE_DAMAGE,
 			(attack) => {
 				if (!attack.isTargeting(component) || attack.isType('status-effect'))
 					return

--- a/common/cards/default/effects/loyalty.ts
+++ b/common/cards/default/effects/loyalty.ts
@@ -24,7 +24,7 @@ const Loyalty: Attach = {
 
 		observer.subscribeWithPriority(
 			game.globalHooks.afterAttack,
-			afterAttack.ON_ROW_DEATH,
+			afterAttack.UPDATE_POST_ATTACK_STATE,
 			(attack) => {
 				if (!component.slot.inRow() || component.slot.row.health) return
 				if (!attack.target || !attack.isTargeting(component)) return

--- a/common/cards/default/effects/loyalty.ts
+++ b/common/cards/default/effects/loyalty.ts
@@ -1,7 +1,7 @@
 import {CardComponent, ObserverComponent} from '../../../components'
 import query from '../../../components/query'
 import {GameModel} from '../../../models/game-model'
-import {afterDefence} from '../../../types/priorities'
+import {afterAttack} from '../../../types/priorities'
 import {attach} from '../../base/defaults'
 import {Attach} from '../../base/types'
 
@@ -23,8 +23,8 @@ const Loyalty: Attach = {
 		const {player} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.afterDefence,
-			afterDefence.ON_ROW_DEATH,
+			game.globalHooks.afterAttack,
+			afterAttack.ON_ROW_DEATH,
 			(attack) => {
 				if (!component.slot.inRow() || component.slot.row.health) return
 				if (!attack.target || !attack.isTargeting(component)) return

--- a/common/cards/default/effects/milk-bucket.ts
+++ b/common/cards/default/effects/milk-bucket.ts
@@ -8,7 +8,7 @@ import query from '../../../components/query'
 import {GameModel} from '../../../models/game-model'
 import BadOmenEffect from '../../../status-effects/badomen'
 import PoisonEffect from '../../../status-effects/poison'
-import {beforeDefence} from '../../../types/priorities'
+import {beforeAttack} from '../../../types/priorities'
 import {applySingleUse} from '../../../utils/board'
 import {attach, singleUse} from '../../base/defaults'
 import {Attach, SingleUse} from '../../base/types'
@@ -77,8 +77,8 @@ const MilkBucket: Attach & SingleUse = {
 			removeStatusEffects(game, component.slot)
 
 			observer.subscribeWithPriority(
-				player.hooks.beforeDefence,
-				beforeDefence.EFFECT_REMOVE_STATUS,
+				game.globalHooks.beforeAttack,
+				beforeAttack.EFFECT_REMOVE_STATUS,
 				(_attack) => {
 					if (!component.slot.inRow()) return
 					removeStatusEffects(game, component.slot.row.getHermit()?.slot)

--- a/common/cards/default/effects/netherite-armor.ts
+++ b/common/cards/default/effects/netherite-armor.ts
@@ -1,6 +1,6 @@
 import {CardComponent, ObserverComponent} from '../../../components'
 import {GameModel} from '../../../models/game-model'
-import {beforeDefence} from '../../../types/priorities'
+import {beforeAttack} from '../../../types/priorities'
 import {attach} from '../../base/defaults'
 import {Attach} from '../../base/types'
 
@@ -15,7 +15,7 @@ const NetheriteArmor: Attach = {
 	description:
 		'When the Hermit this card is attached to takes damage, that damage is reduced by up to 40hp each turn.',
 	onAttach(
-		_game: GameModel,
+		game: GameModel,
 		component: CardComponent,
 		observer: ObserverComponent,
 	) {
@@ -24,8 +24,8 @@ const NetheriteArmor: Attach = {
 		let damageBlocked = 0
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeDefence,
-			beforeDefence.EFFECT_REDUCE_DAMAGE,
+			game.globalHooks.beforeAttack,
+			beforeAttack.EFFECT_REDUCE_DAMAGE,
 			(attack) => {
 				if (!attack.isTargeting(component) || attack.isType('status-effect'))
 					return

--- a/common/cards/default/effects/shield.ts
+++ b/common/cards/default/effects/shield.ts
@@ -44,7 +44,7 @@ const Shield: Attach = {
 
 		observer.subscribeWithPriority(
 			game.globalHooks.afterAttack,
-			afterAttack.DISCARD_SHIELD,
+			afterAttack.UPDATE_POST_ATTACK_STATE,
 			(attack) => {
 				if (damageBlocked > 0 && attack.isTargeting(component)) {
 					// attack.isTargeting asserts `attack.target !== null` and `attack.targetEntity !== null`

--- a/common/cards/default/effects/shield.ts
+++ b/common/cards/default/effects/shield.ts
@@ -1,7 +1,7 @@
 import {CardComponent, ObserverComponent} from '../../../components'
 import query from '../../../components/query'
 import {GameModel} from '../../../models/game-model'
-import {afterDefence, beforeDefence} from '../../../types/priorities'
+import {afterAttack, beforeAttack} from '../../../types/priorities'
 import {attach} from '../../base/defaults'
 import {Attach} from '../../base/types'
 
@@ -23,10 +23,10 @@ const Shield: Attach = {
 		const {player} = component
 		let damageBlocked = 0
 
-		// Note that we are using beforeDefence because we want to activate on any attack to us, not just from the opponent
+		// Note that we want to activate on any attack to us, not just from the opponent
 		observer.subscribeWithPriority(
-			player.hooks.beforeDefence,
-			beforeDefence.EFFECT_REDUCE_DAMAGE,
+			game.globalHooks.beforeAttack,
+			beforeAttack.EFFECT_REDUCE_DAMAGE,
 			(attack) => {
 				if (!attack.isTargeting(component) || attack.isType('status-effect'))
 					return
@@ -43,8 +43,8 @@ const Shield: Attach = {
 		)
 
 		observer.subscribeWithPriority(
-			player.hooks.afterDefence,
-			afterDefence.DISCARD_SHIELD,
+			game.globalHooks.afterAttack,
+			afterAttack.DISCARD_SHIELD,
 			(attack) => {
 				if (damageBlocked > 0 && attack.isTargeting(component)) {
 					// attack.isTargeting asserts `attack.target !== null` and `attack.targetEntity !== null`

--- a/common/cards/default/effects/thorns.ts
+++ b/common/cards/default/effects/thorns.ts
@@ -29,7 +29,7 @@ const Thorns: Attach = {
 
 		observer.subscribeWithPriority(
 			game.globalHooks.beforeAttack,
-			beforeAttack.EFFECT_CREATE_BACKLASH,
+			beforeAttack.REACT_TO_DAMAGE,
 			(attack) => {
 				// If we have already triggered once this turn do not do so again
 				if (hasTriggered) return

--- a/common/cards/default/effects/thorns.ts
+++ b/common/cards/default/effects/thorns.ts
@@ -1,7 +1,7 @@
 import {CardComponent, ObserverComponent} from '../../../components'
 import query from '../../../components/query'
 import {GameModel} from '../../../models/game-model'
-import {beforeDefence, onTurnEnd} from '../../../types/priorities'
+import {beforeAttack, onTurnEnd} from '../../../types/priorities'
 import {attach} from '../../base/defaults'
 import {Attach} from '../../base/types'
 import DiamondArmor from './diamond-armor'
@@ -24,12 +24,12 @@ const Thorns: Attach = {
 		component: CardComponent,
 		observer: ObserverComponent,
 	) {
-		const {player, opponentPlayer} = component
+		const {opponentPlayer} = component
 		let hasTriggered = false
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeDefence,
-			beforeDefence.EFFECT_CREATE_BACKLASH,
+			game.globalHooks.beforeAttack,
+			beforeAttack.EFFECT_CREATE_BACKLASH,
 			(attack) => {
 				// If we have already triggered once this turn do not do so again
 				if (hasTriggered) return

--- a/common/cards/default/effects/totem.ts
+++ b/common/cards/default/effects/totem.ts
@@ -33,7 +33,6 @@ const Totem: Attach = {
 		const {player} = component
 
 		// If we are attacked from any source
-		// Add before any other hook so they can know a hermits health reliably
 		observer.subscribeWithPriority(
 			game.globalHooks.rowRevive,
 			rowRevive.TOTEM_REVIVE,

--- a/common/cards/default/effects/water-bucket.ts
+++ b/common/cards/default/effects/water-bucket.ts
@@ -7,7 +7,7 @@ import {
 import query from '../../../components/query'
 import {GameModel} from '../../../models/game-model'
 import FireEffect from '../../../status-effects/fire'
-import {beforeDefence} from '../../../types/priorities'
+import {beforeAttack} from '../../../types/priorities'
 import {applySingleUse} from '../../../utils/board'
 import String from '../../alter-egos/effects/string'
 import {attach, singleUse} from '../../base/defaults'
@@ -85,8 +85,8 @@ const WaterBucket: Attach & SingleUse = {
 			removeFireEffect(game, component.slot)
 
 			observer.subscribeWithPriority(
-				player.hooks.beforeDefence,
-				beforeDefence.EFFECT_REMOVE_STATUS,
+				game.globalHooks.beforeAttack,
+				beforeAttack.EFFECT_REMOVE_STATUS,
 				(_attack) => {
 					if (!component.slot.inRow()) return
 					removeFireEffect(game, component.slot.row.getHermit()?.slot)

--- a/common/cards/default/effects/wolf.ts
+++ b/common/cards/default/effects/wolf.ts
@@ -31,7 +31,7 @@ const Wolf: Attach = {
 
 		observer.subscribeWithPriority(
 			game.globalHooks.beforeAttack,
-			beforeAttack.EFFECT_CREATE_BACKLASH,
+			beforeAttack.REACT_TO_DAMAGE,
 			(attack) => {
 				if (attack.isType('status-effect') || attack.isBacklash) return
 				// Only on opponents turn

--- a/common/cards/default/effects/wolf.ts
+++ b/common/cards/default/effects/wolf.ts
@@ -1,7 +1,7 @@
 import {CardComponent, ObserverComponent} from '../../../components'
 import query from '../../../components/query'
 import {GameModel} from '../../../models/game-model'
-import {beforeDefence} from '../../../types/priorities'
+import {beforeAttack} from '../../../types/priorities'
 import {attach} from '../../base/defaults'
 import {Attach} from '../../base/types'
 
@@ -30,8 +30,8 @@ const Wolf: Attach = {
 		})
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeDefence,
-			beforeDefence.EFFECT_CREATE_BACKLASH,
+			game.globalHooks.beforeAttack,
+			beforeAttack.EFFECT_CREATE_BACKLASH,
 			(attack) => {
 				if (attack.isType('status-effect') || attack.isBacklash) return
 				// Only on opponents turn

--- a/common/cards/default/hermits/bdoubleo100-rare.ts
+++ b/common/cards/default/hermits/bdoubleo100-rare.ts
@@ -46,9 +46,10 @@ const BdoubleO100Rare: Hermit = {
 		const {player} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.HERMIT_APPLY_ATTACK,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 				game.components

--- a/common/cards/default/hermits/cubfan135-rare.ts
+++ b/common/cards/default/hermits/cubfan135-rare.ts
@@ -39,9 +39,10 @@ const Cubfan135Rare: Hermit = {
 		const {player} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.afterAttack,
+			game.globalHooks.afterAttack,
 			afterAttack.HERMIT_ATTACK_REQUESTS,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 

--- a/common/cards/default/hermits/docm77-rare.ts
+++ b/common/cards/default/hermits/docm77-rare.ts
@@ -29,16 +29,17 @@ const Docm77Rare: Hermit = {
 			'Flip a coin.\nIf heads, attack damage doubles.\nIf tails, attack damage is halved.',
 	},
 	onAttach(
-		_game: GameModel,
+		game: GameModel,
 		component: CardComponent,
 		observer: ObserverComponent,
 	) {
 		const {player} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.MODIFY_DAMAGE,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 				if (!(attack.attacker instanceof CardComponent)) return

--- a/common/cards/default/hermits/ethoslab-rare.ts
+++ b/common/cards/default/hermits/ethoslab-rare.ts
@@ -47,9 +47,10 @@ const EthosLabRare: Hermit = {
 		const {player} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.HERMIT_APPLY_ATTACK,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 				if (!(attack.attacker instanceof CardComponent)) return

--- a/common/cards/default/hermits/ethoslab-ultra-rare.ts
+++ b/common/cards/default/hermits/ethoslab-ultra-rare.ts
@@ -29,16 +29,17 @@ const EthosLabUltraRare: Hermit = {
 			'Flip a coin 3 times.\nDo an additional 20hp damage for every heads.',
 	},
 	onAttach(
-		_game: GameModel,
+		game: GameModel,
 		component: CardComponent,
 		observer: ObserverComponent,
 	) {
 		const {player} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.MODIFY_DAMAGE,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 				if (!(attack.attacker instanceof CardComponent)) return

--- a/common/cards/default/hermits/falsesymmetry-rare.ts
+++ b/common/cards/default/hermits/falsesymmetry-rare.ts
@@ -35,9 +35,10 @@ const FalseSymmetryRare: Hermit = {
 		const {player} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.HERMIT_APPLY_ATTACK,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 

--- a/common/cards/default/hermits/geminitay-rare.ts
+++ b/common/cards/default/hermits/geminitay-rare.ts
@@ -37,9 +37,10 @@ const GeminiTayRare: Hermit = {
 		const {player} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.afterAttack,
+			game.globalHooks.afterAttack,
 			afterAttack.HERMIT_REMOVE_SINGLE_USE,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 

--- a/common/cards/default/hermits/goodtimeswithscar-rare.ts
+++ b/common/cards/default/hermits/goodtimeswithscar-rare.ts
@@ -49,9 +49,10 @@ const GoodTimesWithScarRare: Hermit = {
 		const {player} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.HERMIT_APPLY_ATTACK,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 				// If this component is not blocked from reviving, make possible next turn

--- a/common/cards/default/hermits/grian-rare.ts
+++ b/common/cards/default/hermits/grian-rare.ts
@@ -41,9 +41,10 @@ const GrianRare: Hermit = {
 		const {player} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.afterAttack,
+			game.globalHooks.afterAttack,
 			afterAttack.HERMIT_ATTACK_REQUESTS,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'primary')
 					return
 

--- a/common/cards/default/hermits/hypnotizd-rare.ts
+++ b/common/cards/default/hermits/hypnotizd-rare.ts
@@ -48,9 +48,10 @@ const HypnotizdRare: Hermit = {
 		let target: SlotComponent | null = null
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.HERMIT_SET_TARGET,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 				if (!target?.inRow()) return

--- a/common/cards/default/hermits/ijevin-rare.ts
+++ b/common/cards/default/hermits/ijevin-rare.ts
@@ -41,9 +41,10 @@ const IJevinRare: Hermit = {
 		const {player, opponentPlayer} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.afterAttack,
+			game.globalHooks.afterAttack,
 			afterAttack.HERMIT_ATTACK_REQUESTS,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 

--- a/common/cards/default/hermits/impulsesv-rare.ts
+++ b/common/cards/default/hermits/impulsesv-rare.ts
@@ -40,9 +40,10 @@ const ImpulseSVRare: Hermit = {
 		const {player} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.MODIFY_DAMAGE,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 

--- a/common/cards/default/hermits/iskall85-rare.ts
+++ b/common/cards/default/hermits/iskall85-rare.ts
@@ -27,16 +27,17 @@ const Iskall85Rare: Hermit = {
 		power: 'Attack damage doubles versus Builder types.',
 	},
 	onAttach(
-		_game: GameModel,
+		game: GameModel,
 		component: CardComponent,
 		observer: ObserverComponent,
 	) {
 		const {player} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.MODIFY_DAMAGE,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 

--- a/common/cards/default/hermits/joehills-rare.ts
+++ b/common/cards/default/hermits/joehills-rare.ts
@@ -50,9 +50,10 @@ const JoeHillsRare: Hermit = {
 		const {player, opponentPlayer} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.HERMIT_APPLY_ATTACK,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 

--- a/common/cards/default/hermits/keralis-rare.ts
+++ b/common/cards/default/hermits/keralis-rare.ts
@@ -77,9 +77,10 @@ const KeralisRare: Hermit = {
 
 		// Heals the afk hermit *before* we actually do damage
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.HERMIT_APPLY_ATTACK,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 

--- a/common/cards/default/hermits/mumbojumbo-rare.ts
+++ b/common/cards/default/hermits/mumbojumbo-rare.ts
@@ -40,9 +40,10 @@ const MumboJumboRare: Hermit = {
 		const {player} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.MODIFY_DAMAGE,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 

--- a/common/cards/default/hermits/pearlescentmoon-rare.ts
+++ b/common/cards/default/hermits/pearlescentmoon-rare.ts
@@ -46,9 +46,10 @@ const PearlescentMoonRare: Hermit = {
 		const {player, opponentPlayer} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.HERMIT_APPLY_ATTACK,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 				game.components

--- a/common/cards/default/hermits/stressmonster101-rare.ts
+++ b/common/cards/default/hermits/stressmonster101-rare.ts
@@ -35,9 +35,10 @@ const StressMonster101Rare: Hermit = {
 		const {player} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.MODIFY_DAMAGE,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (
 					!attack.isAttacker(component.entity) ||
 					attack.type !== 'secondary' ||

--- a/common/cards/default/hermits/tangotek-rare.ts
+++ b/common/cards/default/hermits/tangotek-rare.ts
@@ -40,9 +40,10 @@ const TangoTekRare: Hermit = {
 		const {player, opponentPlayer} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.afterAttack,
+			game.globalHooks.afterAttack,
 			afterAttack.HERMIT_ATTACK_REQUESTS,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 

--- a/common/cards/default/hermits/tinfoilchef-rare.ts
+++ b/common/cards/default/hermits/tinfoilchef-rare.ts
@@ -36,9 +36,10 @@ const TinFoilChefRare: Hermit = {
 		const {player} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.HERMIT_APPLY_ATTACK,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 

--- a/common/cards/default/hermits/tinfoilchef-ultra-rare.ts
+++ b/common/cards/default/hermits/tinfoilchef-ultra-rare.ts
@@ -46,9 +46,10 @@ const TinFoilChefUltraRare: Hermit = {
 		)
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.HERMIT_APPLY_ATTACK,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 

--- a/common/cards/default/hermits/vintagebeef-rare.ts
+++ b/common/cards/default/hermits/vintagebeef-rare.ts
@@ -41,9 +41,10 @@ const VintageBeefRare: Hermit = {
 		const {player} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.HERMIT_APPLY_ATTACK,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 

--- a/common/cards/default/hermits/vintagebeef-ultra-rare.ts
+++ b/common/cards/default/hermits/vintagebeef-ultra-rare.ts
@@ -43,9 +43,10 @@ const VintageBeefUltraRare: Hermit = {
 		const {player} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.MODIFY_DAMAGE,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 

--- a/common/cards/default/hermits/welsknight-rare.ts
+++ b/common/cards/default/hermits/welsknight-rare.ts
@@ -28,16 +28,17 @@ const WelsknightRare: Hermit = {
 			"If this Hermit's HP is orange (190-100), do an additional 20hp damage.\nIf this Hermit's HP is red (90 or lower), do an additional 40hp damage.",
 	},
 	onAttach(
-		_game: GameModel,
+		game: GameModel,
 		component: CardComponent,
 		observer: ObserverComponent,
 	) {
 		const {player} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.MODIFY_DAMAGE,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 				if (!component.slot.inRow() || !component.slot.row.health) return

--- a/common/cards/default/hermits/xbcrafted-rare.ts
+++ b/common/cards/default/hermits/xbcrafted-rare.ts
@@ -41,9 +41,10 @@ const XBCraftedRare: Hermit = {
 		const {player} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.IGNORE_CARDS,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 				game.components

--- a/common/cards/default/hermits/xisumavoid-rare.ts
+++ b/common/cards/default/hermits/xisumavoid-rare.ts
@@ -46,9 +46,10 @@ const XisumavoidRare: Hermit = {
 		const {player, opponentPlayer} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.HERMIT_APPLY_ATTACK,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 

--- a/common/cards/default/hermits/zedaphplays-rare.ts
+++ b/common/cards/default/hermits/zedaphplays-rare.ts
@@ -41,9 +41,10 @@ const ZedaphPlaysRare: Hermit = {
 		const {player, opponentPlayer} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.HERMIT_APPLY_ATTACK,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'primary')
 					return
 

--- a/common/cards/default/single-use/bow.ts
+++ b/common/cards/default/single-use/bow.ts
@@ -71,9 +71,10 @@ const Bow: SingleUse = {
 		})
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.APPLY_SINGLE_USE_ATTACK,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (attack.attacker?.entity !== component.entity) return
 				applySingleUse(game, component.slot)
 			},

--- a/common/cards/default/single-use/chorus-fruit.ts
+++ b/common/cards/default/single-use/chorus-fruit.ts
@@ -49,14 +49,15 @@ const ChorusFruit: SingleUse = {
 		const {player} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.afterAttack,
+			game.globalHooks.afterAttack,
 			afterAttack.EFFECT_POST_ATTACK_REQUESTS,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isType('primary', 'secondary')) return
 
 				applySingleUse(game, component.slot)
 
-				observer.unsubscribe(player.hooks.afterAttack)
+				observer.unsubscribe(game.globalHooks.afterAttack)
 
 				game.addPickRequest({
 					player: player.entity,

--- a/common/cards/default/single-use/crossbow.ts
+++ b/common/cards/default/single-use/crossbow.ts
@@ -117,15 +117,16 @@ const Crossbow: SingleUse = {
 		})
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.APPLY_SINGLE_USE_ATTACK,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity)) return
 
 				applySingleUse(game)
 
 				// Do not apply single use more than once
-				observer.unsubscribe(player.hooks.beforeAttack)
+				observer.unsubscribe(game.globalHooks.beforeAttack)
 			},
 		)
 	},

--- a/common/cards/default/single-use/diamond-sword.ts
+++ b/common/cards/default/single-use/diamond-sword.ts
@@ -39,9 +39,10 @@ const DiamondSword: SingleUse = {
 		})
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.APPLY_SINGLE_USE_ATTACK,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity)) return
 				applySingleUse(game)
 			},

--- a/common/cards/default/single-use/golden-axe.ts
+++ b/common/cards/default/single-use/golden-axe.ts
@@ -49,9 +49,10 @@ const GoldenAxe: SingleUse = {
 		})
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.APPLY_SINGLE_USE_ATTACK,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (attack.isAttacker(component.entity)) {
 					applySingleUse(game)
 				}

--- a/common/cards/default/single-use/iron-sword.ts
+++ b/common/cards/default/single-use/iron-sword.ts
@@ -39,9 +39,10 @@ const IronSword: SingleUse = {
 		})
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.APPLY_SINGLE_USE_ATTACK,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity)) return
 				applySingleUse(game)
 			},

--- a/common/cards/default/single-use/knockback.ts
+++ b/common/cards/default/single-use/knockback.ts
@@ -40,13 +40,14 @@ const Knockback: SingleUse = {
 		const {player, opponentPlayer} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.afterAttack,
+			game.globalHooks.afterAttack,
 			afterAttack.EFFECT_POST_ATTACK_REQUESTS,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isType('primary', 'secondary')) return
 				applySingleUse(game)
 				// Only Apply this for the first attack
-				observer.unsubscribe(player.hooks.afterAttack)
+				observer.unsubscribe(game.globalHooks.afterAttack)
 
 				if (!game.components.exists(SlotComponent, pickCondition)) return
 

--- a/common/cards/default/single-use/netherite-sword.ts
+++ b/common/cards/default/single-use/netherite-sword.ts
@@ -39,9 +39,10 @@ const NetheriteSword: SingleUse = {
 		})
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.APPLY_SINGLE_USE_ATTACK,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity)) return
 				applySingleUse(game)
 			},

--- a/common/cards/default/single-use/tnt.ts
+++ b/common/cards/default/single-use/tnt.ts
@@ -53,12 +53,13 @@ const TNT: SingleUse = {
 		})
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.APPLY_SINGLE_USE_ATTACK,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity)) return
 				applySingleUse(game)
-				observer.unsubscribe(player.hooks.beforeAttack)
+				observer.unsubscribe(game.globalHooks.beforeAttack)
 			},
 		)
 	},

--- a/common/cards/season-x/hermits/skizzleman-rare.ts
+++ b/common/cards/season-x/hermits/skizzleman-rare.ts
@@ -41,9 +41,10 @@ const SkizzlemanRare: Hermit = {
 		const {player} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.HERMIT_APPLY_ATTACK,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 				game.components

--- a/common/cards/season-x/hermits/smallishbeans-rare.ts
+++ b/common/cards/season-x/hermits/smallishbeans-rare.ts
@@ -39,9 +39,10 @@ const SmallishbeansRare: Hermit = {
 		const {player} = component
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.MODIFY_DAMAGE,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
 

--- a/common/components/observer-component.ts
+++ b/common/components/observer-component.ts
@@ -1,6 +1,6 @@
 import {Entity, ObserverEntity} from '../entities'
 import type {GameModel} from '../models/game-model'
-import type {Hook, PriorityHook} from '../types/hooks'
+import type {Hook, PriorityHook, WaterfallHook} from '../types/hooks'
 import {PrioritiesT, Priority, PriorityDict} from '../types/priorities'
 import type {CardComponent} from './card-component'
 import type {StatusEffectComponent} from './status-effect-component'
@@ -33,7 +33,7 @@ export class ObserverComponent {
 	 * from the board), please use a status effect or `oneShot` instead.
 	 */
 	public subscribe<Args extends (...any: any) => any>(
-		hook: Hook<ObserverEntity, Args>,
+		hook: Hook<ObserverEntity, Args> | WaterfallHook<Args>,
 		fun: Args,
 	) {
 		hook.add(this.entity, fun)
@@ -44,7 +44,7 @@ export class ObserverComponent {
 	 * removed when the observer is destroyed.
 	 */
 	public subscribeBefore<Args extends (...any: any) => any>(
-		hook: Hook<ObserverEntity, Args>,
+		hook: Hook<ObserverEntity, Args> | WaterfallHook<Args>,
 		fun: Args,
 	) {
 		hook.addBefore(this.entity, fun)

--- a/common/components/player-component.ts
+++ b/common/components/player-component.ts
@@ -12,18 +12,10 @@ import type {
 	UsedHermitAttackInfo,
 } from '../types/game-state'
 import {GameHook, PriorityHook, WaterfallHook} from '../types/hooks'
-import {
-	afterAttack,
-	afterDefence,
-	beforeAttack,
-	beforeDefence,
-	onTurnEnd,
-} from '../types/priorities'
+import {onTurnEnd} from '../types/priorities'
 import {CardComponent} from './card-component'
 import query from './query'
-import {ComponentQuery} from './query'
 import {RowComponent} from './row-component'
-import {SlotComponent} from './slot-component'
 import {StatusEffectComponent} from './status-effect-component'
 
 /** The minimal information that must be known about a player to start a game */
@@ -87,32 +79,6 @@ export class PlayerComponent {
 
 		/** Hook that returns attacks to execute */
 		getAttack: GameHook<() => AttackModel | null>
-		/** Hook called before the main attack loop, for every attack from our side of the board */
-		beforeAttack: PriorityHook<
-			(attack: AttackModel) => void,
-			typeof beforeAttack
-		>
-		/** Hook called before the main attack loop, for every attack targeting our side of the board */
-		beforeDefence: PriorityHook<
-			(attack: AttackModel) => void,
-			typeof beforeDefence
-		>
-		/**
-		 * Hook called after the main attack loop is completed, for every attack from our side of the board.
-		 * Attacks added from this hook will not be executed.
-		 *
-		 * This is called after actions are marked as completed and blocked
-		 */
-		afterAttack: PriorityHook<(attack: AttackModel) => void, typeof afterAttack>
-		/**
-		 * Hook called after the main attack loop, for every attack targeting our side of the board
-		 *
-		 * This is called after actions are marked as completed and blocked
-		 */
-		afterDefence: PriorityHook<
-			(attack: AttackModel) => void,
-			typeof afterDefence
-		>
 
 		/**
 		 * Hook called at the start of the turn
@@ -149,11 +115,6 @@ export class PlayerComponent {
 				newActiveHermit: CardComponent,
 			) => void
 		>
-		/** Hook called when the `slot.locked` combinator is called.
-		 * Returns a combinator that verifies if the slot is locked or not.
-		 * Locked slots cannot be chosen in some combinator expressions.
-		 */
-		freezeSlots: GameHook<() => ComponentQuery<SlotComponent>>
 	}
 
 	constructor(game: GameModel, entity: PlayerEntity, player: PlayerDefs) {
@@ -180,16 +141,11 @@ export class PlayerComponent {
 			afterApply: new GameHook(),
 			getAttackRequests: new GameHook(),
 			getAttack: new GameHook(),
-			beforeAttack: new PriorityHook(beforeAttack),
-			beforeDefence: new PriorityHook(beforeDefence),
-			afterAttack: new PriorityHook(afterAttack),
-			afterDefence: new PriorityHook(afterDefence),
 			onTurnStart: new GameHook(),
 			onTurnEnd: new PriorityHook(onTurnEnd),
 			onCoinFlip: new GameHook(),
 			beforeActiveRowChange: new GameHook(),
 			onActiveRowChange: new GameHook(),
-			freezeSlots: new GameHook(),
 		}
 	}
 

--- a/common/components/query/slot.ts
+++ b/common/components/query/slot.ts
@@ -147,15 +147,7 @@ export const has = (...cards: Array<Card>): ComponentQuery<SlotComponent> => {
  * Use slot.player(player.entity) instead.
  */
 export const frozen: ComponentQuery<SlotComponent> = (game, pos) => {
-	const playerResult = game.currentPlayer.hooks.freezeSlots
-		.call()
-		.some((result) => result(game, pos))
-
-	const opponentResult = game.opponentPlayer.hooks.freezeSlots
-		.call()
-		.some((result) => result(game, pos))
-
-	return playerResult || opponentResult
+	return game.globalHooks.freezeSlots.call().some((result) => result(game, pos))
 }
 
 export function hasStatusEffect(

--- a/common/models/attack-model.ts
+++ b/common/models/attack-model.ts
@@ -146,7 +146,7 @@ export class AttackModel {
 		if (type) {
 			return this.history.filter((history) => history.type == type)
 		}
-		return this.history
+		return [...this.history]
 	}
 
 	/** Returns the current attacker for this attack */
@@ -259,3 +259,18 @@ export class AttackModel {
 		return this.consolidateLogs(values, this.log.length - 1)
 	}
 }
+
+/** Safety type to prevent hooks modifying attack values */
+export type ReadonlyAttackModel = Omit<
+	Readonly<AttackModel>,
+	| 'redirect'
+	| 'addDamage'
+	| 'removeDamage'
+	| 'reduceDamage'
+	| 'multiplyDamage'
+	| 'setAttacker'
+	| 'setTarget'
+	| 'redirect'
+	| 'addNewAttack'
+	| 'updateLog'
+>

--- a/common/models/game-model.ts
+++ b/common/models/game-model.ts
@@ -21,23 +21,24 @@ import {
 	TurnAction,
 	TurnActions,
 } from '../types/game-state'
-import {Hook} from '../types/hooks'
+import {Hook, PriorityHook} from '../types/hooks'
 import {CopyAttack, ModalRequest, SelectCards} from '../types/modal-requests'
+import {rowRevive} from '../types/priorities'
 import {PickRequest} from '../types/server-requests'
 import {
 	PlayerSetupDefs,
 	getGameState,
 	setupComponents,
 } from '../utils/state-gen'
-import {AttackModel} from './attack-model'
+import {AttackModel, ReadonlyAttackModel} from './attack-model'
 import {BattleLogModel} from './battle-log-model'
 import {PlayerId, PlayerModel} from './player-model'
 
 /** Type that allows for additional data about a game to be shared between components */
 export class GameValue<T> extends DefaultDictionary<GameModel, T> {
 	public set(game: GameModel, value: T) {
-		if (game.id in this.values) {
-			game.afterGameEnd.add('GameValue<T>', () => this.clear(game))
+		if (!(game.id in this.values)) {
+			game.globalHooks.afterGameEnd.add('GameValue<T>', () => this.clear(game))
 		}
 		this.setValue(game.id, value)
 	}
@@ -110,8 +111,15 @@ export class GameModel {
 
 	/** The objects used in the game. */
 	public components: ComponentTable
-	/** Hook for when the game ends and references needs to be disposed */
-	public afterGameEnd: Hook<string, () => void>
+	public globalHooks: {
+		/** Hook for when the game ends and references needs to be disposed */
+		afterGameEnd: Hook<string, () => void>
+		/** Hook for reviving rows after all attacks are executed */
+		rowRevive: PriorityHook<
+			(attack: ReadonlyAttackModel) => void,
+			typeof rowRevive
+		>
+	}
 
 	public endInfo: {
 		deadPlayerEntities: Array<PlayerEntity>
@@ -149,7 +157,10 @@ export class GameModel {
 		}
 
 		this.components = new ComponentTable(this)
-		this.afterGameEnd = new Hook<string, () => void>()
+		this.globalHooks = {
+			afterGameEnd: new Hook(),
+			rowRevive: new PriorityHook(rowRevive),
+		}
 		setupComponents(this.components, player1, player2, {
 			shuffleDeck: settings.shuffleDeck,
 			startWithAllCards: settings.startWithAllCards,

--- a/common/status-effects/aussie-ping.ts
+++ b/common/status-effects/aussie-ping.ts
@@ -29,9 +29,10 @@ export const AussiePingEffect: StatusEffect<PlayerComponent> = {
 		let coinFlipResult: CoinFlipResult | null = null
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.MODIFY_DAMAGE,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isType('primary', 'secondary') || attack.isBacklash) return
 				if (!attack.attacker) return
 

--- a/common/status-effects/betrayed.ts
+++ b/common/status-effects/betrayed.ts
@@ -121,9 +121,10 @@ const BetrayedEffect: StatusEffect<PlayerComponent> = {
 		)
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.HERMIT_CHANGE_TARGET,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isType('primary', 'secondary')) return
 
 				if (pickedAfkHermit !== null && pickedAfkHermit.inRow()) {

--- a/common/status-effects/chroma-keyed.ts
+++ b/common/status-effects/chroma-keyed.ts
@@ -17,7 +17,7 @@ const ChromaKeyedEffect: Counter<CardComponent> = {
 	counter: 1,
 	counterType: 'number',
 	onApply(
-		_game: GameModel,
+		game: GameModel,
 		effect: StatusEffectComponent<CardComponent>,
 		target: CardComponent,
 		observer: ObserverComponent,
@@ -28,9 +28,10 @@ const ChromaKeyedEffect: Counter<CardComponent> = {
 		let previousUses = 0
 
 		observer.subscribeWithPriority(
-			target.player.hooks.afterAttack,
+			game.globalHooks.afterAttack,
 			afterAttack.UPDATE_POST_ATTACK_STATE,
 			(attack) => {
+				if (attack.player.entity !== target.player.entity) return
 				if (effect.counter === null) return
 				if (previousUses < effect.counter) jopacityUsedThisTurn = true
 				else if (attack.isAttacker(target.entity)) effect.remove()

--- a/common/status-effects/death-loop.ts
+++ b/common/status-effects/death-loop.ts
@@ -6,7 +6,7 @@ import {
 } from '../components'
 import query from '../components/query'
 import {GameModel} from '../models/game-model'
-import {afterAttack, onTurnEnd} from '../types/priorities'
+import {onTurnEnd, rowRevive} from '../types/priorities'
 import {StatusEffect, systemStatusEffect} from './status-effect'
 
 export const DeathloopReady: StatusEffect<CardComponent> = {
@@ -25,8 +25,8 @@ export const DeathloopReady: StatusEffect<CardComponent> = {
 
 		// Add before so health can be checked reliably
 		observer.subscribeWithPriority(
-			opponentPlayer.hooks.afterAttack,
-			afterAttack.DEATHLOOP_REVIVE,
+			game.globalHooks.rowRevive,
+			rowRevive.DEATHLOOP_REVIVE,
 			(attack) => {
 				const row = attack.target
 				if (!row || row.health === null || row.health > 0) return

--- a/common/status-effects/efficiency.ts
+++ b/common/status-effects/efficiency.ts
@@ -9,14 +9,14 @@ const EfficiencyEffect: StatusEffect<PlayerComponent> = {
 	icon: 'efficiency',
 	description:
 		'You may use an attack from your active Hermit without having the necessary item cards attached.',
-	onApply(_game, effect, player, observer) {
+	onApply(game, effect, player, observer) {
 		observer.subscribe(player.hooks.availableEnergy, (_availableEnergy) => {
 			// Unliimited powwa
 			return ['any', 'any', 'any']
 		})
 
 		observer.subscribeWithPriority(
-			player.hooks.afterAttack,
+			game.globalHooks.afterAttack,
 			afterAttack.UPDATE_POST_ATTACK_STATE,
 			(_attack) => {
 				effect.remove()

--- a/common/status-effects/fire.ts
+++ b/common/status-effects/fire.ts
@@ -4,7 +4,7 @@ import {
 	StatusEffectComponent,
 } from '../components'
 import {GameModel} from '../models/game-model'
-import {afterDefence, onTurnEnd} from '../types/priorities'
+import {afterAttack, onTurnEnd} from '../types/priorities'
 import {executeExtraAttacks} from '../utils/attacks'
 import {StatusEffect, damageEffect} from './status-effect'
 
@@ -22,7 +22,7 @@ const FireEffect: StatusEffect<CardComponent> = {
 		target: CardComponent,
 		observer: ObserverComponent,
 	) {
-		const {player, opponentPlayer} = target
+		const {opponentPlayer} = target
 
 		observer.subscribeWithPriority(
 			opponentPlayer.hooks.onTurnEnd,
@@ -44,8 +44,8 @@ const FireEffect: StatusEffect<CardComponent> = {
 		)
 
 		observer.subscribeWithPriority(
-			player.hooks.afterDefence,
-			afterDefence.ON_ROW_DEATH,
+			game.globalHooks.afterAttack,
+			afterAttack.ON_ROW_DEATH,
 			(_attack) => {
 				if (!target.isAlive()) effect.remove()
 			},

--- a/common/status-effects/fire.ts
+++ b/common/status-effects/fire.ts
@@ -45,7 +45,7 @@ const FireEffect: StatusEffect<CardComponent> = {
 
 		observer.subscribeWithPriority(
 			game.globalHooks.afterAttack,
-			afterAttack.ON_ROW_DEATH,
+			afterAttack.UPDATE_POST_ATTACK_STATE,
 			(_attack) => {
 				if (!target.isAlive()) effect.remove()
 			},

--- a/common/status-effects/gas-light.ts
+++ b/common/status-effects/gas-light.ts
@@ -7,7 +7,7 @@ import query from '../components/query'
 import {RowEntity} from '../entities'
 import {AttackModel} from '../models/attack-model'
 import {GameModel} from '../models/game-model'
-import {afterDefence, onTurnEnd} from '../types/priorities'
+import {afterAttack, onTurnEnd} from '../types/priorities'
 import {executeExtraAttacks} from '../utils/attacks'
 import {
 	StatusEffect,
@@ -42,11 +42,11 @@ export const GasLightEffect: StatusEffect<CardComponent> = {
 		target: CardComponent,
 		observer: ObserverComponent,
 	) {
-		let {player, opponentPlayer} = target
+		let {opponentPlayer} = target
 
 		observer.subscribeWithPriority(
-			player.hooks.afterDefence,
-			afterDefence.TRIGGER_GAS_LIGHT,
+			game.globalHooks.afterAttack,
+			afterAttack.TRIGGER_GAS_LIGHT,
 			(attack) => {
 				if (!attack.isTargeting(target)) return
 				if (attack.calculateDamage() === 0) return

--- a/common/status-effects/ignore-attach.ts
+++ b/common/status-effects/ignore-attach.ts
@@ -16,11 +16,12 @@ export const IgnoreAttachSlotEffect: StatusEffect<CardComponent> = {
 			!value.getStatusEffect(IgnoreAttachSlotEffect)
 		)
 	},
-	onApply(_game, effect, target, observer) {
+	onApply(game, effect, target, observer) {
 		observer.subscribeWithPriority(
-			target.opponentPlayer.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.IGNORE_CARDS,
 			(attack) => {
+				if (attack.player.entity !== target.opponentPlayer.entity) return
 				if (!target.slot.inRow()) return
 				attack.shouldIgnoreCards.push(
 					query.card.slot(

--- a/common/status-effects/invisibility-potion.ts
+++ b/common/status-effects/invisibility-potion.ts
@@ -14,7 +14,7 @@ export const InvisibilityPotionHeadsEffect: StatusEffect<PlayerComponent> = {
 	name: 'Hidden!',
 	description: "Your opponent's next attack will miss.",
 	onApply(
-		_game: GameModel,
+		game: GameModel,
 		effect: StatusEffectComponent,
 		player: PlayerComponent,
 		observer: ObserverComponent,
@@ -22,9 +22,10 @@ export const InvisibilityPotionHeadsEffect: StatusEffect<PlayerComponent> = {
 		let multipliedDamage = false
 
 		observer.subscribeWithPriority(
-			player.opponentPlayer.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.MODIFY_DAMAGE,
 			(attack) => {
+				if (attack.player.entity !== player.opponentPlayer.entity) return
 				if (!attack.isType('primary', 'secondary')) return
 				multipliedDamage = true
 				attack.multiplyDamage(effect.entity, 0)
@@ -47,7 +48,7 @@ export const InvisibilityPotionTailsEffect: StatusEffect<PlayerComponent> = {
 	name: 'Spotted!',
 	description: "Your opponent's next attack will deal double damage.",
 	onApply(
-		_game: GameModel,
+		game: GameModel,
 		effect: StatusEffectComponent,
 		player: PlayerComponent,
 		observer: ObserverComponent,
@@ -55,9 +56,10 @@ export const InvisibilityPotionTailsEffect: StatusEffect<PlayerComponent> = {
 		let multipliedDamage = false
 
 		observer.subscribeWithPriority(
-			player.opponentPlayer.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.MODIFY_DAMAGE,
 			(attack) => {
+				if (attack.player.entity !== player.opponentPlayer.entity) return
 				if (!attack.isType('primary', 'secondary')) return
 				multipliedDamage = true
 				attack.multiplyDamage(effect.entity, 2)

--- a/common/status-effects/poison.ts
+++ b/common/status-effects/poison.ts
@@ -4,7 +4,7 @@ import {
 	StatusEffectComponent,
 } from '../components'
 import {GameModel} from '../models/game-model'
-import {afterDefence, onTurnEnd} from '../types/priorities'
+import {afterAttack, onTurnEnd} from '../types/priorities'
 import {executeExtraAttacks} from '../utils/attacks'
 import {StatusEffect, damageEffect} from './status-effect'
 
@@ -22,7 +22,7 @@ const PoisonEffect: StatusEffect<CardComponent> = {
 		target: CardComponent,
 		observer: ObserverComponent,
 	) {
-		const {player, opponentPlayer} = target
+		const {opponentPlayer} = target
 
 		observer.subscribeWithPriority(
 			opponentPlayer.hooks.onTurnEnd,
@@ -51,8 +51,8 @@ const PoisonEffect: StatusEffect<CardComponent> = {
 		)
 
 		observer.subscribeWithPriority(
-			player.hooks.afterDefence,
-			afterDefence.ON_ROW_DEATH,
+			game.globalHooks.afterAttack,
+			afterAttack.ON_ROW_DEATH,
 			(attack) => {
 				if (!attack.isTargeting(target) || attack.target?.health) return
 				effect.remove()

--- a/common/status-effects/poison.ts
+++ b/common/status-effects/poison.ts
@@ -52,7 +52,7 @@ const PoisonEffect: StatusEffect<CardComponent> = {
 
 		observer.subscribeWithPriority(
 			game.globalHooks.afterAttack,
-			afterAttack.ON_ROW_DEATH,
+			afterAttack.UPDATE_POST_ATTACK_STATE,
 			(attack) => {
 				if (!attack.isTargeting(target) || attack.target?.health) return
 				effect.remove()

--- a/common/status-effects/royal-protection.ts
+++ b/common/status-effects/royal-protection.ts
@@ -4,7 +4,7 @@ import {
 	StatusEffectComponent,
 } from '../components'
 import {GameModel} from '../models/game-model'
-import {beforeDefence} from '../types/priorities'
+import {beforeAttack} from '../types/priorities'
 import {StatusEffect, statusEffect} from './status-effect'
 
 const RoyalProtectionEffect: StatusEffect<CardComponent> = {
@@ -16,14 +16,14 @@ const RoyalProtectionEffect: StatusEffect<CardComponent> = {
 		'Any damage dealt to a Hermit under Royal Protection is prevented.',
 	applyLog: (values) => `${values.target} was granted $eRoyal Protection$`,
 	onApply(
-		_game: GameModel,
+		game: GameModel,
 		effect: StatusEffectComponent<CardComponent>,
 		target: CardComponent,
 		observer: ObserverComponent,
 	): void {
 		observer.subscribeWithPriority(
-			target.player.hooks.beforeDefence,
-			beforeDefence.HERMIT_BLOCK_DAMAGE,
+			game.globalHooks.beforeAttack,
+			beforeAttack.HERMIT_BLOCK_DAMAGE,
 			(attack) => {
 				if (!attack.isTargeting(target)) return
 

--- a/common/status-effects/sheep-stare.ts
+++ b/common/status-effects/sheep-stare.ts
@@ -18,7 +18,7 @@ const SheepStareEffect: StatusEffect<PlayerComponent> = {
 	description:
 		'When you attack, flip a coin. If heads, the attacking hermit attacks themselves. Lasts until you attack or the end of the turn.',
 	onApply(
-		_game: GameModel,
+		game: GameModel,
 		effect: StatusEffectComponent,
 		player: PlayerComponent,
 		observer: ObserverComponent,
@@ -26,9 +26,10 @@ const SheepStareEffect: StatusEffect<PlayerComponent> = {
 		let coinFlipResult: CoinFlipResult | null = null
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.HERMIT_CHANGE_TARGET,
 			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (!attack.isAttacker(player.getActiveHermit()?.entity)) return
 
 				// No need to flip a coin for multiple attacks
@@ -55,9 +56,10 @@ const SheepStareEffect: StatusEffect<PlayerComponent> = {
 		)
 
 		observer.subscribeWithPriority(
-			player.hooks.afterAttack,
+			game.globalHooks.afterAttack,
 			afterAttack.UPDATE_POST_ATTACK_STATE,
-			() => {
+			(attack) => {
+				if (attack.player.entity !== player.entity) return
 				if (coinFlipResult) effect.remove()
 			},
 		)

--- a/common/status-effects/sleeping.ts
+++ b/common/status-effects/sleeping.ts
@@ -4,7 +4,7 @@ import {
 	StatusEffectComponent,
 } from '../components'
 import {GameModel} from '../models/game-model'
-import {afterDefence} from '../types/priorities'
+import {afterAttack} from '../types/priorities'
 import {Counter, statusEffect} from './status-effect'
 
 const SleepingEffect: Counter<CardComponent> = {
@@ -63,8 +63,8 @@ const SleepingEffect: Counter<CardComponent> = {
 		})
 
 		observer.subscribeWithPriority(
-			player.hooks.afterDefence,
-			afterDefence.ON_ROW_DEATH,
+			game.globalHooks.afterAttack,
+			afterAttack.ON_ROW_DEATH,
 			(_attack) => {
 				if (!target.isAlive()) effect.remove()
 			},

--- a/common/status-effects/sleeping.ts
+++ b/common/status-effects/sleeping.ts
@@ -64,7 +64,7 @@ const SleepingEffect: Counter<CardComponent> = {
 
 		observer.subscribeWithPriority(
 			game.globalHooks.afterAttack,
-			afterAttack.ON_ROW_DEATH,
+			afterAttack.UPDATE_POST_ATTACK_STATE,
 			(_attack) => {
 				if (!target.isAlive()) effect.remove()
 			},

--- a/common/status-effects/slowness.ts
+++ b/common/status-effects/slowness.ts
@@ -4,7 +4,7 @@ import {
 	StatusEffectComponent,
 } from '../components'
 import {GameModel} from '../models/game-model'
-import {afterDefence, onTurnEnd} from '../types/priorities'
+import {afterAttack, onTurnEnd} from '../types/priorities'
 import {Counter, statusEffect} from './status-effect'
 
 const SlownessEffect: Counter<CardComponent> = {
@@ -48,8 +48,8 @@ const SlownessEffect: Counter<CardComponent> = {
 		)
 
 		observer.subscribeWithPriority(
-			player.hooks.afterDefence,
-			afterDefence.ON_ROW_DEATH,
+			game.globalHooks.afterAttack,
+			afterAttack.ON_ROW_DEATH,
 			(attack) => {
 				if (
 					!target.slot?.onBoard() ||

--- a/common/status-effects/slowness.ts
+++ b/common/status-effects/slowness.ts
@@ -49,7 +49,7 @@ const SlownessEffect: Counter<CardComponent> = {
 
 		observer.subscribeWithPriority(
 			game.globalHooks.afterAttack,
-			afterAttack.ON_ROW_DEATH,
+			afterAttack.UPDATE_POST_ATTACK_STATE,
 			(attack) => {
 				if (
 					!target.slot?.onBoard() ||

--- a/common/status-effects/target-block.ts
+++ b/common/status-effects/target-block.ts
@@ -14,7 +14,7 @@ export const TargetBlockEffect: StatusEffect<CardComponent> = {
 	name: 'Made the target!',
 	description: 'This hermit will take all damage this turn.',
 	onApply(
-		_game: GameModel,
+		game: GameModel,
 		effect: StatusEffectComponent,
 		target: CardComponent,
 		observer: ObserverComponent,
@@ -22,9 +22,10 @@ export const TargetBlockEffect: StatusEffect<CardComponent> = {
 		let {opponentPlayer} = target
 		// Redirect all future attacks this turn
 		observer.subscribeWithPriority(
-			opponentPlayer.hooks.beforeAttack,
+			game.globalHooks.beforeAttack,
 			beforeAttack.TARGET_BLOCK_REDIRECT,
 			(attack) => {
+				if (attack.player.entity !== opponentPlayer.entity) return
 				if (attack.isType('status-effect') || attack.isBacklash) return
 				if (!target.slot.inRow()) return
 				attack.redirect(effect.entity, target.slot.row.entity)

--- a/common/status-effects/weakness.ts
+++ b/common/status-effects/weakness.ts
@@ -4,7 +4,7 @@ import {
 	StatusEffectComponent,
 } from '../components'
 import {GameModel} from '../models/game-model'
-import {beforeDefence} from '../types/priorities'
+import {beforeAttack} from '../types/priorities'
 import {Counter, statusEffect} from './status-effect'
 
 const WeaknessEffect: Counter<CardComponent> = {
@@ -16,7 +16,7 @@ const WeaknessEffect: Counter<CardComponent> = {
 	counter: 3,
 	counterType: 'turns',
 	onApply(
-		_game: GameModel,
+		game: GameModel,
 		effect: StatusEffectComponent,
 		target: CardComponent,
 		observer: ObserverComponent,
@@ -33,8 +33,8 @@ const WeaknessEffect: Counter<CardComponent> = {
 		})
 
 		observer.subscribeWithPriority(
-			player.hooks.beforeDefence,
-			beforeDefence.FORCE_WEAKNESS_ATTACK,
+			game.globalHooks.beforeAttack,
+			beforeAttack.FORCE_WEAKNESS_ATTACK,
 			(attack) => {
 				if (!target.slot.inRow()) return
 				if (

--- a/common/types/priorities.ts
+++ b/common/types/priorities.ts
@@ -73,12 +73,8 @@ export const afterAttack = createPriorityDictionary({
 	UPDATE_POST_ATTACK_STATE: null,
 	/** When it is safe for Hermit attacks to remove the card in the single use slot */
 	HERMIT_REMOVE_SINGLE_USE: null,
-	/** Shield can now discard itself if it blocked any damage */
-	DISCARD_SHIELD: null,
 	/** Gas Light effect reacting to target taking damage, to be damaged at end of turn */
 	TRIGGER_GAS_LIGHT: null,
-	/** Listeners can confidently execute after a row has been knocked-out */
-	ON_ROW_DEATH: null,
 	/** All hermit attack logic should occur before this, to support mocking with Puppetry/Role Play */
 	DESTROY_MOCK_CARD: null,
 })

--- a/common/types/priorities.ts
+++ b/common/types/priorities.ts
@@ -43,9 +43,6 @@ export const beforeAttack = createPriorityDictionary({
 	HERMIT_APPLY_ATTACK: null,
 	/** Any attacking single-use cards must call `applySingleUse` at this stage */
 	APPLY_SINGLE_USE_ATTACK: null,
-})
-
-export const beforeDefence = createPriorityDictionary({
 	/** Hermits blocking all damage done by certain attacks */
 	HERMIT_BLOCK_DAMAGE: null,
 	/** Effect cards blocking all damage done by certain attacks */
@@ -60,11 +57,14 @@ export const beforeDefence = createPriorityDictionary({
 	EFFECT_CREATE_BACKLASH: null,
 })
 
-export const afterAttack = createPriorityDictionary({
+export const rowRevive = createPriorityDictionary({
 	/** Deathloop may revive their row (does not trigger an attached Totem when present) */
 	DEATHLOOP_REVIVE: null,
 	/** Totems may revive their row and be discarded */
 	TOTEM_REVIVE: null,
+})
+
+export const afterAttack = createPriorityDictionary({
 	/** Hermit attacks add any requests dependent on the new board state */
 	HERMIT_ATTACK_REQUESTS: null,
 	/** Effect cards that take effect after attacking can add their requests */
@@ -73,17 +73,14 @@ export const afterAttack = createPriorityDictionary({
 	UPDATE_POST_ATTACK_STATE: null,
 	/** When it is safe for Hermit attacks to remove the card in the single use slot */
 	HERMIT_REMOVE_SINGLE_USE: null,
-	/** All hermit attack logic should occur before this, to support mocking with Puppetry/Role Play */
-	DESTROY_MOCK_CARD: null,
-})
-
-export const afterDefence = createPriorityDictionary({
 	/** Shield can now discard itself if it blocked any damage */
 	DISCARD_SHIELD: null,
 	/** Gas Light effect reacting to target taking damage, to be damaged at end of turn */
 	TRIGGER_GAS_LIGHT: null,
 	/** Listeners can confidently execute after a row has been knocked-out */
 	ON_ROW_DEATH: null,
+	/** All hermit attack logic should occur before this, to support mocking with Puppetry/Role Play */
+	DESTROY_MOCK_CARD: null,
 })
 
 export const onTurnEnd = createPriorityDictionary({

--- a/common/types/priorities.ts
+++ b/common/types/priorities.ts
@@ -53,8 +53,8 @@ export const beforeAttack = createPriorityDictionary({
 	EFFECT_REDUCE_DAMAGE: null,
 	/** Effects such as buckets can remove status effects created by an attack */
 	EFFECT_REMOVE_STATUS: null,
-	/** Effects reacting to the whether the attack's target will be damaged */
-	EFFECT_CREATE_BACKLASH: null,
+	/** Listeners reacting to the whether the attack's target will be damaged */
+	REACT_TO_DAMAGE: null,
 })
 
 export const rowRevive = createPriorityDictionary({
@@ -73,8 +73,6 @@ export const afterAttack = createPriorityDictionary({
 	UPDATE_POST_ATTACK_STATE: null,
 	/** When it is safe for Hermit attacks to remove the card in the single use slot */
 	HERMIT_REMOVE_SINGLE_USE: null,
-	/** Gas Light effect reacting to target taking damage, to be damaged at end of turn */
-	TRIGGER_GAS_LIGHT: null,
 	/** All hermit attack logic should occur before this, to support mocking with Puppetry/Role Play */
 	DESTROY_MOCK_CARD: null,
 })

--- a/common/utils/attacks.ts
+++ b/common/utils/attacks.ts
@@ -60,6 +60,22 @@ function runBeforeDefenceHooks(game: GameModel, attacks: Array<AttackModel>) {
 	}
 }
 
+function runRowReviveHooks(game: GameModel, attacks: Array<AttackModel>) {
+	for (let i = 0; i < attacks.length; i++) {
+		const attack = attacks[i]
+
+		// Call after attack hooks
+		game.globalHooks.rowRevive.callSome([attack], (observer) => {
+			let entity = game.components.get(
+				game.components.get(observer)?.wrappingEntity || null,
+			)
+			if (entity instanceof CardComponent)
+				return !shouldIgnoreCard(attack, game, entity)
+			return true
+		})
+	}
+}
+
 function runAfterAttackHooks(game: GameModel, attacks: Array<AttackModel>) {
 	for (let i = 0; i < attacks.length; i++) {
 		const attack = attacks[i]
@@ -138,6 +154,7 @@ export function executeAttacks(game: GameModel, attacks: Array<AttackModel>) {
 	}
 
 	// STEP 6 - After all attacks have been executed, call after attack and defence hooks
+	runRowReviveHooks(game, allAttacks)
 	runAfterAttackHooks(game, allAttacks)
 	runAfterDefenceHooks(game, allAttacks)
 }

--- a/server/src/routines/matchmaking.ts
+++ b/server/src/routines/matchmaking.ts
@@ -140,7 +140,7 @@ function* gameManager(game: GameModel) {
 		broadcast(game.getPlayers(), {type: serverMessages.GAME_CRASH})
 	} finally {
 		if (game.task) yield* cancel(game.task)
-		game.afterGameEnd.call()
+		game.globalHooks.afterGameEnd.call()
 
 		const gameType = game.code ? 'Private' : 'Public'
 		console.log(

--- a/server/src/utils/index.ts
+++ b/server/src/utils/index.ts
@@ -5,7 +5,9 @@ import {
 } from 'common/components'
 import query from 'common/components/query'
 import {ViewerComponent} from 'common/components/viewer-component'
+import {ObserverEntity} from 'common/entities'
 import {GameModel} from 'common/models/game-model'
+import {Hook, PriorityHook} from 'common/types/hooks'
 
 export const getOpponentId = (game: GameModel, playerId: string) => {
 	const players = game.components
@@ -33,10 +35,14 @@ export function printHooksState(game: GameModel) {
 	// Second loop to populate instancesInfo and customValues
 	for (const player of [currentPlayer, opponentPlayer]) {
 		// Instance Info
-		for (const [hookName, hookValue] of Object.entries(player.hooks)) {
+		for (const [hookName, hookValue] of [
+			...Object.entries(player.hooks),
+			...Object.entries(game.globalHooks),
+		] satisfies [string, Hook<string, any> | PriorityHook<any, any>][]) {
 			hookValue.listeners.forEach(([observer, _args, _key], i) => {
 				let target = game.components.get(
-					game.components.get(observer)?.wrappingEntity || null,
+					game.components.get(observer as ObserverEntity)?.wrappingEntity ||
+						null,
 				)
 				if (!(target instanceof CardComponent)) return
 				const pos = target.slot

--- a/tests/unit/game/effects/totem.test.ts
+++ b/tests/unit/game/effects/totem.test.ts
@@ -3,6 +3,7 @@ import Thorns from 'common/cards/default/effects/thorns'
 import Totem from 'common/cards/default/effects/totem'
 import EthosLabCommon from 'common/cards/default/hermits/ethoslab-common'
 import GoodTimesWithScarRare from 'common/cards/default/hermits/goodtimeswithscar-rare'
+import IJevinRare from 'common/cards/default/hermits/ijevin-rare'
 import Iskall85Common from 'common/cards/default/hermits/iskall85-common'
 import PearlescentMoonCommon from 'common/cards/default/hermits/pearlescentmoon-common'
 import WelsknightCommon from 'common/cards/default/hermits/welsknight-common'
@@ -25,7 +26,6 @@ import {
 	playCardFromHand,
 	testGame,
 } from '../utils'
-import IJevinRare from 'common/cards/default/hermits/ijevin-rare'
 
 describe('Test Totem of Undying', () => {
 	test('Test Totem with TNT', () => {

--- a/tests/unit/game/effects/totem.test.ts
+++ b/tests/unit/game/effects/totem.test.ts
@@ -25,6 +25,7 @@ import {
 	playCardFromHand,
 	testGame,
 } from '../utils'
+import IJevinRare from 'common/cards/default/hermits/ijevin-rare'
 
 describe('Test Totem of Undying', () => {
 	test('Test Totem with TNT', () => {
@@ -318,6 +319,42 @@ describe('Test Totem of Undying', () => {
 				},
 			},
 			{startWithAllCards: true},
+		)
+	})
+
+	test('Test Totem revives rows before `afterAttack` requests are created', () => {
+		testGame(
+			{
+				playerOneDeck: [EthosLabCommon, Iskall85Common, Totem],
+				playerTwoDeck: [IJevinRare, Bow],
+				saga: function* (game) {
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
+					yield* playCardFromHand(game, Iskall85Common, 'hermit', 1)
+					yield* playCardFromHand(game, Totem, 'attach', 1)
+					yield* endTurn(game)
+
+					// Manually set Iskall health to trigger zone
+					game.components.find(
+						RowComponent,
+						query.row.opponentPlayer,
+						query.row.index(1),
+					)!.health = 10
+
+					yield* playCardFromHand(game, IJevinRare, 'hermit', 0)
+					yield* playCardFromHand(game, Bow, 'single_use')
+					yield* attack(game, 'secondary')
+					yield* pick(
+						game,
+						query.slot.opponent,
+						query.slot.hermit,
+						query.slot.rowIndex(1),
+					)
+
+					// "Peace Out" should create a request for the opponent to pick their AFK Hermit
+					expect(game.state.pickRequests).toHaveLength(1)
+				},
+			},
+			{startWithAllCards: true, noItemRequirements: true},
 		)
 	})
 })

--- a/tests/unit/game/hermits/skizzleman-rare.test.ts
+++ b/tests/unit/game/hermits/skizzleman-rare.test.ts
@@ -2,11 +2,20 @@ import {describe, expect, test} from '@jest/globals'
 import Anvil from 'common/cards/alter-egos/single-use/anvil'
 import GoldArmor from 'common/cards/default/effects/gold-armor'
 import Thorns from 'common/cards/default/effects/thorns'
+import Totem from 'common/cards/default/effects/totem'
 import EthosLabCommon from 'common/cards/default/hermits/ethoslab-common'
+import LavaBucket from 'common/cards/default/single-use/lava-bucket'
 import SkizzlemanRare from 'common/cards/season-x/hermits/skizzleman-rare'
 import {RowComponent} from 'common/components'
 import query from 'common/components/query'
-import {attack, endTurn, playCardFromHand, testGame} from '../utils'
+import {
+	applyEffect,
+	attack,
+	changeActiveHermit,
+	endTurn,
+	playCardFromHand,
+	testGame,
+} from '../utils'
 
 describe('Test Skizzleman Rare', () => {
 	test('Gaslight works as intended', () => {
@@ -104,6 +113,77 @@ describe('Test Skizzleman Rare', () => {
 							query.row.index(1),
 						)?.health,
 					).toBe(EthosLabCommon.health)
+				},
+			},
+			{startWithAllCards: true, noItemRequirements: true},
+		)
+	})
+
+	test('Totem keeps hermits alive when damaged by Gaslight and Burn at end of turn', () => {
+		testGame(
+			{
+				playerOneDeck: [
+					EthosLabCommon,
+					EthosLabCommon,
+					EthosLabCommon,
+					Totem,
+					Totem,
+				],
+				playerTwoDeck: [SkizzlemanRare, LavaBucket, LavaBucket, Anvil],
+				saga: function* (game) {
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 1)
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 2)
+					yield* playCardFromHand(game, Totem, 'attach', 0)
+					yield* playCardFromHand(game, Totem, 'attach', 2)
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, SkizzlemanRare, 'hermit', 1)
+					yield* playCardFromHand(game, LavaBucket, 'single_use')
+					yield* applyEffect(game)
+					yield* endTurn(game)
+
+					yield* changeActiveHermit(game, 2)
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, LavaBucket, 'single_use')
+					yield* applyEffect(game)
+					yield* endTurn(game)
+
+					yield* changeActiveHermit(game, 1)
+					yield* endTurn(game)
+
+					// Manually set Etho (1) health to trigger zone
+					game.components.find(
+						RowComponent,
+						query.row.opponentPlayer,
+						query.row.index(0),
+					)!.health = 20
+					// Manually set Etho (3) health to trigger zone
+					game.components.find(
+						RowComponent,
+						query.row.opponentPlayer,
+						query.row.index(2),
+					)!.health = 30
+
+					yield* playCardFromHand(game, Anvil, 'single_use')
+					yield* attack(game, 'secondary')
+					yield* endTurn(game)
+
+					expect(
+						game.components.find(
+							RowComponent,
+							query.row.currentPlayer,
+							query.row.index(0),
+						)?.health,
+					).toBe(10) // Check Burn -> Gas Light
+					expect(
+						game.components.find(
+							RowComponent,
+							query.row.currentPlayer,
+							query.row.index(2),
+						)?.health,
+					).toBe(10) // Check Anvil -> Gas Light + Burn
 				},
 			},
 			{startWithAllCards: true, noItemRequirements: true},


### PR DESCRIPTION
- Moves attack hooks and `freezeSlots` to GameModel
- Removes `beforeDefence` and `afterDefence` hooks
- Adds type `ReadonlyAttackModel` to prevent modifying attacks after execution
- Fixes issues with reviving rows by adding a dedicated hook to the attack cycle
- Adds explicit typing to calling hooks