### PR TITLE
Fix issues with tooltips and deck builder on mobile

### DIFF
--- a/client/src/app/deck/layout/deck-sidebar.module.scss
+++ b/client/src/app/deck/layout/deck-sidebar.module.scss
@@ -61,18 +61,6 @@
 	display: none;
 }
 
-@media screen and (max-width: 720px) {
-	.bodyWrapper {
-		position: absolute;
-		background: #313233fd;
-		width: calc(100% + 4px);
-		transform: translateX(-2px);
-		max-height: calc(80vh);
-		z-index: 12;
-		border: 2px solid black;
-	}
-}
-
 // DESKTOP
 @media (min-width: 720px) {
 	.sidebar {
@@ -105,6 +93,10 @@
 @media (max-width: 720px) {
 	.sidebar {
 		border: 0px solid black;
+		position: relative;
+		display: flex;
+		max-height: 100%;
+		flex-direction: column;
 	}
 
 	.showOnMobile {
@@ -115,5 +107,15 @@
 	.hideOnMobile {
 		display: none;
 		visibility: hidden;
+	}
+
+	.bodyWrapper {
+		background: #313233fd;
+		width: calc(100% + 4px);
+		transform: translateX(-2px);
+		max-height: 100%;
+		z-index: 12;
+		border: 2px solid black;
+		border-bottom: 0px;
 	}
 }

--- a/client/src/components/card/card-tooltip.module.scss
+++ b/client/src/components/card/card-tooltip.module.scss
@@ -6,7 +6,7 @@
 		display: flex;
 		flex-direction: column;
 
-		>div>p {
+		> div > p {
 			color: var(--gray-300);
 		}
 	}
@@ -178,6 +178,25 @@
 
 	&.advent_of_tcg_ii {
 		color: #de9292;
+	}
+}
+
+.moveStats {
+	display: grid;
+	grid-auto-flow: row;
+	grid-template-columns: 4rem 100%;
+}
+
+.costItem {
+	vertical-align: text-bottom;
+	margin-right: 3px;
+	margin-left: 1px;
+
+	&.prankster {
+		filter: drop-shadow(1px 1px 0 rgb(116, 55, 168))
+			drop-shadow(1px -1px 0 rgb(116, 55, 168))
+			drop-shadow(-1px 1px 0 rgb(116, 55, 168))
+			drop-shadow(-1px -1px 0 rgb(116, 55, 168));
 	}
 }
 

--- a/client/src/components/card/card-tooltip.tsx
+++ b/client/src/components/card/card-tooltip.tsx
@@ -1,4 +1,5 @@
 import classNames from 'classnames'
+import {getCardTypeIcon} from 'common/cards/card'
 import {
 	Card,
 	hasDescription,
@@ -35,6 +36,7 @@ const HERMIT_TYPES: Record<string, string> = {
 
 type Props = {
 	card: WithoutFunctions<Card>
+	showStatsOnTooltip: boolean
 }
 
 const getDescription = (card: WithoutFunctions<Card>): React.ReactNode => {
@@ -51,6 +53,62 @@ const getDescription = (card: WithoutFunctions<Card>): React.ReactNode => {
 		text = formatText(`*${card.description}*`)
 	}
 	return FormattedText(text)
+}
+
+const getDescriptionWithStats = (
+	card: WithoutFunctions<Card>,
+): React.ReactNode => {
+	let text: FormattedTextNode = EmptyNode()
+	if (isHermit(card)) {
+		return (
+			<div>
+				<div>{FormattedText(formatText(`Health - **${card.health}**`))}</div>
+				<div className={css.moveStats}>
+					<div>
+						{card.primary.cost.map((type, i) => (
+							<img
+								width={'16px'}
+								height={'16px'}
+								key={i}
+								src={getCardTypeIcon(type)}
+								className={classNames(css.costItem, css[type])}
+							/>
+						))}
+					</div>
+					{FormattedText(
+						formatText(`**${card.primary.name}** - **${card.primary.damage}**`),
+					)}
+				</div>
+				{card.primary.power && (
+					<div>{FormattedText(formatText(card.primary.power))}</div>
+				)}
+				<div className={css.moveStats}>
+					<div>
+						{card.secondary.cost.map((type, i) => (
+							<img
+								width={'16px'}
+								height={'16px'}
+								key={i}
+								src={getCardTypeIcon(type)}
+								className={classNames(css.costItem, css[type])}
+							/>
+						))}
+					</div>
+					{FormattedText(
+						formatText(
+							`**${card.secondary.name}** - **${card.secondary.damage}**`,
+						),
+					)}
+				</div>
+				{card.secondary.power && (
+					<div>{FormattedText(formatText(card.secondary.power))}</div>
+				)}
+			</div>
+		)
+	} else if (hasDescription(card)) {
+		text = formatText(`*${card.description}*`)
+		return FormattedText(text)
+	}
 }
 
 const joinJsx = (array: Array<React.ReactNode>) => {
@@ -185,7 +243,7 @@ const getSidebarDescriptions = (
 	})
 }
 
-const CardInstanceTooltip = ({card}: Props) => {
+const CardInstanceTooltip = ({card, showStatsOnTooltip}: Props) => {
 	const settings = useSelector(getSettings)
 
 	return (
@@ -205,7 +263,9 @@ const CardInstanceTooltip = ({card}: Props) => {
 				<div className={css.description}>
 					{getExpansion(card)}
 					{getStrengthsAndWeaknesses(card)}
-					{getDescription(card)}
+					{showStatsOnTooltip
+						? getDescriptionWithStats(card)
+						: getDescription(card)}
 				</div>
 				<div></div>
 			</div>

--- a/client/src/components/card/card.tsx
+++ b/client/src/components/card/card.tsx
@@ -62,7 +62,9 @@ const Card = (props: CardReactProps) => {
 
 	return (
 		<Tooltip
-			tooltip={<CardInstanceTooltip card={props.card} />}
+			tooltip={
+				<CardInstanceTooltip card={props.card} showStatsOnTooltip={false} />
+			}
 			showAboveModal={props.tooltipAboveModal}
 		>
 			<button

--- a/client/src/components/card/mobile-card-component.tsx
+++ b/client/src/components/card/mobile-card-component.tsx
@@ -24,7 +24,12 @@ const MobileCardComponent = (props: CardReactProps) => {
 
 	return (
 		<Tooltip
-			tooltip={<CardInstanceTooltip card={props.cards[0].props} />}
+			tooltip={
+				<CardInstanceTooltip
+					card={props.cards[0].props}
+					showStatsOnTooltip={true}
+				/>
+			}
 			showAboveModal={props.tooltipAboveModal}
 		>
 			<div className={css.MobileCardComponentContainer}>

--- a/client/src/components/status-effects/status-effect-tooltip.module.scss
+++ b/client/src/components/status-effects/status-effect-tooltip.module.scss
@@ -39,3 +39,14 @@
 .counter {
 	font-family: MinecraftBold;
 }
+
+@media (max-width: 720px) {
+	.topLine {
+		gap: 8px;
+		font-size: 16px;
+	}
+
+	.description {
+		font-size: 16px;
+	}
+}

--- a/client/src/components/tooltip/tooltip.module.scss
+++ b/client/src/components/tooltip/tooltip.module.scss
@@ -20,18 +20,16 @@
 }
 
 .tooltipContainer {
-	width: 100%;
-	height: 100%;
+	width: 0px;
+	height: 0px;
 }
 
 .tooltipBox {
 	position: absolute;
 }
 
-@media screen and (max-width: 720px) {
-	.tooltip {
-		overflow: hidden;
-	}
+.tooltip {
+	overflow: hidden;
 }
 
 .smallTooltip {

--- a/client/src/components/tooltip/tooltip.module.scss
+++ b/client/src/components/tooltip/tooltip.module.scss
@@ -20,8 +20,12 @@
 }
 
 .tooltipContainer {
-	width: 0px;
-	height: 0px;
+	width: 100%;
+	height: 100%;
+	overflow: hidden;
+	position: absolute;
+	top: 0;
+	left: 0;
 }
 
 .tooltipBox {


### PR DESCRIPTION
- Fixes issue with save button not showing for some people on mobile
- Fixes issue where the tooltip would display in the wrong place for some elements
- Fixes issue where the tooltip would sometimes show offscreen
- Fixes issue where the status effect tooltips font size was way too big
- Fixes scrollbars sometimes appearing when clicking on tooltips
- Makes stats visible in mobile tooltip component, since it was a bit frustrating building a deck before. This issue will be further alleviated with PR #1085 