### PR TITLE
Add "test:unit-verbose" command for verbose unit tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ This project contains a few tests that are run against every PR.
 npm run test              # run all the tests
 npm run test:unit         # run unittests written with jest, this will catch most errors.
 npm run test:unit-verbose # run unittests written with jest and print verbose logs for debugging.
+npm run test:vunit        # the same as test:unit-verbose
 npm run test:ct           # run component tests with playwright.
 npm run test:ct-update    # update component snapshots.
 npm run test:api          # run tests for the hc-tcg API.

--- a/README.md
+++ b/README.md
@@ -95,12 +95,13 @@ wait a few minutes and there should be a commit with the card image!
 This project contains a few tests that are run against every PR.
 
 ```sh
-npm run test            # run all the tests
-npm run test:unit       # run unittests written with jest, this will catch most errors.
-npm run test:ct         # run component tests with playwright.
-npm run test:ct-update  # update component snapshots.
-npm run test:api        # run tests for the hc-tcg API.
-npm run test:e2e        # run end-to-end tests with Playwright.
+npm run test              # run all the tests
+npm run test:unit         # run unittests written with jest, this will catch most errors.
+npm run test:unit-verbose # run unittests written with jest and print verbose logs for debugging.
+npm run test:ct           # run component tests with playwright.
+npm run test:ct-update    # update component snapshots.
+npm run test:api          # run tests for the hc-tcg API.
+npm run test:e2e          # run end-to-end tests with Playwright.
 ```
 
 # Building & Self Hosting

--- a/common/config/debug-config.example.js
+++ b/common/config/debug-config.example.js
@@ -12,7 +12,7 @@ export default {
 	availableActions: [],
 	shuffleDeck: true,
 	logErrorsToStderr: true,
-	logBoardState: true,
+	verboseLogging: true,
 	showHooksState: {
 		enabled: false,
 		clearConsole: true,

--- a/common/models/battle-log-model.ts
+++ b/common/models/battle-log-model.ts
@@ -92,7 +92,9 @@ export class BattleLogModel {
 				message: formatText(firstEntry.description, {censor: true}),
 			})
 
-			console.info(`${this.game.logHeader} ${firstEntry.description}`)
+			if (this.game.settings.verboseLogging) {
+				console.info(`${this.game.logHeader} ${firstEntry.description}`)
+			}
 		}
 
 		// We skip waiting for the logs to send if there are no players. This is because

--- a/common/models/game-model.ts
+++ b/common/models/game-model.ts
@@ -56,7 +56,7 @@ export type GameSettings = {
 	forceCoinFlip: boolean
 	shuffleDeck: boolean
 	logErrorsToStderr: boolean
-	logBoardState: boolean
+	verboseLogging: boolean
 	disableRewardCards: boolean
 }
 
@@ -78,7 +78,7 @@ export function gameSettingsFromEnv(): GameSettings {
 		forceCoinFlip: DEBUG_CONFIG.forceCoinFlip,
 		shuffleDeck: DEBUG_CONFIG.shuffleDeck,
 		logErrorsToStderr: DEBUG_CONFIG.logErrorsToStderr,
-		logBoardState: DEBUG_CONFIG.logBoardState,
+		verboseLogging: DEBUG_CONFIG.verboseLogging,
 		disableRewardCards: DEBUG_CONFIG.disableRewardCards,
 	}
 }

--- a/package.json
+++ b/package.json
@@ -82,6 +82,8 @@
 		"test": "npm run test:unit && npm run test:snapshot && npm run test:ct && npm run test:api && npm run test:e2e",
 		"test:api": "./tests/sh/test-api",
 		"test:unit": "jest tests/unit/ --detect-open-handles",
+		"test:unit-verbose": "UNIT_VERBOSE=true jest tests/unit/ --detect-open-handles",
+		"test:unit-v": "npm run test:unit-verbose",
 		"test:db": "jest tests/db/",
 		"test:snapshot": "jest tests/snapshots/ --env jsdom",
 		"test:snapshot-update": "jest tests/snapshots/ --env jsdom --updateSnapshot",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
 		"test": "npm run test:unit && npm run test:snapshot && npm run test:ct && npm run test:api && npm run test:e2e",
 		"test:api": "./tests/sh/test-api",
 		"test:unit": "jest tests/unit/ --detect-open-handles",
-		"test:unit-verbose": "UNIT_VERBOSE=true jest tests/unit/ --detect-open-handles",
+		"test:vunit": "UNIT_VERBOSE=true jest tests/unit/ --detect-open-handles",
 		"test:unit-v": "npm run test:unit-verbose",
 		"test:db": "jest tests/db/",
 		"test:snapshot": "jest tests/snapshots/ --env jsdom",

--- a/server/src/routines/game.ts
+++ b/server/src/routines/game.ts
@@ -405,9 +405,11 @@ function* turnActionSaga(
 			case 'END_TURN':
 				endTurn = true
 				// Turn end actions are not in the battle log, so we log them to stdout manually.
-				console.info(
-					`${game.logHeader} ${game.currentPlayer.playerName} ended their turn.`,
-				)
+				if (game.settings.verboseLogging) {
+					console.info(
+						`${game.logHeader} ${game.currentPlayer.playerName} ended their turn.`,
+					)
+				}
 				break
 			case 'DELAY':
 				yield* call(sendGameState, game)
@@ -429,7 +431,7 @@ function* turnActionSaga(
 	}
 
 	// We log endTurn at the start of the turn so the state updates properly.
-	if (game.settings.logBoardState && !endTurn) {
+	if (game.settings.verboseLogging && !endTurn) {
 		printBoardState(game)
 	}
 
@@ -658,7 +660,7 @@ export function* turnSaga(game: GameModel) {
 	// Call turn start hooks
 	currentPlayer.hooks.onTurnStart.call()
 
-	if (game.settings.logBoardState) {
+	if (game.settings.verboseLogging) {
 		printBoardState(game)
 	}
 
@@ -754,9 +756,10 @@ function* checkDeckedOut(game: GameModel) {
 }
 
 function* gameSaga(game: GameModel) {
-	console.info(
-		`${game.logHeader} ${game.opponentPlayer.playerName} was decided to be the first player.`,
-	)
+	if (game.settings.verboseLogging)
+		console.info(
+			`${game.logHeader} ${game.opponentPlayer.playerName} was decided to be the first player.`,
+		)
 	while (true) {
 		game.state.turn.turnNumber++
 		const result = yield* call(turnSaga, game)

--- a/tests/unit/game/hermits/ijevin-rare.test.ts
+++ b/tests/unit/game/hermits/ijevin-rare.test.ts
@@ -2,6 +2,7 @@ import {describe, expect, test} from '@jest/globals'
 import EthosLabCommon from 'common/cards/hermits/ethoslab-common'
 import IJevinRare from 'common/cards/hermits/ijevin-rare'
 import Iskall85Common from 'common/cards/hermits/iskall85-common'
+import {printBoardState} from 'server/utils'
 import {attack, endTurn, playCardFromHand, testGame} from '../utils'
 
 describe('Test iJevin Peace Out', () => {
@@ -26,7 +27,10 @@ describe('Test iJevin Peace Out', () => {
 
 					// Manually timeout request
 					game.removePickRequest(0, true)
-					console.info(`${game.logHeader} Manually timed out pick request 0`)
+					if (game.settings.verboseLogging) {
+						console.info(`${game.logHeader} Manually timed out pick request 0`)
+						printBoardState(game)
+					}
 
 					expect(game.opponentPlayer.activeRow?.index).toBe(2)
 					expect(game.opponentPlayer.activeRow?.playerId).toBe(

--- a/tests/unit/game/hermits/ijevin-rare.test.ts
+++ b/tests/unit/game/hermits/ijevin-rare.test.ts
@@ -2,7 +2,6 @@ import {describe, expect, test} from '@jest/globals'
 import EthosLabCommon from 'common/cards/hermits/ethoslab-common'
 import IJevinRare from 'common/cards/hermits/ijevin-rare'
 import Iskall85Common from 'common/cards/hermits/iskall85-common'
-import {printBoardState} from 'server/utils'
 import {attack, endTurn, playCardFromHand, testGame} from '../utils'
 
 describe('Test iJevin Peace Out', () => {
@@ -28,7 +27,6 @@ describe('Test iJevin Peace Out', () => {
 					// Manually timeout request
 					game.removePickRequest(0, true)
 					console.info(`${game.logHeader} Manually timed out pick request 0`)
-					printBoardState(game)
 
 					expect(game.opponentPlayer.activeRow?.index).toBe(2)
 					expect(game.opponentPlayer.activeRow?.playerId).toBe(

--- a/tests/unit/game/utils.ts
+++ b/tests/unit/game/utils.ts
@@ -245,7 +245,7 @@ const defaultGameSettings = {
 	forceCoinFlip: true,
 	shuffleDeck: false,
 	logErrorsToStderr: false,
-	verboseLogging: !process.env.CI,
+	verboseLogging: !!process.env.UNIT_VERBOSE,
 	disableRewardCards: false,
 } satisfies GameSettings
 

--- a/tests/unit/game/utils.ts
+++ b/tests/unit/game/utils.ts
@@ -245,7 +245,8 @@ const defaultGameSettings = {
 	forceCoinFlip: true,
 	shuffleDeck: false,
 	logErrorsToStderr: false,
-	logBoardState: !process.env.CI,
+	verboseLogging: !process.env.CI,
+	logTurnActions: !process.env.CI,
 	disableRewardCards: false,
 } satisfies GameSettings
 

--- a/tests/unit/game/utils.ts
+++ b/tests/unit/game/utils.ts
@@ -245,7 +245,7 @@ const defaultGameSettings = {
 	forceCoinFlip: true,
 	shuffleDeck: false,
 	logErrorsToStderr: false,
-	logBoardState: true,
+	logBoardState: !process.env.CI,
 	disableRewardCards: false,
 } satisfies GameSettings
 

--- a/tests/unit/game/utils.ts
+++ b/tests/unit/game/utils.ts
@@ -246,7 +246,6 @@ const defaultGameSettings = {
 	shuffleDeck: false,
 	logErrorsToStderr: false,
 	verboseLogging: !process.env.CI,
-	logTurnActions: !process.env.CI,
 	disableRewardCards: false,
 } satisfies GameSettings
 


### PR DESCRIPTION
Adds `test:unit-verbose` and the alias `test:vunit` commands.
This will make the github CI results easier to look at.
Adds new "verboseLogging" option to debug config to control this. When running tests "verboseLogging" is on to make debugging specific tests easier.