### PR TITLE
Fix "Bop 'N' Go" passive interaction with Attach

### DIFF
--- a/common/cards/advent-of-tcg/attach/brewing-stand.ts
+++ b/common/cards/advent-of-tcg/attach/brewing-stand.ts
@@ -31,6 +31,7 @@ const BrewingStand: Attach = {
 
 			if (component.slot.row.entity !== player.activeRowEntity) return
 
+			/** @todo This flip does not get logged, may have to be added manually */
 			const flip = flipCoin(game, player, component)[0]
 			if (flip !== 'heads') return
 

--- a/common/cards/advent-of-tcg/attach/brewing-stand.ts
+++ b/common/cards/advent-of-tcg/attach/brewing-stand.ts
@@ -23,7 +23,10 @@ const BrewingStand: Attach = {
 		const {player} = component
 
 		observer.subscribe(player.hooks.onTurnStart, () => {
-			if (!component.slot.inRow() || component.slot.row.getItems().length === 0)
+			if (
+				!component.slot.inRow() ||
+				component.slot.row.getItems(true).length === 0
+			)
 				return
 
 			if (component.slot.row.entity !== player.activeRowEntity) return

--- a/common/status-effects/smelting.ts
+++ b/common/status-effects/smelting.ts
@@ -28,7 +28,7 @@ const SmeltingEffect: Counter<CardComponent> = {
 			effect.counter -= 1
 			if (effect.counter === 0) {
 				if (target.slot.inRow()) {
-					target.slot.row.getItems().forEach((item) => {
+					target.slot.row.getItems(true).forEach((item) => {
 						if (item.isItem() && item.props.id.includes('common')) {
 							// Create a new double item and delete the old single item
 							game.components.new(


### PR DESCRIPTION
Brewing Stand and Furnace are no longer affected by Cyberpunk Impulse's passive
Fixes #1209