### PR TITLE
Fix guaranteed hermit reducing chance of drawing second

### DIFF
--- a/common/cards/default/hermits/rendog-rare.ts
+++ b/common/cards/default/hermits/rendog-rare.ts
@@ -90,8 +90,6 @@ const RendogRare: Hermit = {
 					)
 					.apply(component.entity)
 			observer.subscribe(player.hooks.onTurnStart, () => {
-				// Ren having the "Blocked Action" icon on turn one looks weird
-				if (game.state.turn.turnNumber <= 1) return
 				if (!game.components.exists(SlotComponent, pickCondition))
 					game.components
 						.new(

--- a/common/cards/default/hermits/rendog-rare.ts
+++ b/common/cards/default/hermits/rendog-rare.ts
@@ -90,6 +90,8 @@ const RendogRare: Hermit = {
 					)
 					.apply(component.entity)
 			observer.subscribe(player.hooks.onTurnStart, () => {
+				// Ren having the "Blocked Action" icon on turn one looks weird
+				if (game.state.turn.turnNumber <= 1) return
 				if (!game.components.exists(SlotComponent, pickCondition))
 					game.components
 						.new(

--- a/common/utils/state-gen.ts
+++ b/common/utils/state-gen.ts
@@ -100,28 +100,26 @@ function setupEcsForPlayer(
 	}
 
 	// Ensure there is a hermit in the first 5 cards
-	const sortedCards = components.filter(
+	const cards = components.filter(
 		CardComponent,
 		query.card.player(playerEntity),
 		query.card.slot(query.slot.deck),
 	)
 
 	const amountOfStartingCards =
-		options.startWithAllCards || options.unlimitedCards ? sortedCards.length : 7
+		options.startWithAllCards || options.unlimitedCards ? cards.length : 7
 
 	if (options.shuffleDeck) {
-		sortedCards
+		cards
 			.sort(() => Math.random() - 0.5)
 			.forEach((card, i) => {
 				if (card.slot.inDeck()) card.slot.order = i
 			})
 
 		while (
-			!sortedCards
-				.slice(0, amountOfStartingCards)
-				.some((card) => card.isHermit())
+			!cards.slice(0, amountOfStartingCards).some((card) => card.isHermit())
 		) {
-			sortedCards
+			cards
 				.sort(() => Math.random() - 0.5)
 				.forEach((card, i) => {
 					if (card.slot.inDeck()) card.slot.order = i
@@ -135,7 +133,7 @@ function setupEcsForPlayer(
 		components.new(CardComponent, id, slot.entity)
 	}
 
-	sortedCards.slice(0, amountOfStartingCards).forEach((card) => {
+	cards.slice(0, amountOfStartingCards).forEach((card) => {
 		card.attach(components.new(HandSlotComponent, playerEntity))
 	})
 }

--- a/common/utils/state-gen.ts
+++ b/common/utils/state-gen.ts
@@ -108,14 +108,22 @@ function setupEcsForPlayer(
 		)
 		.sort(CardComponent.compareOrder)
 
-	let index = sortedCards.findIndex((card) => card.isHermit())
+	const amountOfStartingCards =
+		options.startWithAllCards || options.unlimitedCards ? sortedCards.length : 7
 
-	if (index > 5) {
-		let a = sortedCards[index]
-		const swapIndex = Math.floor(Math.random() * 5)
+	if (
+		!sortedCards
+			.slice(0, amountOfStartingCards)
+			.some((card) => card.isHermit()) &&
+		options.shuffleDeck
+	) {
+		const hermits = sortedCards.filter((card) => card.isHermit())
+		let a = hermits[Math.floor(Math.random() * hermits.length)]
+		const index = sortedCards.indexOf(a)
+		const swapIndex = Math.floor(Math.random() * amountOfStartingCards)
 		let b = sortedCards[swapIndex]
 
-		if (a.slot?.inDeck() && b.slot?.inDeck()) {
+		if (a?.slot.inDeck() && b?.slot.inDeck()) {
 			let tmp = b.slot.order
 			a.slot.order = b.slot.order
 			b.slot.order = tmp
@@ -124,9 +132,6 @@ function setupEcsForPlayer(
 			sortedCards[swapIndex] = tmpCard
 		}
 	}
-
-	const amountOfStartingCards =
-		options.startWithAllCards || options.unlimitedCards ? sortedCards.length : 7
 
 	for (let i = 0; i < options.extraStartingCards.length; i++) {
 		const id = options.extraStartingCards[i]

--- a/common/utils/state-gen.ts
+++ b/common/utils/state-gen.ts
@@ -111,27 +111,18 @@ function setupEcsForPlayer(
 	const amountOfStartingCards =
 		options.startWithAllCards || options.unlimitedCards ? sortedCards.length : 7
 
-	if (
-		!sortedCards
-			.slice(0, amountOfStartingCards)
-			.some((card) => card.isHermit()) &&
-		options.shuffleDeck
-	) {
-		const hermits = sortedCards.filter((card) => card.isHermit())
-		let a = hermits[Math.floor(Math.random() * hermits.length)]
-		const index = sortedCards.indexOf(a)
-		const swapIndex = Math.floor(Math.random() * amountOfStartingCards)
-		let b = sortedCards[swapIndex]
-
-		if (a?.slot.inDeck() && b?.slot.inDeck()) {
-			let tmp = b.slot.order
-			a.slot.order = b.slot.order
-			b.slot.order = tmp
-			let tmpCard = sortedCards[index]
-			sortedCards[index] = sortedCards[swapIndex]
-			sortedCards[swapIndex] = tmpCard
+	if (options.shuffleDeck)
+		while (
+			!sortedCards
+				.slice(0, amountOfStartingCards)
+				.some((card) => card.isHermit())
+		) {
+			sortedCards
+				.sort(() => Math.random() - 0.5)
+				.forEach((card, i) => {
+					if (card.slot.inDeck()) card.slot.order = i
+				})
 		}
-	}
 
 	for (let i = 0; i < options.extraStartingCards.length; i++) {
 		const id = options.extraStartingCards[i]

--- a/common/utils/state-gen.ts
+++ b/common/utils/state-gen.ts
@@ -100,18 +100,22 @@ function setupEcsForPlayer(
 	}
 
 	// Ensure there is a hermit in the first 5 cards
-	const sortedCards = components
-		.filter(
-			CardComponent,
-			query.card.player(playerEntity),
-			query.card.slot(query.slot.deck),
-		)
-		.sort(CardComponent.compareOrder)
+	const sortedCards = components.filter(
+		CardComponent,
+		query.card.player(playerEntity),
+		query.card.slot(query.slot.deck),
+	)
 
 	const amountOfStartingCards =
 		options.startWithAllCards || options.unlimitedCards ? sortedCards.length : 7
 
 	if (options.shuffleDeck) {
+		sortedCards
+			.sort(() => Math.random() - 0.5)
+			.forEach((card, i) => {
+				if (card.slot.inDeck()) card.slot.order = i
+			})
+
 		while (
 			!sortedCards
 				.slice(0, amountOfStartingCards)

--- a/common/utils/state-gen.ts
+++ b/common/utils/state-gen.ts
@@ -59,7 +59,7 @@ function setupEcsForPlayer(
 ) {
 	for (const card of deck) {
 		let slot = components.new(DeckSlotComponent, playerEntity, {
-			position: options.shuffleDeck ? 'random' : 'back',
+			position: 'back',
 		})
 		components.new(CardComponent, card, slot.entity)
 	}
@@ -111,7 +111,7 @@ function setupEcsForPlayer(
 	const amountOfStartingCards =
 		options.startWithAllCards || options.unlimitedCards ? sortedCards.length : 7
 
-	if (options.shuffleDeck)
+	if (options.shuffleDeck) {
 		while (
 			!sortedCards
 				.slice(0, amountOfStartingCards)
@@ -123,6 +123,7 @@ function setupEcsForPlayer(
 					if (card.slot.inDeck()) card.slot.order = i
 				})
 		}
+	}
 
 	for (let i = 0; i < options.extraStartingCards.length; i++) {
 		const id = options.extraStartingCards[i]


### PR DESCRIPTION
If starting hand does not start with a hermit, reshuffles the deck pile until there is at least one. Fixes always swapping the first hermit in deck, which reduced the odds of drawing a second hermit.