### PR TITLE
fix Aussie Ping flipping on consecutive turns after heads

### DIFF
--- a/common/status-effects/aussie-ping.ts
+++ b/common/status-effects/aussie-ping.ts
@@ -77,6 +77,15 @@ export const AussiePingEffect: StatusEffect<PlayerComponent> = {
 				if (gasLightRecord.length) {
 					updateGasLightRecord()
 					effect.remove()
+					if (flippedHeads) {
+						game.components
+							.new(
+								StatusEffectComponent,
+								AussiePingImmuneEffect,
+								effect.creator.entity,
+							)
+							.apply(player.entity)
+					}
 				}
 			},
 		)

--- a/tests/unit/game/hermits/pearlescentmoon-rare.test.ts
+++ b/tests/unit/game/hermits/pearlescentmoon-rare.test.ts
@@ -95,6 +95,13 @@ describe('Test Pearlescent Moon Rare', () => {
 							query.row.index(1),
 						)?.health,
 					).toBe(EthosLabCommon.health - 10 /* Anvil damage */)
+					expect(
+						game.components.find(
+							StatusEffectComponent,
+							query.effect.is(AussiePingImmuneEffect),
+							query.effect.targetEntity(game.opponentPlayer.entity),
+						),
+					).not.toBe(null)
 				},
 			},
 			{startWithAllCards: true, noItemRequirements: true, forceCoinFlip: true},


### PR DESCRIPTION
Fixes Aussie Ping not applying Immune status if either player brought a rare Skizzleman