### PR TITLE
Fix clamping row health to hermit's max after using Ladder

### DIFF
--- a/common/components/row-component.ts
+++ b/common/components/row-component.ts
@@ -107,6 +107,9 @@ export class RowComponent {
 		)
 		if (this.health === null) return
 		if (!hermit?.isHealth()) return
-		this.health = Math.min(this.health + amount, hermit.props.health)
+		this.health = Math.min(
+			this.health + amount,
+			Math.max(this.health, hermit.props.health),
+		)
 	}
 }

--- a/tests/unit/game/effects/ladder.test.ts
+++ b/tests/unit/game/effects/ladder.test.ts
@@ -131,8 +131,11 @@ describe('Test Ladder', () => {
 	})
 
 	test('Ladder allows row to have more health than hermit max', () => {
-		// Test is dependent on second hermit having greater max health
+		// Test is dependent on these inequalities
 		expect(FalseSymmetryRare.health).toBeLessThan(GrianCommon.health)
+		expect(EthosLabCommon.primary.damage).toBeLessThan(
+			GrianCommon.health - FalseSymmetryRare.health,
+		)
 
 		testGame(
 			{
@@ -154,6 +157,13 @@ describe('Test Ladder', () => {
 					expect(game.currentPlayer.activeRow?.health).toBe(GrianCommon.health)
 					yield* attack(game, 'secondary')
 					expect(game.currentPlayer.activeRow?.health).toBe(GrianCommon.health)
+					yield* endTurn(game)
+
+					yield* attack(game, 'primary')
+					expect(game.opponentPlayer.activeRow?.health).toBe(
+						GrianCommon.health - EthosLabCommon.primary.damage,
+					)
+					yield* endTurn(game)
 				},
 			},
 			{startWithAllCards: true, noItemRequirements: true, forceCoinFlip: true},

--- a/tests/unit/game/effects/ladder.test.ts
+++ b/tests/unit/game/effects/ladder.test.ts
@@ -1,6 +1,8 @@
 import {describe, expect, test} from '@jest/globals'
 import {IronArmor} from 'common/cards/attach/armor'
 import EthosLabCommon from 'common/cards/hermits/ethoslab-common'
+import FalseSymmetryRare from 'common/cards/hermits/falsesymmetry-rare'
+import GrianCommon from 'common/cards/hermits/grian-common'
 import SmallishbeansCommon from 'common/cards/hermits/smallishbeans-common'
 import BalancedItem from 'common/cards/items/balanced-common'
 import Ladder from 'common/cards/single-use/ladder'
@@ -125,6 +127,36 @@ describe('Test Ladder', () => {
 				},
 			},
 			{startWithAllCards: true, noItemRequirements: true},
+		)
+	})
+
+	test('Ladder allows row to have more health than hermit max', () => {
+		// Test is dependent on second hermit having greater max health
+		expect(FalseSymmetryRare.health).toBeLessThan(GrianCommon.health)
+
+		testGame(
+			{
+				playerOneDeck: [EthosLabCommon],
+				playerTwoDeck: [FalseSymmetryRare, GrianCommon, Ladder],
+				saga: function* (game) {
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, FalseSymmetryRare, 'hermit', 1)
+					yield* playCardFromHand(game, GrianCommon, 'hermit', 0)
+					yield* playCardFromHand(game, Ladder, 'single_use')
+					yield* pick(
+						game,
+						query.slot.currentPlayer,
+						query.slot.hermit,
+						query.slot.rowIndex(0),
+					)
+					expect(game.currentPlayer.activeRow?.health).toBe(GrianCommon.health)
+					yield* attack(game, 'secondary')
+					expect(game.currentPlayer.activeRow?.health).toBe(GrianCommon.health)
+				},
+			},
+			{startWithAllCards: true, noItemRequirements: true, forceCoinFlip: true},
 		)
 	})
 })


### PR DESCRIPTION
- Fixes healing a Hermit above max health reducing health to their max health
- Adds test to prevent re-introducing bug where attacks could "deal extra damage" if `row.health - attack.calculateDamage()` was greater than `hermit.props.health`