### PR TITLE
Make toasts never return after entering a page that cannot show toasts

### DIFF
--- a/client/src/app/main-menu/main-menu.tsx
+++ b/client/src/app/main-menu/main-menu.tsx
@@ -24,6 +24,7 @@ function MainMenu({setMenuSection}: Props) {
 
 		if (validation.valid) {
 			dispatch({type: localMessages.MATCHMAKING_QUEUE_JOIN})
+			dispatch({type: localMessages.EVERY_TOAST_CLOSE})
 		} else {
 			dispatch({
 				type: localMessages.TOAST_OPEN,
@@ -34,11 +35,16 @@ function MainMenu({setMenuSection}: Props) {
 			})
 		}
 	}
-	const handlePrivateGame = () =>
+	const handlePrivateGame = () => {
+		dispatch({type: localMessages.EVERY_TOAST_CLOSE})
 		dispatch({type: localMessages.MATCHMAKING_PRIVATE_GAME_LOBBY})
+	}
 	const handleSoloGame = () => setMenuSection('boss-landing')
 
-	const handleLogOut = () => dispatch({type: localMessages.LOGOUT})
+	const handleLogOut = () => {
+		dispatch({type: localMessages.EVERY_TOAST_CLOSE})
+		dispatch({type: localMessages.LOGOUT})
+	}
 	const handleDeck = () => setMenuSection('deck')
 	const handleSettings = () => setMenuSection('settings')
 

--- a/client/src/logic/messages.ts
+++ b/client/src/logic/messages.ts
@@ -39,6 +39,7 @@ export const localMessages = messages({
 	UPDATES_LOAD: null,
 	TOAST_OPEN: null,
 	TOAST_CLOSE: null,
+	EVERY_TOAST_CLOSE: null,
 	MINECRAFT_NAME_SET: null,
 	MINECRAFT_NAME_NEW: null,
 	MATCHMAKING_QUEUE_JOIN: null,
@@ -122,6 +123,7 @@ type Messages = [
 		image?: string
 	},
 	{type: typeof localMessages.TOAST_CLOSE; id: number},
+	{type: typeof localMessages.EVERY_TOAST_CLOSE},
 	{type: typeof localMessages.MINECRAFT_NAME_SET; name: string},
 	{type: typeof localMessages.MINECRAFT_NAME_NEW; name: string},
 	{type: typeof localMessages.MATCHMAKING_QUEUE_JOIN},

--- a/client/src/logic/session/session-reducer.ts
+++ b/client/src/logic/session/session-reducer.ts
@@ -111,6 +111,11 @@ const loginReducer = (
 				...state,
 				toast: [],
 			}
+		case localMessages.EVERY_TOAST_CLOSE:
+			return {
+				...state,
+				toast: [],
+			}
 		case localMessages.SHOW_TOOLTIP:
 			return {
 				...state,


### PR DESCRIPTION
This was an issue before, but allowing stacking toasts made it a lot more noticeable. It feels a lot better to not have toasts "randomly" return