### PR TITLE
Fix interactions with ultra-rare TFC and rare Worm Man

### DIFF
--- a/common/cards/alter-egos-iii/hermits/wormman-rare.ts
+++ b/common/cards/alter-egos-iii/hermits/wormman-rare.ts
@@ -1,12 +1,8 @@
 import {CardComponent, ObserverComponent} from '../../../components'
-import {ObserverEntity} from '../../../entities'
 import {GameModel} from '../../../models/game-model'
 import {afterAttack, onTurnEnd} from '../../../types/priorities'
-import {InstancedValue} from '../../base/card'
 import {hermit} from '../../base/defaults'
 import {Hermit} from '../../base/types'
-
-const observers = new InstancedValue<Array<ObserverEntity>>(() => [])
 
 const WormManRare: Hermit = {
 	...hermit,
@@ -41,6 +37,8 @@ const WormManRare: Hermit = {
 	): void {
 		const {player} = component
 
+		let pendingObserver: ObserverComponent | null = null
+
 		observer.subscribeWithPriority(
 			player.hooks.afterAttack,
 			afterAttack.UPDATE_POST_ATTACK_STATE,
@@ -50,29 +48,34 @@ const WormManRare: Hermit = {
 
 				game.removeBlockedActions('game', 'PLAY_HERMIT_CARD')
 
-				observer.subscribe(player.hooks.onAttach, (attachedComponent) => {
-					game.addBlockedActions(this.id, 'PLAY_HERMIT_CARD')
-					attachedComponent.turnedOver = true
+				pendingObserver = game.components.new(
+					ObserverComponent,
+					component.entity,
+				)
 
-					const newObserver = game.components.new(
-						ObserverComponent,
-						attachedComponent.entity,
-					)
-					observers.set(component, [
-						...observers.get(component),
-						newObserver.entity,
-					])
+				const newObserver = pendingObserver
+				newObserver.subscribe(player.hooks.onAttach, (attachedComponent) => {
+					game.addBlockedActions(this.id, 'PLAY_HERMIT_CARD')
+					newObserver.unsubscribe(player.hooks.onAttach)
+					pendingObserver = null
+					if (!component.slot.onBoard()) return
+
+					attachedComponent.turnedOver = true
 
 					newObserver.subscribe(
 						player.hooks.onActiveRowChange,
 						(_oldActiveHermit, newActiveHermit) => {
 							if (newActiveHermit.entity !== attachedComponent.entity) return
 							attachedComponent.turnedOver = false
-							newObserver.unsubscribe(player.hooks.freezeSlots)
+							newObserver.unsubscribeFromEverything()
 						},
 					)
 
-					observer.unsubscribe(player.hooks.onAttach)
+					newObserver.subscribe(player.hooks.onDetach, (instance) => {
+						if (instance.entity !== component.entity) return
+						attachedComponent.turnedOver = false
+						newObserver.unsubscribeFromEverything()
+					})
 				})
 			},
 		)
@@ -81,26 +84,10 @@ const WormManRare: Hermit = {
 			player.hooks.onTurnEnd,
 			onTurnEnd.BEFORE_STATUS_EFFECT_TIMEOUT,
 			() => {
-				observer.unsubscribe(player.hooks.onAttach)
+				pendingObserver?.unsubscribe(player.hooks.onAttach)
+				pendingObserver = null
 			},
 		)
-	},
-	onDetach(
-		game: GameModel,
-		component: CardComponent,
-		_observer: ObserverComponent,
-	): void {
-		const {player} = component
-
-		observers.get(component).forEach((observerEntity) => {
-			const observer = game.components.get(observerEntity)
-			if (!observer) return
-			observer.unsubscribe(player.hooks.onActiveRowChange)
-
-			const attachedCard = game.components.get(observer.wrappingEntity)
-			if (!attachedCard || !(attachedCard instanceof CardComponent)) return
-			attachedCard.turnedOver = false
-		})
 	},
 }
 

--- a/common/cards/default/hermits/tinfoilchef-ultra-rare.ts
+++ b/common/cards/default/hermits/tinfoilchef-ultra-rare.ts
@@ -1,7 +1,12 @@
-import {CardComponent, ObserverComponent} from '../../../components'
+import {
+	CardComponent,
+	ObserverComponent,
+	StatusEffectComponent,
+} from '../../../components'
 import query from '../../../components/query'
 import {RowEntity} from '../../../entities'
 import {GameModel} from '../../../models/game-model'
+import TFCDiscardedFromEffect from '../../../status-effects/tfc-discarded-from'
 import {beforeAttack} from '../../../types/priorities'
 import {flipCoin} from '../../../utils/coinFlips'
 import {hermit} from '../../base/defaults'
@@ -37,7 +42,14 @@ const TinFoilChefUltraRare: Hermit = {
 	) {
 		const {player, opponentPlayer} = component
 
-		let hasDiscardedFrom = new Set<RowEntity>()
+		const hasDiscardedFrom = (row: RowEntity): boolean => {
+			return game.components.exists(
+				StatusEffectComponent,
+				query.effect.is(TFCDiscardedFromEffect),
+				query.effect.targetIsCardAnd(query.card.rowEntity(row)),
+				(_game, value) => value.creatorEntity === component.entity,
+			)
+		}
 
 		let targetCardQuery = query.every(
 			query.card.active,
@@ -54,13 +66,15 @@ const TinFoilChefUltraRare: Hermit = {
 
 				if (opponentPlayer.activeRow === null) return
 				// Can't discard two effect cards on the same hermit
-				if (hasDiscardedFrom.has(opponentPlayer.activeRow.entity)) return
+				if (hasDiscardedFrom(opponentPlayer.activeRow.entity)) return
 				if (!game.components.exists(CardComponent, targetCardQuery)) return
 
 				const coinFlip = flipCoin(player, component)
 				if (coinFlip[0] === 'tails') return
 
-				hasDiscardedFrom.add(opponentPlayer.activeRow.entity)
+				game.components
+					.new(StatusEffectComponent, TFCDiscardedFromEffect, component.entity)
+					.apply(opponentPlayer.activeRow.getHermit()?.entity)
 
 				game.components.find(CardComponent, targetCardQuery)?.discard()
 			},

--- a/common/models/battle-log-model.ts
+++ b/common/models/battle-log-model.ts
@@ -122,15 +122,17 @@ export class BattleLogModel {
 		if (card == null) return '$bINVALID VALUE$'
 
 		if (
-			card.props.category === 'hermit' &&
+			card.slot.type === 'hermit' &&
 			player &&
 			player.activeRowEntity !== row?.entity &&
 			row?.index !== undefined
 		) {
-			return `${card.props.name} (${row?.index + 1})`
+			return card.turnedOver
+				? `??? (${row.index + 1})`
+				: `${card.props.name} (${row?.index + 1})`
 		}
 
-		return `${card.props.name}`
+		return card.turnedOver ? '???' : `${card.props.name}`
 	}
 
 	public addPlayCardEntry(

--- a/common/status-effects/index.ts
+++ b/common/status-effects/index.ts
@@ -38,6 +38,7 @@ import SlownessEffect from './slowness'
 import SmeltingEffect from './smelting'
 import {StatusEffect} from './status-effect'
 import {TargetBlockEffect} from './target-block'
+import TFCDiscardedFromEffect from './tfc-discarded-from'
 import {TrapHoleEffect} from './trap-hole'
 import TurnSkippedEffect from './turn-skipped'
 import UsedClockEffect from './used-clock'
@@ -84,6 +85,7 @@ export const STATUS_EFFECTS_LIST: Array<StatusEffect> = [
 	IgnoreAttachSlotEffect,
 	EfficiencyEffect,
 	LooseShellEffect,
+	TFCDiscardedFromEffect,
 ]
 
 export const STATUS_EFFECTS: Record<string, StatusEffect> =

--- a/common/status-effects/tfc-discarded-from.ts
+++ b/common/status-effects/tfc-discarded-from.ts
@@ -1,0 +1,17 @@
+import {CardComponent} from '../components'
+import {hiddenStatusEffect, StatusEffect} from './status-effect'
+
+const TFCDiscardedFromEffect: StatusEffect<CardComponent> = {
+	...hiddenStatusEffect,
+	id: 'tfc-discarded-from',
+	onApply(_game, effect, target, observer) {
+		observer.subscribe(effect.creator.player.hooks.onDetach, (instance) => {
+			if (instance.entity === effect.creatorEntity) effect.remove()
+		})
+		observer.subscribe(target.player.hooks.onDetach, (instance) => {
+			if (instance.entity === target.entity) effect.remove()
+		})
+	},
+}
+
+export default TFCDiscardedFromEffect

--- a/common/status-effects/tfc-discarded-from.ts
+++ b/common/status-effects/tfc-discarded-from.ts
@@ -1,5 +1,5 @@
 import {CardComponent} from '../components'
-import {hiddenStatusEffect, StatusEffect} from './status-effect'
+import {StatusEffect, hiddenStatusEffect} from './status-effect'
 
 const TFCDiscardedFromEffect: StatusEffect<CardComponent> = {
 	...hiddenStatusEffect,

--- a/server/src/utils/index.ts
+++ b/server/src/utils/index.ts
@@ -164,6 +164,7 @@ export function printBoardState(game: GameModel) {
 
 		if (card) {
 			let name = card.props.name
+			if (card.turnedOver) name = '?' + name
 
 			if (
 				slot.inRow() &&
@@ -176,6 +177,7 @@ export function printBoardState(game: GameModel) {
 			buffer.push(name.slice(0, 10).padEnd(11))
 			if (slot.type === 'hermit' && slot.inRow() && slot.row.health) {
 				buffer.push(slot.row.health)
+				if (card.turnedOver) buffer.push('?')
 
 				buffer.push(
 					...game.components

--- a/tests/unit/game/hermits/tinfoilchef-ultra-rare.test.ts
+++ b/tests/unit/game/hermits/tinfoilchef-ultra-rare.test.ts
@@ -1,0 +1,341 @@
+import {describe, expect, test} from '@jest/globals'
+import TinFoilChefUltraRare from 'common/cards/default/hermits/tinfoilchef-ultra-rare'
+import query from 'common/components/query'
+import {
+	attack,
+	changeActiveHermit,
+	endTurn,
+	finishModalRequest,
+	pick,
+	playCardFromHand,
+	testGame,
+} from '../utils'
+import EthosLabCommon from 'common/cards/default/hermits/ethoslab-common'
+import ChainmailArmor from 'common/cards/alter-egos/effects/chainmail-armor'
+import {CardComponent} from 'common/components'
+import Ladder from 'common/cards/alter-egos/single-use/ladder'
+import Chest from 'common/cards/default/single-use/chest'
+import RendogRare from 'common/cards/default/hermits/rendog-rare'
+import ArmorStand from 'common/cards/alter-egos/effects/armor-stand'
+
+describe('Test Ultra Rare TFC "Take It Easy"', () => {
+	test('Can not discard two attach effects from the same hermit', () => {
+		testGame(
+			{
+				playerOneDeck: [EthosLabCommon, ChainmailArmor, ChainmailArmor],
+				playerTwoDeck: [TinFoilChefUltraRare],
+				saga: function* (game) {
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
+					yield* playCardFromHand(game, ChainmailArmor, 'attach', 0)
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, TinFoilChefUltraRare, 'hermit', 0)
+					yield* attack(game, 'secondary')
+
+					expect(
+						game.components.find(
+							CardComponent,
+							query.card.opponentPlayer,
+							query.card.slot(query.slot.discardPile),
+						)?.props,
+					).toBe(ChainmailArmor)
+
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, ChainmailArmor, 'attach', 0)
+					yield* endTurn(game)
+
+					yield* attack(game, 'secondary')
+
+					expect(
+						game.components.find(
+							CardComponent,
+							query.card.opponentPlayer,
+							query.card.active,
+							query.card.slot(query.slot.attach),
+						)?.props,
+					).toBe(ChainmailArmor)
+				},
+			},
+			{startWithAllCards: true, noItemRequirements: true, forceCoinFlip: true},
+		)
+	})
+
+	test('Can not discard twice after hermit swaps rows with Ladder', () => {
+		testGame(
+			{
+				playerOneDeck: [
+					EthosLabCommon,
+					EthosLabCommon,
+					ChainmailArmor,
+					ChainmailArmor,
+					Ladder,
+				],
+				playerTwoDeck: [TinFoilChefUltraRare],
+				saga: function* (game) {
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 1)
+					yield* playCardFromHand(game, ChainmailArmor, 'attach', 0)
+					yield* playCardFromHand(game, ChainmailArmor, 'attach', 1)
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, TinFoilChefUltraRare, 'hermit', 0)
+					yield* attack(game, 'secondary')
+
+					expect(
+						game.components.find(
+							CardComponent,
+							query.card.opponentPlayer,
+							query.card.slot(query.slot.discardPile),
+						)?.props,
+					).toBe(ChainmailArmor)
+
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, Ladder, 'single_use')
+					yield* pick(
+						game,
+						query.slot.currentPlayer,
+						query.slot.hermit,
+						query.slot.rowIndex(1),
+					)
+					yield* endTurn(game)
+
+					yield* attack(game, 'secondary')
+
+					expect(
+						game.components.find(
+							CardComponent,
+							query.card.opponentPlayer,
+							query.card.active,
+							query.card.slot(query.slot.attach),
+						)?.props,
+					).toBe(ChainmailArmor)
+				},
+			},
+			{startWithAllCards: true, noItemRequirements: true, forceCoinFlip: true},
+		)
+	})
+
+	test('Can discard from the same hermit after they are knocked-out', () => {
+		testGame(
+			{
+				playerOneDeck: [
+					EthosLabCommon,
+					EthosLabCommon,
+					ChainmailArmor,
+					Chest,
+					ChainmailArmor,
+				],
+				playerTwoDeck: [TinFoilChefUltraRare],
+				saga: function* (game) {
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 1)
+					yield* playCardFromHand(game, ChainmailArmor, 'attach', 0)
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, TinFoilChefUltraRare, 'hermit', 0)
+					yield* attack(game, 'secondary')
+
+					expect(
+						game.components.find(
+							CardComponent,
+							query.card.opponentPlayer,
+							query.card.slot(query.slot.discardPile),
+						)?.props,
+					).toBe(ChainmailArmor)
+
+					yield* endTurn(game)
+
+					yield* endTurn(game)
+
+					yield* attack(game, 'secondary')
+					yield* endTurn(game)
+
+					yield* endTurn(game)
+
+					yield* attack(game, 'secondary')
+					yield* endTurn(game)
+
+					yield* changeActiveHermit(game, 1)
+					yield* playCardFromHand(game, Chest, 'single_use')
+					yield* finishModalRequest(game, {
+						result: true,
+						cards: game.components.filterEntities(
+							CardComponent,
+							query.card.currentPlayer,
+							query.card.is(EthosLabCommon),
+							query.card.slot(query.slot.discardPile),
+						),
+					})
+
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
+					yield* playCardFromHand(game, ChainmailArmor, 'attach', 0)
+					yield* changeActiveHermit(game, 0)
+					yield* endTurn(game)
+
+					yield* attack(game, 'secondary')
+
+					expect(
+						game.components.find(
+							CardComponent,
+							query.card.opponentPlayer,
+							query.card.active,
+							query.card.slot(query.slot.attach),
+						),
+					).toBe(null)
+				},
+			},
+			{startWithAllCards: true, noItemRequirements: true, forceCoinFlip: true},
+		)
+	})
+
+	test('Can discard from the same hermit after TFC is knocked-out', () => {
+		testGame(
+			{
+				playerOneDeck: [EthosLabCommon, ChainmailArmor, ChainmailArmor],
+				playerTwoDeck: [TinFoilChefUltraRare, ArmorStand, Chest],
+				saga: function* (game) {
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
+					yield* playCardFromHand(game, ChainmailArmor, 'attach', 0)
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, TinFoilChefUltraRare, 'hermit', 0)
+					yield* playCardFromHand(game, ArmorStand, 'hermit', 1)
+					yield* attack(game, 'secondary')
+
+					expect(
+						game.components.find(
+							CardComponent,
+							query.card.opponentPlayer,
+							query.card.slot(query.slot.discardPile),
+						)?.props,
+					).toBe(ChainmailArmor)
+					yield* endTurn(game)
+
+					yield* attack(game, 'secondary')
+					yield* endTurn(game)
+
+					yield* endTurn(game)
+
+					yield* attack(game, 'secondary')
+					yield* endTurn(game)
+
+					yield* endTurn(game)
+
+					yield* attack(game, 'secondary')
+					yield* endTurn(game)
+
+					yield* changeActiveHermit(game, 1)
+					yield* playCardFromHand(game, Chest, 'single_use')
+					yield* finishModalRequest(game, {
+						result: true,
+						cards: game.components.filterEntities(
+							CardComponent,
+							query.card.currentPlayer,
+							query.card.is(TinFoilChefUltraRare),
+							query.card.slot(query.slot.discardPile),
+						),
+					})
+
+					yield* playCardFromHand(game, TinFoilChefUltraRare, 'hermit', 0)
+					yield* changeActiveHermit(game, 0)
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, ChainmailArmor, 'attach', 0)
+					yield* endTurn(game)
+
+					yield* attack(game, 'secondary')
+
+					expect(
+						game.components.find(
+							CardComponent,
+							query.card.opponentPlayer,
+							query.card.active,
+							query.card.slot(query.slot.attach),
+						),
+					).toBe(null)
+				},
+			},
+			{startWithAllCards: true, noItemRequirements: true, forceCoinFlip: true},
+		)
+	})
+
+	test('Can not discard when used by/facing Role Play', () => {
+		testGame(
+			{
+				playerOneDeck: [RendogRare, ChainmailArmor, ChainmailArmor],
+				playerTwoDeck: [TinFoilChefUltraRare, ChainmailArmor, ChainmailArmor],
+				saga: function* (game) {
+					yield* playCardFromHand(game, RendogRare, 'hermit', 0)
+					yield* playCardFromHand(game, ChainmailArmor, 'attach', 0)
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, TinFoilChefUltraRare, 'hermit', 0)
+					yield* playCardFromHand(game, ChainmailArmor, 'attach', 0)
+					yield* attack(game, 'secondary')
+
+					expect(
+						game.components.find(
+							CardComponent,
+							query.card.opponentPlayer,
+							query.card.slot(query.slot.discardPile),
+						)?.props,
+					).toBe(ChainmailArmor)
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, ChainmailArmor, 'attach', 0)
+					yield* attack(game, 'secondary')
+					yield* pick(
+						game,
+						query.slot.opponent,
+						query.slot.active,
+						query.slot.hermit,
+					)
+					yield* finishModalRequest(game, {pick: 'secondary'})
+
+					expect(
+						game.components.find(
+							CardComponent,
+							query.card.opponentPlayer,
+							query.card.slot(query.slot.discardPile),
+						)?.props,
+					).toBe(ChainmailArmor)
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, ChainmailArmor, 'attach', 0)
+					yield* attack(game, 'secondary')
+
+					expect(
+						game.components.find(
+							CardComponent,
+							query.card.opponentPlayer,
+							query.card.active,
+							query.card.slot(query.slot.attach),
+						),
+					).not.toBe(null)
+					yield* endTurn(game)
+
+					yield* attack(game, 'secondary')
+					yield* pick(
+						game,
+						query.slot.opponent,
+						query.slot.active,
+						query.slot.hermit,
+					)
+					yield* finishModalRequest(game, {pick: 'secondary'})
+
+					expect(
+						game.components.find(
+							CardComponent,
+							query.card.opponentPlayer,
+							query.card.active,
+							query.card.slot(query.slot.attach),
+						),
+					).not.toBe(null)
+				},
+			},
+			{startWithAllCards: true, noItemRequirements: true, forceCoinFlip: true},
+		)
+	})
+})

--- a/tests/unit/game/hermits/wormman-rare.test.ts
+++ b/tests/unit/game/hermits/wormman-rare.test.ts
@@ -1,0 +1,220 @@
+import {describe, expect, test} from '@jest/globals'
+import WormManRare from 'common/cards/alter-egos-iii/hermits/wormman-rare'
+import ArmorStand from 'common/cards/alter-egos/effects/armor-stand'
+import ThornsIII from 'common/cards/alter-egos/effects/thorns_iii'
+import PoultrymanCommon from 'common/cards/alter-egos/hermits/poultryman-common'
+import Anvil from 'common/cards/alter-egos/single-use/anvil'
+import TargetBlock from 'common/cards/alter-egos/single-use/target-block'
+import EthosLabCommon from 'common/cards/default/hermits/ethoslab-common'
+import Bow from 'common/cards/default/single-use/bow'
+import {CardComponent} from 'common/components'
+import query from 'common/components/query'
+import {TurnAction} from 'common/types/game-state'
+import {
+	attack,
+	changeActiveHermit,
+	endTurn,
+	pick,
+	playCardFromHand,
+	testGame,
+} from '../utils'
+
+describe('Test Rare Worm Man', () => {
+	test('Total Anonymity functionality', () => {
+		testGame(
+			{
+				playerOneDeck: [EthosLabCommon, TargetBlock],
+				playerTwoDeck: [WormManRare, PoultrymanCommon, PoultrymanCommon],
+				saga: function* (game) {
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, WormManRare, 'hermit', 0)
+					yield* attack(game, 'secondary')
+					yield* playCardFromHand(game, PoultrymanCommon, 'hermit', 1)
+					expect(
+						game.components.find(
+							CardComponent,
+							query.card.currentPlayer,
+							query.card.slot(query.slot.rowIndex(1)),
+						)?.turnedOver,
+					).toBe(true)
+					expect(game.state.turn.availableActions).not.toContain(
+						'PLAY_HERMIT_CARD' satisfies TurnAction,
+					)
+					yield* endTurn(game)
+
+					yield* attack(game, 'secondary')
+					yield* endTurn(game)
+
+					yield* attack(game, 'secondary')
+					yield* playCardFromHand(game, PoultrymanCommon, 'hermit', 2)
+					expect(
+						game.components.find(
+							CardComponent,
+							query.card.currentPlayer,
+							query.card.slot(query.slot.rowIndex(2)),
+						)?.turnedOver,
+					).toBe(true)
+					yield* endTurn(game)
+
+					yield* attack(game, 'secondary')
+					yield* endTurn(game)
+
+					yield* changeActiveHermit(game, 1)
+					expect(
+						game.components.find(
+							CardComponent,
+							query.card.currentPlayer,
+							query.card.slot(query.slot.rowIndex(1)),
+						)?.turnedOver,
+					).toBe(false)
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, TargetBlock, 'single_use')
+					yield* pick(
+						game,
+						query.slot.opponent,
+						query.slot.hermit,
+						query.slot.rowIndex(0),
+					)
+					yield* attack(game, 'secondary')
+					expect(
+						game.components.find(
+							CardComponent,
+							query.card.opponentPlayer,
+							query.card.slot(query.slot.rowIndex(2)),
+						)?.turnedOver,
+					).toBe(false)
+				},
+			},
+			{startWithAllCards: true, noItemRequirements: true},
+		)
+	})
+
+	test('One Hermit can be placed face-up after Thorns knock-out', () => {
+		testGame(
+			{
+				playerOneDeck: [
+					WormManRare,
+					ArmorStand,
+					PoultrymanCommon,
+					PoultrymanCommon,
+				],
+				playerTwoDeck: [EthosLabCommon, ThornsIII],
+				saga: function* (game) {
+					yield* playCardFromHand(game, WormManRare, 'hermit', 0)
+					yield* playCardFromHand(game, ArmorStand, 'hermit', 1)
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
+					yield* playCardFromHand(game, ThornsIII, 'attach', 0)
+					yield* attack(game, 'secondary')
+					yield* endTurn(game)
+
+					yield* attack(game, 'secondary')
+					yield* endTurn(game)
+
+					yield* attack(game, 'secondary')
+					yield* endTurn(game)
+
+					yield* attack(game, 'secondary')
+					yield* changeActiveHermit(game, 1)
+					yield* playCardFromHand(game, PoultrymanCommon, 'hermit', 2)
+					expect(
+						game.components.find(
+							CardComponent,
+							query.card.currentPlayer,
+							query.card.slot(query.slot.rowIndex(2)),
+						)?.turnedOver,
+					).toBe(false)
+					expect(game.state.turn.availableActions).not.toContain(
+						'PLAY_HERMIT_CARD' satisfies TurnAction,
+					)
+				},
+			},
+			{startWithAllCards: true, noItemRequirements: true},
+		)
+	})
+
+	test('Total Anonymity can place Armor Stand', () => {
+		testGame(
+			{
+				playerOneDeck: [EthosLabCommon],
+				playerTwoDeck: [WormManRare, ArmorStand],
+				saga: function* (game) {
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, WormManRare, 'hermit', 0)
+					yield* attack(game, 'secondary')
+					yield* playCardFromHand(game, ArmorStand, 'hermit', 1)
+					expect(
+						game.components.find(
+							CardComponent,
+							query.card.currentPlayer,
+							query.card.slot(query.slot.rowIndex(1)),
+						)?.turnedOver,
+					).toBe(true)
+				},
+			},
+			{startWithAllCards: true, noItemRequirements: true},
+		)
+	})
+
+	test('Face-down hermits are revealed when picked, not attacked/attached to', () => {
+		testGame(
+			{
+				playerOneDeck: [EthosLabCommon, Anvil, Bow],
+				playerTwoDeck: [WormManRare, PoultrymanCommon, ThornsIII],
+				saga: function* (game) {
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, WormManRare, 'hermit', 0)
+					yield* attack(game, 'secondary')
+					yield* playCardFromHand(game, PoultrymanCommon, 'hermit', 1)
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, Anvil, 'single_use')
+					yield* attack(game, 'single-use')
+					expect(
+						game.components.find(
+							CardComponent,
+							query.card.opponentPlayer,
+							query.card.slot(query.slot.hermit, query.slot.rowIndex(1)),
+						)?.turnedOver,
+					).toBe(true)
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, ThornsIII, 'attach', 0)
+					expect(
+						game.components.find(
+							CardComponent,
+							query.card.currentPlayer,
+							query.card.slot(query.slot.hermit, query.slot.rowIndex(1)),
+						)?.turnedOver,
+					).toBe(true)
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, Bow, 'single_use')
+					yield* attack(game, 'single-use')
+					yield* pick(
+						game,
+						query.slot.opponent,
+						query.slot.hermit,
+						query.slot.rowIndex(1),
+					)
+					expect(
+						game.components.find(
+							CardComponent,
+							query.card.opponentPlayer,
+							query.card.slot(query.slot.hermit, query.slot.rowIndex(1)),
+						)?.turnedOver,
+					).toBe(false)
+				},
+			},
+			{startWithAllCards: true, noItemRequirements: true},
+		)
+	})
+})

--- a/tests/unit/game/hermits/wormman-rare.test.ts
+++ b/tests/unit/game/hermits/wormman-rare.test.ts
@@ -187,7 +187,7 @@ describe('Test Rare Worm Man', () => {
 					).toBe(true)
 					yield* endTurn(game)
 
-					yield* playCardFromHand(game, ThornsIII, 'attach', 0)
+					yield* playCardFromHand(game, ThornsIII, 'attach', 1)
 					expect(
 						game.components.find(
 							CardComponent,

--- a/tests/unit/game/hermits/zombie-cleo-rare.test.ts
+++ b/tests/unit/game/hermits/zombie-cleo-rare.test.ts
@@ -300,7 +300,7 @@ function* testPuppetingTotalAnonymity(game: GameModel) {
 	expect(
 		game.components.find(
 			CardComponent,
-			query.card.currentPlayer,
+			query.card.opponentPlayer,
 			query.card.slot(query.slot.rowIndex(2)),
 		)?.turnedOver,
 	).toBe(false)

--- a/tests/unit/game/hermits/zombie-cleo-rare.test.ts
+++ b/tests/unit/game/hermits/zombie-cleo-rare.test.ts
@@ -2,12 +2,14 @@ import {describe, expect, test} from '@jest/globals'
 import BoomerBdubsRare from 'common/cards/alter-egos-ii/hermits/boomerbdubs-rare'
 import ArchitectFalseRare from 'common/cards/alter-egos-iii/hermits/architectfalse-rare'
 import BeetlejhostRare from 'common/cards/alter-egos-iii/hermits/beetlejhost-rare'
+import WormManRare from 'common/cards/alter-egos-iii/hermits/wormman-rare'
 import EthosLabCommon from 'common/cards/default/hermits/ethoslab-common'
 import HypnotizdRare from 'common/cards/default/hermits/hypnotizd-rare'
 import ZombieCleoRare from 'common/cards/default/hermits/zombiecleo-rare'
 import PvPItem from 'common/cards/default/items/pvp-common'
 import SmallishbeansCommon from 'common/cards/season-x/hermits/smallishbeans-common'
 import {
+	CardComponent,
 	RowComponent,
 	SlotComponent,
 	StatusEffectComponent,
@@ -260,6 +262,50 @@ function* testPuppetryDiscardingItem(game: GameModel) {
 	).toBe(null)
 }
 
+function* testPuppetingTotalAnonymity(game: GameModel) {
+	yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
+	yield* endTurn(game)
+
+	yield* playCardFromHand(game, ZombieCleoRare, 'hermit', 0)
+	yield* playCardFromHand(game, WormManRare, 'hermit', 1)
+	yield* attack(game, 'secondary')
+	yield* pick(
+		game,
+		query.slot.currentPlayer,
+		query.slot.hermit,
+		query.slot.rowIndex(1),
+	)
+	yield* finishModalRequest(game, {pick: 'secondary'})
+	yield* playCardFromHand(game, EthosLabCommon, 'hermit', 2)
+	expect(
+		game.components.find(
+			CardComponent,
+			query.card.currentPlayer,
+			query.card.slot(query.slot.rowIndex(2)),
+		)?.turnedOver,
+	).toBe(true)
+	yield* endTurn(game)
+
+	yield* attack(game, 'secondary')
+	yield* endTurn(game)
+
+	yield* endTurn(game)
+
+	yield* attack(game, 'secondary')
+	yield* endTurn(game)
+
+	yield* endTurn(game)
+
+	yield* attack(game, 'secondary')
+	expect(
+		game.components.find(
+			CardComponent,
+			query.card.currentPlayer,
+			query.card.slot(query.slot.rowIndex(2)),
+		)?.turnedOver,
+	).toBe(false)
+}
+
 describe('Test Zombie Cleo', () => {
 	test('Test Zombie Cleo Primary Does Not Crash Server', () => {
 		testGame(
@@ -311,6 +357,17 @@ describe('Test Zombie Cleo', () => {
 				saga: testPuppetryDiscardingItem,
 				playerOneDeck: [EthosLabCommon, EthosLabCommon],
 				playerTwoDeck: [ZombieCleoRare, PvPItem, HypnotizdRare],
+			},
+			{startWithAllCards: true, noItemRequirements: true},
+		)
+	})
+
+	test('Test using Puppetry on Total Anonymity', () => {
+		testGame(
+			{
+				saga: testPuppetingTotalAnonymity,
+				playerOneDeck: [EthosLabCommon],
+				playerTwoDeck: [ZombieCleoRare, WormManRare, EthosLabCommon],
 			},
 			{startWithAllCards: true, noItemRequirements: true},
 		)


### PR DESCRIPTION
**Worm Man's Total Anonymity**
- Fixed not flipping cards when mocked by Puppetry/Role Play
- Fixed being able to place multiple hermits after Worm Man is knocked out
- Fixed logs revealing cards placed face-down before they are turned face-up

**TFC's Take It Easy**
- Fixed being able to discard twice from the same hermit when mocked by Puppetry/Role Play
- Fixed discarding twice from a hermit after they are moved by Ladder
- Fixed not being able to discard if TFC already discarded from a previous hermit in that row