### PR TITLE
Fix swapping after using an attack

### DIFF
--- a/common/cards/default/hermits/cubfan135-rare.ts
+++ b/common/cards/default/hermits/cubfan135-rare.ts
@@ -52,8 +52,8 @@ const Cubfan135Rare: Hermit = {
 						query.slot.hermit,
 						query.not(query.slot.active),
 						query.not(query.slot.empty),
-						query.actionAvailable('CHANGE_ACTIVE_HERMIT'),
-					)
+					) ||
+					game.isActionBlocked('CHANGE_ACTIVE_HERMIT', ['game'])
 				)
 					return
 

--- a/common/cards/default/single-use/chorus-fruit.ts
+++ b/common/cards/default/single-use/chorus-fruit.ts
@@ -24,7 +24,8 @@ const ChorusFruit: SingleUse = {
 	log: (values) => `${values.defaultLog} with {your|their} attack`,
 	attachCondition: query.every(
 		singleUse.attachCondition,
-		query.actionAvailable('CHANGE_ACTIVE_HERMIT'),
+		(game, _slot) =>
+			!game.isActionBlocked('CHANGE_ACTIVE_HERMIT', ['game', 'betrayed']),
 		query.not(
 			query.exists(
 				SlotComponent,
@@ -55,6 +56,8 @@ const ChorusFruit: SingleUse = {
 				if (!attack.isType('primary', 'secondary')) return
 
 				applySingleUse(game, component.slot)
+
+				if (game.isActionBlocked('CHANGE_ACTIVE_HERMIT', ['game'])) return
 
 				observer.unsubscribe(game.hooks.afterAttack)
 

--- a/tests/unit/game/effects/chorus-fruit.test.ts
+++ b/tests/unit/game/effects/chorus-fruit.test.ts
@@ -1,0 +1,147 @@
+import {describe, expect, test} from '@jest/globals'
+import HumanCleoRare from 'common/cards/alter-egos/hermits/humancleo-rare'
+import BdoubleO100Rare from 'common/cards/default/hermits/bdoubleo100-rare'
+import EthosLabCommon from 'common/cards/default/hermits/ethoslab-common'
+import ChorusFruit from 'common/cards/default/single-use/chorus-fruit'
+import CurseOfBinding from 'common/cards/default/single-use/curse-of-binding'
+import query from 'common/components/query'
+import {
+	applyEffect,
+	attack,
+	endTurn,
+	pick,
+	playCardFromHand,
+	testGame,
+} from '../utils'
+
+describe('Test Chorus Fruit', () => {
+	test('Basic functionality', () => {
+		testGame(
+			{
+				playerOneDeck: [EthosLabCommon],
+				playerTwoDeck: [EthosLabCommon, EthosLabCommon, ChorusFruit],
+				saga: function* (game) {
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 1)
+					yield* playCardFromHand(game, ChorusFruit, 'single_use')
+					yield* attack(game, 'secondary')
+					yield* pick(
+						game,
+						query.slot.currentPlayer,
+						query.slot.hermit,
+						query.slot.rowIndex(1),
+					)
+					expect(game.currentPlayer.activeRow?.index).toBe(1)
+				},
+			},
+			{startWithAllCards: true, noItemRequirements: true},
+		)
+	})
+
+	test('Chorus Fruit can be used to swap after attacking for Betrayed', () => {
+		testGame(
+			{
+				playerOneDeck: [EthosLabCommon, EthosLabCommon, ChorusFruit],
+				playerTwoDeck: [HumanCleoRare],
+				saga: function* (game) {
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 1)
+
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, HumanCleoRare, 'hermit', 0)
+
+					yield* attack(game, 'secondary')
+
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, ChorusFruit, 'single_use')
+					yield* attack(game, 'secondary')
+
+					// First request should be for Betrayal target
+					expect(game.state.pickRequests).toHaveLength(1)
+					yield* pick(
+						game,
+						query.slot.currentPlayer,
+						query.slot.hermit,
+						query.slot.rowIndex(1),
+					)
+
+					// Second request should be to switch active row
+					expect(game.state.pickRequests).toHaveLength(1)
+					yield* pick(
+						game,
+						query.slot.currentPlayer,
+						query.slot.hermit,
+						query.slot.rowIndex(1),
+					)
+
+					expect(game.currentPlayer.activeRow?.index).toBe(1)
+				},
+			},
+			{startWithAllCards: true, noItemRequirements: true, forceCoinFlip: true},
+		)
+	})
+
+	test('Curse of Binding prevents using Chorus Fruit', () => {
+		testGame(
+			{
+				playerOneDeck: [EthosLabCommon, EthosLabCommon, ChorusFruit],
+				playerTwoDeck: [EthosLabCommon, CurseOfBinding],
+				saga: function* (game) {
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 1)
+
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
+					yield* playCardFromHand(game, CurseOfBinding, 'single_use')
+					yield* applyEffect(game)
+
+					yield* endTurn(game)
+
+					expect(
+						game.getPickableSlots(ChorusFruit.attachCondition),
+					).toStrictEqual([])
+				},
+			},
+			{startWithAllCards: true, noItemRequirements: true},
+		)
+	})
+
+	test('Shreep prevents using Chorus Fruit', () => {
+		testGame(
+			{
+				playerOneDeck: [EthosLabCommon],
+				playerTwoDeck: [
+					BdoubleO100Rare,
+					EthosLabCommon,
+					ChorusFruit,
+					ChorusFruit,
+				],
+				saga: function* (game) {
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, BdoubleO100Rare, 'hermit', 0)
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 1)
+					yield* playCardFromHand(game, ChorusFruit, 'single_use')
+					yield* attack(game, 'secondary')
+					expect(game.currentPlayer.singleUseCardUsed).toBe(true)
+					expect(game.state.pickRequests).toHaveLength(0)
+					yield* endTurn(game)
+
+					yield* endTurn(game)
+
+					expect(
+						game.getPickableSlots(ChorusFruit.attachCondition),
+					).toStrictEqual([])
+				},
+			},
+			{startWithAllCards: true, noItemRequirements: true},
+		)
+	})
+})

--- a/tests/unit/game/hermits/zombie-cleo-rare.test.ts
+++ b/tests/unit/game/hermits/zombie-cleo-rare.test.ts
@@ -3,10 +3,12 @@ import BoomerBdubsRare from 'common/cards/alter-egos-ii/hermits/boomerbdubs-rare
 import ArchitectFalseRare from 'common/cards/alter-egos-iii/hermits/architectfalse-rare'
 import BeetlejhostRare from 'common/cards/alter-egos-iii/hermits/beetlejhost-rare'
 import WormManRare from 'common/cards/alter-egos-iii/hermits/wormman-rare'
+import Cubfan135Rare from 'common/cards/default/hermits/cubfan135-rare'
 import EthosLabCommon from 'common/cards/default/hermits/ethoslab-common'
 import HypnotizdRare from 'common/cards/default/hermits/hypnotizd-rare'
 import ZombieCleoRare from 'common/cards/default/hermits/zombiecleo-rare'
 import PvPItem from 'common/cards/default/items/pvp-common'
+import ChorusFruit from 'common/cards/default/single-use/chorus-fruit'
 import SmallishbeansCommon from 'common/cards/season-x/hermits/smallishbeans-common'
 import {
 	CardComponent,
@@ -368,6 +370,46 @@ describe('Test Zombie Cleo', () => {
 				saga: testPuppetingTotalAnonymity,
 				playerOneDeck: [EthosLabCommon],
 				playerTwoDeck: [ZombieCleoRare, WormManRare, EthosLabCommon],
+			},
+			{startWithAllCards: true, noItemRequirements: true},
+		)
+	})
+
+	test("Test using Puppetry on Let's Go with Chorus Fruit", () => {
+		testGame(
+			{
+				playerOneDeck: [EthosLabCommon],
+				playerTwoDeck: [ZombieCleoRare, Cubfan135Rare, ChorusFruit],
+				saga: function* (game) {
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, ZombieCleoRare, 'hermit', 0)
+					yield* playCardFromHand(game, Cubfan135Rare, 'hermit', 1)
+					yield* playCardFromHand(game, ChorusFruit, 'single_use')
+					yield* attack(game, 'secondary')
+					yield* pick(
+						game,
+						query.slot.currentPlayer,
+						query.slot.hermit,
+						query.slot.rowIndex(1),
+					)
+					yield* finishModalRequest(game, {pick: 'secondary'})
+					yield* pick(
+						game,
+						query.slot.currentPlayer,
+						query.slot.hermit,
+						query.slot.rowIndex(1),
+					)
+					expect(game.currentPlayer.activeRow?.index).toBe(1)
+					yield* pick(
+						game,
+						query.slot.currentPlayer,
+						query.slot.hermit,
+						query.slot.rowIndex(0),
+					)
+					expect(game.currentPlayer.activeRow?.index).toBe(0)
+				},
 			},
 			{startWithAllCards: true, noItemRequirements: true},
 		)


### PR DESCRIPTION
- Fixes Let's Go not allowing to switch hermits when mocked by Puppetry/Role Play
- Fixes Chorus Fruit allowing to switch hermits after attacking with Shreep
- Fixes Chorus Fruit being unusable if oppenent flipped 2 heads for Betrayed