### PR TITLE
Use GNU Parallel To Improve Build Speed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ COPY . .
 
 COPY common/config/debug-config.example.json common/config/debug-config.json
 
+RUN apt-get install -y parallel
+
 RUN npm ci && npm run build
 # Remove the build-time dependencies to keep the image small and enable node optimizations.
 ENV NODE_ENV production

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
 		"dev": "npm run client:dev & npm run server:dev",
 		"husky": "husky install",
 		"clean": "rm -rf client/dist && rm -rf server/dist",
-		"build": "npm run client:build && npm run server:build",
+		"build": "parallel npm run ::: client:build server:build",
 		"server": "node --enable-source-maps server/dist/index.js",
 		"server:build": "npm run server:tsc && node esbuild.js",
 		"server:dev": "tsx watch --tsconfig server/tsconfig.json server/src",


### PR DESCRIPTION
This reduces build times by 5s on my machine and GitHub actions. Not sure if its worth it. Vite and tsc I think can only use one core so it probably helps a bit there but Its hard for me to know.