### PR TITLE
Fix ignored battle log messages

### DIFF
--- a/common/models/battle-log-model.ts
+++ b/common/models/battle-log-model.ts
@@ -13,6 +13,7 @@ import {
 	RowEntity,
 	StatusEffectEntity,
 } from '../entities'
+import {serverMessages} from '../socket-messages/server-messages'
 import {StatusEffectLog} from '../status-effects/status-effect'
 import {BattleLogT, CurrentCoinFlip} from '../types/game-state'
 import {LineNode, formatText} from '../utils/formatting'
@@ -115,7 +116,7 @@ export class BattleLogModel {
 		)
 
 		broadcast(this.game.getPlayers(), {
-			type: 'CHAT_UPDATE',
+			type: serverMessages.CHAT_UPDATE,
 			messages: this.game.chat,
 		})
 	}
@@ -360,7 +361,7 @@ export class BattleLogModel {
 		})
 
 		broadcast(this.game.getPlayers(), {
-			type: 'CHAT_UPDATE',
+			type: serverMessages.CHAT_UPDATE,
 			messages: this.game.chat,
 		})
 	}


### PR DESCRIPTION
Battle log was never updated to use the message dictionary instead of string literals for sending updates to chat.