### PR TITLE
Make Messages Unique

### DIFF
--- a/client/src/logic/messages.ts
+++ b/client/src/logic/messages.ts
@@ -25,7 +25,7 @@ import {
 	LocalSettings,
 } from './local-settings/local-settings-reducer'
 
-export const localMessages = messages({
+export const localMessages = messages('clientLocalMessages', {
 	SOCKET_CONNECTING: null,
 	SOCKET_CONNECT: null,
 	SOCKET_DISCONNECT: null,

--- a/common/redux-messages.ts
+++ b/common/redux-messages.ts
@@ -16,11 +16,12 @@ type MessageDict<T extends Record<string, null>> = {
 }
 
 export function messages<T extends Record<string, null>>(
+	groupName: string,
 	actions: T,
 ): MessageDict<T> {
 	let actionsDict: Record<string, string> = {}
 	for (const action of Object.keys(actions)) {
-		actionsDict[action] = action
+		actionsDict[action] = `${groupName}-${action}`
 	}
 	return actionsDict as any
 }

--- a/common/socket-messages/client-messages.ts
+++ b/common/socket-messages/client-messages.ts
@@ -4,7 +4,7 @@ import {Message, MessageTable, messages} from '../redux-messages'
 import {Deck, Tag} from '../types/deck'
 import {AnyTurnActionData} from '../types/turn-action-data'
 
-export const clientMessages = messages({
+export const clientMessages = messages('clientMessages', {
 	GET_UPDATES: null,
 	SELECT_DECK: null,
 	UPDATE_MINECRAFT_NAME: null,

--- a/common/socket-messages/server-messages.ts
+++ b/common/socket-messages/server-messages.ts
@@ -10,7 +10,7 @@ import {
 import {Message as ChatMessage} from '../types/game-state'
 import {PlayerInfo} from '../types/server-requests'
 
-export const serverMessages = messages({
+export const serverMessages = messages("serverMessages", {
 	PLAYER_RECONNECTED: null,
 	INVALID_PLAYER: null,
 	PLAYER_INFO: null,

--- a/common/socket-messages/server-messages.ts
+++ b/common/socket-messages/server-messages.ts
@@ -10,7 +10,7 @@ import {
 import {Message as ChatMessage} from '../types/game-state'
 import {PlayerInfo} from '../types/server-requests'
 
-export const serverMessages = messages("serverMessages", {
+export const serverMessages = messages('serverMessages', {
 	PLAYER_RECONNECTED: null,
 	INVALID_PLAYER: null,
 	PLAYER_INFO: null,

--- a/server/src/messages.ts
+++ b/server/src/messages.ts
@@ -4,7 +4,7 @@ import {Message, MessageTable, messages} from 'common/redux-messages'
 import {Deck} from 'common/types/deck'
 import {AnyTurnActionData} from 'common/types/turn-action-data'
 
-export const localMessages = messages({
+export const localMessages = messages('serverLocalMessages', {
 	CLIENT_CONNECTED: null,
 	CLIENT_DISCONNECTED: null,
 	PLAYER_CONNECTED: null,

--- a/server/src/routines/player.ts
+++ b/server/src/routines/player.ts
@@ -109,7 +109,7 @@ export function* playerDisconnectedSaga(
 		),
 	})
 
-	console.log("Reconnect done")
+	console.log('Reconnect done')
 	console.log(result)
 
 	if (result.timeout) {

--- a/server/src/routines/player.ts
+++ b/server/src/routines/player.ts
@@ -109,6 +109,9 @@ export function* playerDisconnectedSaga(
 		),
 	})
 
+	console.log("Reconnect done")
+	console.log(result)
+
 	if (result.timeout) {
 		yield* put<LocalMessage>({type: localMessages.PLAYER_REMOVED, player}) // @TODO will we try to get playerId here after instance is deleted?
 		delete root.players[playerId]

--- a/server/src/routines/player.ts
+++ b/server/src/routines/player.ts
@@ -109,9 +109,6 @@ export function* playerDisconnectedSaga(
 		),
 	})
 
-	console.log('Reconnect done')
-	console.log(result)
-
 	if (result.timeout) {
 		yield* put<LocalMessage>({type: localMessages.PLAYER_REMOVED, player}) // @TODO will we try to get playerId here after instance is deleted?
 		delete root.players[playerId]


### PR DESCRIPTION
This prevents any accidental bugs caused by using repeated message names.