### PR TITLE
Improve Text For Games Endpoint in HOF

### DIFF
--- a/client/src/app/main-menu/hall-of-fame.tsx
+++ b/client/src/app/main-menu/hall-of-fame.tsx
@@ -103,7 +103,7 @@ type Props = {
 	setMenuSection: (section: string) => void
 }
 
-type Endpoints = 'decks' | 'cards' | 'game' | 'types'
+type Endpoints = 'decks' | 'cards' | 'games' | 'types'
 
 const cardOrderByOptions = {
 	winrate: 'Winrate',
@@ -188,7 +188,7 @@ function HallOfFame({setMenuSection}: Props) {
 			}
 			return url
 		},
-		game: () => {
+		games: () => {
 			if (endpointBefore !== null && endpointAfter !== null) {
 				return `games?after=${endpointAfter}&before=${endpointBefore}`
 			}
@@ -431,14 +431,24 @@ function HallOfFame({setMenuSection}: Props) {
 	const parseGame = (game: Record<string, any>) => {
 		return (
 			<table className={css.hallOfFameTableNoHeader}>
-				<tr>
-					<th>All time games</th>
-					<td>{game.allTimeGames}</td>
-				</tr>
-				<tr>
-					<th>Games since 1.0</th>
-					<td>{game.games}</td>
-				</tr>
+				{endpointAfter === null && endpointBefore === null && (
+					<>
+						<tr>
+							<th>All time games</th>
+							<td>{game.allTimeGames}</td>
+						</tr>
+						<tr>
+							<th>Games since 1.0</th>
+							<td>{game.games}</td>
+						</tr>
+					</>
+				)}
+				{(endpointAfter !== null || endpointBefore !== null) && (
+					<tr>
+						<th>Games Within Time Window</th>
+						<td>{game.games}</td>
+					</tr>
+				)}
 				<tr>
 					<th>Tie rate</th>
 					<td>{padDecimal(game.tieRate, 3)}</td>
@@ -589,7 +599,7 @@ function HallOfFame({setMenuSection}: Props) {
 			return parseDecks(data.body)
 		} else if (selectedEndpoint === 'cards') {
 			return parseCards(data)
-		} else if (selectedEndpoint === 'game') {
+		} else if (selectedEndpoint === 'games') {
 			return parseGame(data)
 		} else if (selectedEndpoint === 'types') {
 			return parseTypes(data)
@@ -629,7 +639,7 @@ function HallOfFame({setMenuSection}: Props) {
 									options={[
 										{name: 'Decks'},
 										{name: 'Cards'},
-										{name: 'Game'},
+										{name: 'Games'},
 										{name: 'Types'},
 									]}
 									showNames={true}

--- a/client/src/app/main-menu/hall-of-fame.tsx
+++ b/client/src/app/main-menu/hall-of-fame.tsx
@@ -445,7 +445,7 @@ function HallOfFame({setMenuSection}: Props) {
 				)}
 				{(endpointAfter !== null || endpointBefore !== null) && (
 					<tr>
-						<th>Games Within Time Window</th>
+						<th>Games</th>
 						<td>{game.games}</td>
 					</tr>
 				)}


### PR DESCRIPTION
Changes `Game` to `Games` in the endpoint dropdown menu and removes the "games since 1.0" field if a timeframe is selected.