### PR TITLE
Fix replaying coinflip animations after forfeit

### DIFF
--- a/server/src/routines/matchmaking.ts
+++ b/server/src/routines/matchmaking.ts
@@ -132,7 +132,9 @@ function* gameManager(game: GameModel) {
 					// clients replaying animations after a forfeit, disconnect, or excessive game duration
 					game.components
 						.filter(PlayerComponent)
-						.forEach((player) => (player.coinFlips = []))
+						.forEach(
+							(player) => (gameState.players[player.entity].coinFlips = []),
+						)
 				}
 			}
 			const outcome = getGamePlayerOutcome(game, result, viewer)


### PR DESCRIPTION
Fixes the first viewer having to wait for the previous action's coinflip animations to play again after a player forfeits