### PR TITLE
Fix card type being marked as playable incorrectly 

### DIFF
--- a/server/src/routines/game.ts
+++ b/server/src/routines/game.ts
@@ -245,16 +245,48 @@ function getAvailableActions(
 
 				if (pickableSlots.length === 0) return reducer
 
-				if (card.isHealth() && !reducer.includes('PLAY_HERMIT_CARD')) {
+				if (
+					card.isHealth() &&
+					!reducer.includes('PLAY_HERMIT_CARD') &&
+					game.components.find(
+						SlotComponent,
+						card.props.attachCondition,
+						query.slot.hermit,
+					)
+				) {
 					reducer.push('PLAY_HERMIT_CARD')
 				}
-				if (card.isAttach() && !reducer.includes('PLAY_EFFECT_CARD')) {
+				if (
+					card.isAttach() &&
+					!reducer.includes('PLAY_EFFECT_CARD') &&
+					game.components.find(
+						SlotComponent,
+						card.props.attachCondition,
+						query.slot.attach,
+					)
+				) {
 					reducer.push('PLAY_EFFECT_CARD')
 				}
-				if (card.isItem() && !reducer.includes('PLAY_ITEM_CARD')) {
+				if (
+					card.isItem() &&
+					!reducer.includes('PLAY_ITEM_CARD') &&
+					game.components.find(
+						SlotComponent,
+						card.props.attachCondition,
+						query.slot.item,
+					)
+				) {
 					reducer.push('PLAY_ITEM_CARD')
 				}
-				if (card.isSingleUse() && !reducer.includes('PLAY_SINGLE_USE_CARD')) {
+				if (
+					card.isSingleUse() &&
+					!reducer.includes('PLAY_SINGLE_USE_CARD') &&
+					game.components.find(
+						SlotComponent,
+						card.props.attachCondition,
+						query.slot.singleUse,
+					)
+				) {
 					reducer.push('PLAY_SINGLE_USE_CARD')
 				}
 				return reducer

--- a/tests/fuzz/fuzz-ai.ts
+++ b/tests/fuzz/fuzz-ai.ts
@@ -128,6 +128,7 @@ function getNextTurnAction(
 	}
 
 	if (nextAction === 'PLAY_SINGLE_USE_CARD') {
+		console.log('here')
 		const card = choose(
 			game.components.filter(
 				CardComponent,
@@ -333,7 +334,9 @@ export const FuzzAI: VirtualAI = {
 	id: 'fuzz_ai',
 	getTurnActions: function* (game, component) {
 		while (true) {
-			yield getNextTurnAction(game, component)
+			let next = getNextTurnAction(game, component)
+			console.log(next)
+			yield next
 		}
 	},
 }

--- a/tests/fuzz/fuzz-ai.ts
+++ b/tests/fuzz/fuzz-ai.ts
@@ -128,7 +128,6 @@ function getNextTurnAction(
 	}
 
 	if (nextAction === 'PLAY_SINGLE_USE_CARD') {
-		console.log('here')
 		const card = choose(
 			game.components.filter(
 				CardComponent,
@@ -334,9 +333,7 @@ export const FuzzAI: VirtualAI = {
 	id: 'fuzz_ai',
 	getTurnActions: function* (game, component) {
 		while (true) {
-			let next = getNextTurnAction(game, component)
-			console.log(next)
-			yield next
+			yield getNextTurnAction(game, component)
 		}
 	},
 }

--- a/tests/unit/game/hermits/geminitay-rare.test.ts
+++ b/tests/unit/game/hermits/geminitay-rare.test.ts
@@ -19,6 +19,8 @@ import {
 	playCardFromHand,
 	testGame,
 } from '../utils'
+import {SplashPotionOfHealing} from 'common/cards/single-use/splash-potion-of-healing'
+import MilkBucket from 'common/cards/attach/milk-bucket'
 
 describe('Test Gemini Tay', () => {
 	test('Test Axe Functions Until End Of Turn', () => {


### PR DESCRIPTION
Fixes card action A being marked as playable when you have a card that is of two types, A, B, but could only be played in slot B.