### PR TITLE
Fix playing milk/water bucket as single use

### DIFF
--- a/server/src/routines/game.ts
+++ b/server/src/routines/game.ts
@@ -208,16 +208,16 @@ function getAvailableActions(
 				if (pickableSlots.length === 0) return reducer
 
 				if (card.isHealth() && !reducer.includes('PLAY_HERMIT_CARD')) {
-					return [...reducer, 'PLAY_HERMIT_CARD']
+					reducer.push('PLAY_HERMIT_CARD')
 				}
 				if (card.isAttach() && !reducer.includes('PLAY_EFFECT_CARD')) {
-					return [...reducer, 'PLAY_EFFECT_CARD']
+					reducer.push('PLAY_EFFECT_CARD')
 				}
 				if (card.isItem() && !reducer.includes('PLAY_ITEM_CARD')) {
-					return [...reducer, 'PLAY_ITEM_CARD']
+					reducer.push('PLAY_ITEM_CARD')
 				}
 				if (card.isSingleUse() && !reducer.includes('PLAY_SINGLE_USE_CARD')) {
-					return [...reducer, 'PLAY_SINGLE_USE_CARD']
+					reducer.push('PLAY_SINGLE_USE_CARD')
 				}
 				return reducer
 			}, [] as TurnActions)

--- a/tests/unit/game/effects/milk-bucket.test.ts
+++ b/tests/unit/game/effects/milk-bucket.test.ts
@@ -1,14 +1,14 @@
 import {describe, expect, test} from '@jest/globals'
-import {applyEffect, endTurn, pick, playCardFromHand, testGame} from '../utils'
-import Iskall85Common from 'common/cards/default/hermits/iskall85-common'
+import BadOmen from 'common/cards/alter-egos/single-use/bad-omen'
 import MilkBucket from 'common/cards/default/effects/milk-bucket'
 import EthosLabCommon from 'common/cards/default/hermits/ethoslab-common'
-import query from 'common/components/query'
-import BadOmen from 'common/cards/alter-egos/single-use/bad-omen'
+import Iskall85Common from 'common/cards/default/hermits/iskall85-common'
 import SplashPotionOfPoison from 'common/cards/default/single-use/splash-potion-of-poison'
-import PoisonEffect from 'common/status-effects/poison'
 import {StatusEffectComponent} from 'common/components'
+import query from 'common/components/query'
 import BadOmenEffect from 'common/status-effects/badomen'
+import PoisonEffect from 'common/status-effects/poison'
+import {applyEffect, endTurn, pick, playCardFromHand, testGame} from '../utils'
 
 describe('Test Milk Bucket', () => {
 	test('Single Use Functionality', () => {

--- a/tests/unit/game/effects/milk-bucket.test.ts
+++ b/tests/unit/game/effects/milk-bucket.test.ts
@@ -1,0 +1,66 @@
+import {describe, expect, test} from '@jest/globals'
+import {applyEffect, endTurn, pick, playCardFromHand, testGame} from '../utils'
+import Iskall85Common from 'common/cards/default/hermits/iskall85-common'
+import MilkBucket from 'common/cards/default/effects/milk-bucket'
+import EthosLabCommon from 'common/cards/default/hermits/ethoslab-common'
+import query from 'common/components/query'
+import BadOmen from 'common/cards/alter-egos/single-use/bad-omen'
+import SplashPotionOfPoison from 'common/cards/default/single-use/splash-potion-of-poison'
+import PoisonEffect from 'common/status-effects/poison'
+import {StatusEffectComponent} from 'common/components'
+import BadOmenEffect from 'common/status-effects/badomen'
+
+describe('Test Milk Bucket', () => {
+	test('Single Use Functionality', () => {
+		testGame({
+			playerOneDeck: [Iskall85Common, MilkBucket],
+			playerTwoDeck: [EthosLabCommon, BadOmen, SplashPotionOfPoison],
+			saga: function* (game) {
+				yield* playCardFromHand(game, Iskall85Common, 'hermit', 0)
+				yield* endTurn(game)
+
+				yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
+				yield* playCardFromHand(game, SplashPotionOfPoison, 'single_use')
+				yield* applyEffect(game)
+				yield* endTurn(game)
+
+				yield* endTurn(game)
+
+				yield* playCardFromHand(game, BadOmen, 'single_use')
+				yield* applyEffect(game)
+				yield* endTurn(game)
+
+				expect(
+					game.components.find(
+						StatusEffectComponent,
+						query.effect.is(PoisonEffect),
+						query.effect.targetIsCardAnd(query.card.currentPlayer),
+					),
+				).not.toBe(null)
+				expect(
+					game.components.find(
+						StatusEffectComponent,
+						query.effect.is(BadOmenEffect),
+						query.effect.targetIsCardAnd(query.card.currentPlayer),
+					),
+				).not.toBe(null)
+
+				yield* playCardFromHand(game, MilkBucket, 'single_use')
+				yield* pick(
+					game,
+					query.slot.currentPlayer,
+					query.slot.hermit,
+					query.slot.rowIndex(0),
+				)
+
+				expect(
+					game.components.find(
+						StatusEffectComponent,
+						query.effect.is(PoisonEffect, BadOmenEffect),
+						query.effect.targetIsCardAnd(query.card.currentPlayer),
+					),
+				).toBe(null)
+			},
+		})
+	})
+})


### PR DESCRIPTION
Fixes Milk/Water Bucket only being playable as a single use depending on other cards in hand