### PR TITLE
fix Elder Guardian issues

### DIFF
--- a/common/cards/advent-of-tcg/attach/elder-guardian.ts
+++ b/common/cards/advent-of-tcg/attach/elder-guardian.ts
@@ -24,16 +24,28 @@ const ElderGuardian: Attach = {
 		component: CardComponent,
 		observer: ObserverComponent,
 	) {
-		let {opponentPlayer} = game
+		const {opponentPlayer} = component
 
 		observer.subscribeWithPriority(
 			game.hooks.afterAttack,
 			afterAttack.UPDATE_POST_ATTACK_STATE,
 			(attack) => {
-				if (!attack.isTargeting(component)) return
+				if (!attack.isTargeting(component) || attack.isType('status-effect'))
+					return
+				if (attack.player !== opponentPlayer) return
 
-				let opponentActiveHermit = opponentPlayer.getActiveHermit()
+				const opponentActiveHermit = opponentPlayer.getActiveHermit()
 				if (!opponentActiveHermit) return
+
+				const previousStatus = opponentActiveHermit.getStatusEffect(
+					SingleTurnMiningFatigueEffect,
+				)
+				if (
+					previousStatus &&
+					previousStatus.counter !== null &&
+					previousStatus.counter < 2
+				)
+					previousStatus.remove()
 
 				game.components
 					.new(

--- a/common/status-effects/mining-fatigue.ts
+++ b/common/status-effects/mining-fatigue.ts
@@ -40,6 +40,13 @@ export const SingleTurnMiningFatigueEffect: StatusEffect<CardComponent> = {
 	name: 'Mining Fatigue',
 	description:
 		"This Hermit's attacks cost an additional item card of their type.",
+	counter: 2,
+	applyCondition(_game, value) {
+		return (
+			value instanceof CardComponent &&
+			value.getStatusEffect(SingleTurnMiningFatigueEffect)?.counter !== 2
+		)
+	},
 	onApply(_game, effect, target, observer) {
 		const {player} = target
 
@@ -57,7 +64,13 @@ export const SingleTurnMiningFatigueEffect: StatusEffect<CardComponent> = {
 			player.hooks.onTurnEnd,
 			onTurnEnd.ON_STATUS_EFFECT_TIMEOUT,
 			() => {
-				effect.remove()
+				if (!effect.counter) return
+
+				effect.counter--
+				if (effect.counter === 0) {
+					effect.remove()
+					return
+				}
 			},
 		)
 	},

--- a/common/status-effects/status-effect.ts
+++ b/common/status-effects/status-effect.ts
@@ -117,5 +117,5 @@ export const damageEffect = {
 export function isCounter<T extends CardComponent | PlayerComponent>(
 	effect: StatusEffect<T>,
 ): effect is Counter<T> {
-	return effect.counter !== undefined
+	return effect.counter !== undefined && 'counterType' in effect
 }

--- a/tests/unit/game/advent-of-tcg/effects/elder-guardian.test.ts
+++ b/tests/unit/game/advent-of-tcg/effects/elder-guardian.test.ts
@@ -1,11 +1,22 @@
 import {describe, expect, test} from '@jest/globals'
 import ElderGuardian from 'common/cards/advent-of-tcg/attach/elder-guardian'
+import GrianchRare from 'common/cards/advent-of-tcg/hermits/grianch-rare'
 import EthosLabCommon from 'common/cards/hermits/ethoslab-common'
 import GeminiTayCommon from 'common/cards/hermits/geminitay-common'
+import BalancedItem from 'common/cards/items/balanced-common'
+import BalancedDoubleItem from 'common/cards/items/balanced-rare'
+import Anvil from 'common/cards/single-use/anvil'
+import Efficiency from 'common/cards/single-use/efficiency'
 import {CardComponent, StatusEffectComponent} from 'common/components'
 import query from 'common/components/query'
 import {SingleTurnMiningFatigueEffect} from 'common/status-effects/mining-fatigue'
-import {attack, endTurn, playCardFromHand, testGame} from '../../utils'
+import {
+	applyEffect,
+	attack,
+	endTurn,
+	playCardFromHand,
+	testGame,
+} from '../../utils'
 
 describe('Test Elder Guardian', () => {
 	test('Test mining fatigue is applied', () => {
@@ -28,6 +39,8 @@ describe('Test Elder Guardian', () => {
 							query.not(query.effect.targetEntity(null)),
 						),
 					).not.toBeNull()
+					yield* endTurn(game)
+					yield* endTurn(game)
 
 					expect(
 						game.components
@@ -64,6 +77,126 @@ describe('Test Elder Guardian', () => {
 				},
 			},
 			{startWithAllCards: true, noItemRequirements: true},
+		)
+	})
+
+	test('Mining Fatigue functionality', () => {
+		testGame(
+			{
+				playerOneDeck: [EthosLabCommon, ElderGuardian],
+				playerTwoDeck: [
+					EthosLabCommon,
+					BalancedItem,
+					BalancedDoubleItem,
+					BalancedItem,
+				],
+				saga: function* (game) {
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
+					yield* playCardFromHand(game, ElderGuardian, 'attach', 0)
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
+					yield* playCardFromHand(game, BalancedItem, 'item', 0, 0)
+					yield* attack(game, 'primary')
+					yield* endTurn(game)
+
+					yield* endTurn(game)
+
+					expect(game.state.turn.availableActions).not.toContain(
+						'PRIMARY_ATTACK',
+					)
+					yield* playCardFromHand(game, BalancedDoubleItem, 'item', 0, 1)
+					expect(game.state.turn.availableActions).toContain('PRIMARY_ATTACK')
+					yield* attack(game, 'primary')
+					yield* endTurn(game)
+
+					yield* endTurn(game)
+
+					expect(game.state.turn.availableActions).not.toContain(
+						'SECONDARY_ATTACK',
+					)
+					yield* playCardFromHand(game, BalancedItem, 'item', 0, 2)
+					expect(game.state.turn.availableActions).toContain('SECONDARY_ATTACK')
+					yield* endTurn(game)
+				},
+			},
+			{startWithAllCards: true, noItemRequirements: false},
+		)
+	})
+
+	test('Efficiency works against Mining Fatigue', () => {
+		testGame(
+			{
+				playerOneDeck: [EthosLabCommon, ElderGuardian],
+				playerTwoDeck: [EthosLabCommon, Efficiency, Efficiency],
+				saga: function* (game) {
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
+					yield* playCardFromHand(game, ElderGuardian, 'attach', 0)
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
+					yield* playCardFromHand(game, Efficiency, 'single_use')
+					yield* applyEffect(game)
+					yield* attack(game, 'primary')
+					yield* endTurn(game)
+
+					yield* endTurn(game)
+
+					expect(game.state.turn.availableActions).not.toContain(
+						'PRIMARY_ATTACK',
+					)
+					expect(game.state.turn.availableActions).not.toContain(
+						'SECONDARY_ATTACK',
+					)
+					yield* playCardFromHand(game, Efficiency, 'single_use')
+					yield* applyEffect(game)
+					expect(game.state.turn.availableActions).toContain('PRIMARY_ATTACK')
+					expect(game.state.turn.availableActions).toContain('SECONDARY_ATTACK')
+				},
+			},
+			{startWithAllCards: true, noItemRequirements: false},
+		)
+	})
+
+	test('Mining Fatigue is not stacked by multiple attacks', () => {
+		testGame(
+			{
+				playerOneDeck: [
+					EthosLabCommon,
+					EthosLabCommon,
+					ElderGuardian,
+					ElderGuardian,
+				],
+				playerTwoDeck: [GrianchRare, Anvil],
+				saga: function* (game) {
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 1)
+					yield* playCardFromHand(game, ElderGuardian, 'attach', 0)
+					yield* playCardFromHand(game, ElderGuardian, 'attach', 1)
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, GrianchRare, 'hermit', 0)
+					yield* playCardFromHand(game, Anvil, 'single_use')
+					yield* attack(game, 'secondary')
+					expect(
+						game.components.filter(
+							StatusEffectComponent,
+							query.effect.is(SingleTurnMiningFatigueEffect),
+							query.effect.targetIsCardAnd(query.card.currentPlayer),
+						).length,
+					).toBe(1)
+					yield* attack(game, 'secondary')
+					expect(
+						game.components.filter(
+							StatusEffectComponent,
+							query.effect.is(SingleTurnMiningFatigueEffect),
+							query.effect.targetIsCardAnd(query.card.currentPlayer),
+						).length,
+					).toBe(1)
+					yield* endTurn(game)
+				},
+			},
+			{startWithAllCards: true, noItemRequirements: true, forceCoinFlip: true},
 		)
 	})
 })


### PR DESCRIPTION
- Fixes giving Mining Fatigue to wrong player when Elder Guardian is given to opponent with Emerald
- Fixes `SingleTurnMiningFatigue` being removed before the opponent's next full turn
- Fixes `SingleTurnMiningFatigue` stacking and logging removal/apply for refreshing status in wrong order
- Repurposes single-use mining fatigue tests for Elder Guardian