### PR TITLE
Fix some problems with tooltips

### DIFF
--- a/client/src/components/card/mobile-card-component.tsx
+++ b/client/src/components/card/mobile-card-component.tsx
@@ -26,7 +26,7 @@ const MobileCardComponent = (props: CardReactProps) => {
 			showAboveModal={props.tooltipAboveModal}
 		>
 			<div className={css.MobileCardComponentContainer}>
-				<button onClick={onClick} className={css.mainButton}>
+				<button onTouchStart={onClick} className={css.mainButton}>
 					<div
 						className={classNames(css.MobileCardComponent, small && css.small)}
 					>

--- a/client/src/components/tooltip/tooltip.module.scss
+++ b/client/src/components/tooltip/tooltip.module.scss
@@ -30,7 +30,6 @@
 
 @media screen and (max-width: 800px) {
 	.tooltip {
-		margin: 2vh;
 		overflow: hidden;
 	}
 }

--- a/client/src/components/tooltip/tooltip.tsx
+++ b/client/src/components/tooltip/tooltip.tsx
@@ -8,8 +8,9 @@ import React, {
 	useRef,
 	useState,
 } from 'react'
-import {useDispatch} from 'react-redux'
+import {useDispatch, useSelector} from 'react-redux'
 import css from './tooltip.module.scss'
+import {getSettings} from 'logic/local-settings/local-settings-selectors'
 
 type Props = {
 	children: React.ReactElement
@@ -31,11 +32,18 @@ const Tooltip = memo(({children, tooltip, showAboveModal}: Props) => {
 	const [tooltipSize, setTooltipSize] = useState<{h: number; w: number} | null>(
 		null,
 	)
+
+	const showAdvancedTooltips = useSelector(getSettings).showAdvancedTooltips
+
 	const [, forceUpdate] = useReducer((x) => x + 1, 0)
 
 	useEffect(() => {
+		setTooltipSize(null)
+	}, [showAdvancedTooltips])
+
+	useEffect(() => {
 		if (!tooltipSize) forceUpdate()
-	}, [tooltipRef])
+	}, [tooltipRef, tooltipSize])
 
 	if (tooltipRef && tooltipRef.current && tooltipSize === null) {
 		setTooltipSize({

--- a/client/src/components/tooltip/tooltip.tsx
+++ b/client/src/components/tooltip/tooltip.tsx
@@ -1,4 +1,5 @@
 import classNames from 'classnames'
+import {getSettings} from 'logic/local-settings/local-settings-selectors'
 import {localMessages} from 'logic/messages'
 import React, {
 	memo,
@@ -10,7 +11,6 @@ import React, {
 } from 'react'
 import {useDispatch, useSelector} from 'react-redux'
 import css from './tooltip.module.scss'
-import {getSettings} from 'logic/local-settings/local-settings-selectors'
 
 type Props = {
 	children: React.ReactElement

--- a/client/src/components/tooltip/tooltip.tsx
+++ b/client/src/components/tooltip/tooltip.tsx
@@ -39,7 +39,7 @@ const Tooltip = memo(({children, tooltip, showAboveModal}: Props) => {
 
 	useEffect(() => {
 		setTooltipSize(null)
-	}, [showAdvancedTooltips])
+	}, [showAdvancedTooltips, window.innerWidth])
 
 	useEffect(() => {
 		if (!tooltipSize) forceUpdate()


### PR DESCRIPTION
- Tooltips behavior is now a lot nicer on mobile. Tooltips do not show unless you long press on a card
- Tooltips always show on the proper position on mobile
- Tooltips show in the proper position after switching showing and hiding advanced tooltips
- The issue of tooltips sometimes showing in the wrong spot on desktop also seems to be fixed