### PR TITLE
Remove Database Connection Timeout

### DIFF
--- a/server/src/db/db.ts
+++ b/server/src/db/db.ts
@@ -1153,7 +1153,7 @@ export const setupDatabase = (
 		connectionString: env.DATABASE_URL,
 		max: 10,
 		idleTimeoutMillis: 0,
-		connectionTimeoutMillis: 2000,
+		connectionTimeoutMillis: 0,
 	})
 
 	return new Database(pool, allCards, bfDepth)


### PR DESCRIPTION
Setting this to 0 should prevent the DB from terminating the connection randomly, which is what was taking down the process.