### PR TITLE
Probably Fix Double Messages Animation Issues on Reconnect

### DIFF
--- a/client/src/app/match-making/match-making.tsx
+++ b/client/src/app/match-making/match-making.tsx
@@ -124,7 +124,7 @@ function MatchMaking() {
 						</div>
 					</>
 				)
-			case 'starting':
+			case 'in_game':
 				return (
 					<>
 						<Spinner />

--- a/client/src/logic/matchmaking/matchmaking-reducer.ts
+++ b/client/src/logic/matchmaking/matchmaking-reducer.ts
@@ -77,7 +77,7 @@ const matchmakingReducer = (
 		case localMessages.GAME_START:
 			return {
 				...state,
-				status: 'starting',
+				status: 'in_game',
 			}
 		default:
 			return state

--- a/client/src/logic/matchmaking/matchmaking-types.ts
+++ b/client/src/logic/matchmaking/matchmaking-types.ts
@@ -4,5 +4,5 @@ export type MatchmakingStatus =
 	| 'private_lobby'
 	| 'waiting_for_player'
 	| 'waiting_for_player_as_spectator'
-	| 'starting'
+	| 'in_game'
 	| null

--- a/common/socket-messages/server-messages.ts
+++ b/common/socket-messages/server-messages.ts
@@ -55,7 +55,7 @@ export type ServerMessages = [
 	},
 	{
 		type: typeof serverMessages.GAME_STATE_ON_RECONNECT
-		localGameState: LocalGameState | null
+		localGameState: LocalGameState
 		order: PlayerId[]
 	},
 	{type: typeof serverMessages.OPPONENT_CONNECTION; isConnected: boolean},

--- a/server/src/routines/background/connection-status.ts
+++ b/server/src/routines/background/connection-status.ts
@@ -16,6 +16,8 @@ export function* sendGameStateOnReconnect(
 	const playerId = action.player.id
 	const player = game.players[playerId]
 
+  // Do not remove this or games will not reconnect!
+  // This is because the client takes a long time to start up.
 	yield* delay(500)
 
 	if (game.state.timer.turnStartTime) {

--- a/server/src/routines/background/connection-status.ts
+++ b/server/src/routines/background/connection-status.ts
@@ -16,8 +16,8 @@ export function* sendGameStateOnReconnect(
 	const playerId = action.player.id
 	const player = game.players[playerId]
 
-  // Do not remove this or games will not reconnect!
-  // This is because the client takes a long time to start up.
+	// Do not remove this or games will not reconnect!
+	// This is because the client takes a long time to start up.
 	yield* delay(500)
 
 	if (game.state.timer.turnStartTime) {

--- a/tests/e2e/private-queue.spec.ts
+++ b/tests/e2e/private-queue.spec.ts
@@ -188,7 +188,7 @@ test('Game starts for players and spectators and places players back on title sc
 	for (const player of [playerOne, playerTwo, spectator]) {
 		await expect(
 			await player.evaluate(() => global.getState().matchmaking.status),
-		).toBe('starting')
+		).toBe('in_game')
 	}
 
 	// After the game is over, players should be placed on the title screen.


### PR DESCRIPTION
I believe these bugs were caused by two game sagas starting if the player disconnects and reconnects while in the page. The reason the message count stopped at two is that the game reconnection saga in matchmaking could only run once per page load.