### PR TITLE
Reorganization of Status Effects

### DIFF
--- a/common/status-effects/frozen.ts
+++ b/common/status-effects/frozen.ts
@@ -6,7 +6,7 @@ import {
 } from '../components'
 import query from '../components/query'
 import {afterAttack, beforeAttack} from '../types/priorities'
-import {StatusEffect, systemStatusEffect} from './status-effect'
+import {StatusEffect, statusEffect} from './status-effect'
 
 const hasNotFrozenHermit = (player: PlayerComponent) => [
 	query.slot.player(player.entity),
@@ -16,7 +16,7 @@ const hasNotFrozenHermit = (player: PlayerComponent) => [
 ]
 
 const FrozenEffect: StatusEffect<CardComponent> = {
-	...systemStatusEffect,
+	...statusEffect,
 	name: 'Frozen',
 	icon: 'frozen',
 	id: 'frozen',

--- a/common/status-effects/index.ts
+++ b/common/status-effects/index.ts
@@ -63,20 +63,18 @@ import UsedClockEffect from './used-clock'
 import WeaknessEffect from './weakness'
 
 export const STATUS_EFFECTS_LIST: Array<StatusEffect> = [
-	/* Regualr status effects */
-	FireEffect,
-	PoisonEffect,
+
+	/* Regualr Status Effects */ //statusEffect
+	FireEffect, //damageEffect
+	PoisonEffect, //damageEffect
 	SleepingEffect,
 	BadOmenEffect,
-	SlownessEffect,
-	WeaknessEffect,
-	ProtectedEffect,
-	DyedEffect,
-	MuseumCollectionEffect,
-	SmeltingEffect,
-	MelodyEffect,
+	RoyalProtectionEffect,
+	FrozenEffect,
+	MiningFatigueEffect,
+	SingleTurnMiningFatigueEffect,
 
-	/* System Status Effect */
+	/* System Status Effects */ //systemStatusEffect
 	ExBossNineEffect,
 	UsedClockEffect,
 	DeathloopReady,
@@ -87,7 +85,7 @@ export const STATUS_EFFECTS_LIST: Array<StatusEffect> = [
 	AussiePingImmuneEffect,
 	InvisibilityPotionHeadsEffect,
 	InvisibilityPotionTailsEffect,
-	TurnSkippedEffect,
+	TurnSkippedEffect, //hiddenStatusEffect
 	PrimaryAttackDisabledEffect,
 	SecondaryAttackDisabledEffect,
 	TrapHoleEffect,
@@ -97,26 +95,29 @@ export const STATUS_EFFECTS_LIST: Array<StatusEffect> = [
 	MultiturnSecondaryAttackDisabledEffect,
 	ChromaKeyedEffect,
 	GoMiningEffect,
-	RoyalProtectionEffect,
 	TargetBlockEffect,
-	GasLightEffect,
+	GasLightEffect, //hiddenStatusEffect
 	GasLightTriggeredEffect,
-	GasLightPotentialEffect,
+	GasLightPotentialEffect, //hiddenStatusEffect
 	IgnoreAttachSlotEffect,
 	EfficiencyEffect,
 	LooseShellEffect,
-	TFCDiscardedFromEffect,
+	TFCDiscardedFromEffect, //hiddenStatusEffect
 	TimeSkipDisabledEffect,
 	SoulmateEffect,
 	NaughtyRegiftEffect,
 	SpentFortuneEffect,
 	PoisonQuiverEffect,
-	SculkCatalystTriggeredEffect,
-	FrozenEffect,
-	MiningFatigueEffect,
-	SingleTurnMiningFatigueEffect,
+	SculkCatalystTriggeredEffect, //hiddenStatusEffect
 	SmithingTableEffect,
 	PostInspectorEffect,
+	SlownessEffect,
+	WeaknessEffect,
+	ProtectedEffect,
+	DyedEffect,
+	MuseumCollectionEffect,
+	SmeltingEffect,
+	MelodyEffect,
 ]
 
 export const STATUS_EFFECTS: Record<string, StatusEffect> =

--- a/common/status-effects/index.ts
+++ b/common/status-effects/index.ts
@@ -63,17 +63,18 @@ import UsedClockEffect from './used-clock'
 import WeaknessEffect from './weakness'
 
 export const STATUS_EFFECTS_LIST: Array<StatusEffect> = [
-	/* Regular Status Effects */ //statusEffect
-	FireEffect, //damageEffect
-	PoisonEffect, //damageEffect
+	/* Regular Status Effects */
 	SleepingEffect,
 	BadOmenEffect,
 	RoyalProtectionEffect,
 	FrozenEffect,
 	MiningFatigueEffect,
 	SingleTurnMiningFatigueEffect,
+	/* Damage Effects */
+	FireEffect,
+	PoisonEffect,
 
-	/* System Status Effects */ //systemStatusEffect
+	/* System Status Effects */
 	ExBossNineEffect,
 	UsedClockEffect,
 	DeathloopReady,
@@ -84,7 +85,6 @@ export const STATUS_EFFECTS_LIST: Array<StatusEffect> = [
 	AussiePingImmuneEffect,
 	InvisibilityPotionHeadsEffect,
 	InvisibilityPotionTailsEffect,
-	TurnSkippedEffect, //hiddenStatusEffect
 	PrimaryAttackDisabledEffect,
 	SecondaryAttackDisabledEffect,
 	TrapHoleEffect,
@@ -95,19 +95,15 @@ export const STATUS_EFFECTS_LIST: Array<StatusEffect> = [
 	ChromaKeyedEffect,
 	GoMiningEffect,
 	TargetBlockEffect,
-	GasLightEffect, //hiddenStatusEffect
 	GasLightTriggeredEffect,
-	GasLightPotentialEffect, //hiddenStatusEffect
 	IgnoreAttachSlotEffect,
 	EfficiencyEffect,
 	LooseShellEffect,
-	TFCDiscardedFromEffect, //hiddenStatusEffect
 	TimeSkipDisabledEffect,
 	SoulmateEffect,
 	NaughtyRegiftEffect,
 	SpentFortuneEffect,
 	PoisonQuiverEffect,
-	SculkCatalystTriggeredEffect, //hiddenStatusEffect
 	SmithingTableEffect,
 	PostInspectorEffect,
 	SlownessEffect,
@@ -117,6 +113,12 @@ export const STATUS_EFFECTS_LIST: Array<StatusEffect> = [
 	MuseumCollectionEffect,
 	SmeltingEffect,
 	MelodyEffect,
+	/* Hidden Status Effects */
+	TurnSkippedEffect,
+	GasLightEffect,
+	GasLightPotentialEffect,
+	TFCDiscardedFromEffect,
+	SculkCatalystTriggeredEffect,
 ]
 
 export const STATUS_EFFECTS: Record<string, StatusEffect> =

--- a/common/status-effects/index.ts
+++ b/common/status-effects/index.ts
@@ -63,8 +63,7 @@ import UsedClockEffect from './used-clock'
 import WeaknessEffect from './weakness'
 
 export const STATUS_EFFECTS_LIST: Array<StatusEffect> = [
-
-	/* Regualr Status Effects */ //statusEffect
+	/* Regular Status Effects */ //statusEffect
 	FireEffect, //damageEffect
 	PoisonEffect, //damageEffect
 	SleepingEffect,

--- a/common/status-effects/slowness.ts
+++ b/common/status-effects/slowness.ts
@@ -5,10 +5,10 @@ import {
 } from '../components'
 import {GameModel} from '../models/game-model'
 import {afterAttack, onTurnEnd} from '../types/priorities'
-import {Counter, statusEffect} from './status-effect'
+import {Counter, systemStatusEffect} from './status-effect'
 
 const SlownessEffect: Counter<CardComponent> = {
-	...statusEffect,
+	...systemStatusEffect,
 	id: 'slowness',
 	icon: 'slowness',
 	name: 'Slowness',

--- a/common/status-effects/weakness.ts
+++ b/common/status-effects/weakness.ts
@@ -6,10 +6,10 @@ import {
 } from '../components'
 import {GameModel} from '../models/game-model'
 import {beforeAttack} from '../types/priorities'
-import {Counter, statusEffect} from './status-effect'
+import {Counter, systemStatusEffect} from './status-effect'
 
 const WeaknessEffect: Counter<PlayerComponent> = {
-	...statusEffect,
+	...systemStatusEffect,
 	id: 'weakness',
 	icon: 'weakness',
 	name: 'Weakness',


### PR DESCRIPTION
From my understanding, a regular status effect is directly mentioned in the description as a thing.
- Frozen was mentioned by Powder Snow Bucket as its own thing, thus, a regular one.
- Potion of Slowness' description only says to disable the secondary effect. Slowness effect should be a system status effect.
- Same for weakness, but this time, as a mechanic, it's not even inflicting a hermit or a player with weakness.

And quite a few were just listed in the wrong section of the index file.