### PR TITLE
Fix Composter and Jingler Not Specifying the Current Player's Hand

### DIFF
--- a/common/cards/hermits/jingler-rare.ts
+++ b/common/cards/hermits/jingler-rare.ts
@@ -54,7 +54,7 @@ const JinglerRare: Hermit = {
 					player: opponentPlayer.entity,
 					id: component.entity,
 					message: 'Pick 1 card from your hand to discard',
-					canPick: query.slot.hand,
+					canPick: query.every(query.slot.currentPlayer, query.slot.hand),
 					onResult(pickedSlot) {
 						pickedSlot.getCard()?.discard()
 					},

--- a/common/cards/single-use/composter.ts
+++ b/common/cards/single-use/composter.ts
@@ -33,7 +33,7 @@ const Composter: SingleUse = {
 			player: player.entity,
 			id: component.entity,
 			message: 'Pick 2 cards from your hand',
-			canPick: query.slot.hand,
+			canPick: query.every(query.slot.currentPlayer, query.slot.hand),
 			onResult(pickedSlot) {
 				firstPickedSlot = pickedSlot
 			},
@@ -46,6 +46,7 @@ const Composter: SingleUse = {
 			canPick: (game, pos) => {
 				if (firstPickedSlot === null) return false
 				return query.every(
+					query.slot.currentPlayer,
 					query.slot.hand,
 					query.not(query.slot.entity(firstPickedSlot.entity)),
 				)(game, pos)

--- a/common/components/query/slot.ts
+++ b/common/components/query/slot.ts
@@ -64,7 +64,7 @@ export const active: ComponentQuery<SlotComponent> = (_game, pos) => {
 	return pos.onBoard() && pos.player?.activeRowEntity === pos.rowEntity
 }
 
-/* Return true if the slot is in a player's hand */
+/* Return true if the slot is in the current player's hand */
 export const hand: ComponentQuery<SlotComponent> = (_game, pos) => {
 	return pos.type === 'hand'
 }

--- a/common/components/query/slot.ts
+++ b/common/components/query/slot.ts
@@ -64,7 +64,7 @@ export const active: ComponentQuery<SlotComponent> = (_game, pos) => {
 	return pos.onBoard() && pos.player?.activeRowEntity === pos.rowEntity
 }
 
-/* Return true if the slot is in the current player's hand */
+/* Return true if the slot is in a player's hand */
 export const hand: ComponentQuery<SlotComponent> = (_game, pos) => {
 	return pos.type === 'hand'
 }


### PR DESCRIPTION
This allows for actions to happen that should NOT be a allowed. This will be important if we make AIs that rely on cards doing random actions based on pick requests.

Patches #1201 