### PR TITLE
Move Copy Attack Modal Blocked Actions To Backend

### DIFF
--- a/client/src/app/game/modals/copy-attack-modal.tsx
+++ b/client/src/app/game/modals/copy-attack-modal.tsx
@@ -54,9 +54,8 @@ function CopyAttackModal({closeModal}: Props) {
 		closeModal()
 	}
 
-	let isPrimaryAvailable = !modalData.blockedActions.includes('PRIMARY_ATTACK')
-	let isSecondaryAvailable =
-		!modalData.blockedActions.includes('SECONDARY_ATTACK')
+	let isPrimaryAvailable = modalData.availableAttacks.includes('primary')
+	let isSecondaryAvailable = modalData.availableAttacks.includes('secondary')
 
 	return (
 		<Modal

--- a/common/cards/hermits/evilxisuma_rare.ts
+++ b/common/cards/hermits/evilxisuma_rare.ts
@@ -70,7 +70,7 @@ const EvilXisumaRare: Hermit = {
 				)
 				if (!opponentActiveHermit?.isAlive()) return
 
-				game.addModalRequest({
+				game.addCopyAttackModalRequest({
 					player: player.entity,
 					modal: {
 						type: 'copyAttack',

--- a/common/cards/hermits/rendog-rare.ts
+++ b/common/cards/hermits/rendog-rare.ts
@@ -119,7 +119,7 @@ const RendogRare: Hermit = {
 						let pickedCard = pickedSlot.getCard() as CardComponent<Hermit>
 						if (!pickedCard) return
 
-						game.addModalRequest({
+						game.addCopyAttackModalRequest({
 							player: player.entity,
 							modal: {
 								type: 'copyAttack',

--- a/common/cards/hermits/zombiecleo-rare.ts
+++ b/common/cards/hermits/zombiecleo-rare.ts
@@ -98,7 +98,7 @@ const ZombieCleoRare: Hermit = {
 							pickedSlot.getCard() as CardComponent<Hermit> | null
 						if (!pickedCard) return
 
-						game.addModalRequest({
+						game.addCopyAttackModalRequest({
 							player: player.entity,
 							modal: {
 								type: 'copyAttack',

--- a/common/models/game-model.ts
+++ b/common/models/game-model.ts
@@ -356,7 +356,7 @@ export class GameModel {
 
 	public addCopyAttackModalRequest(
 		newRequest: Omit<CopyAttack.Request, 'modal'> & {
-			modal: Omit<CopyAttack.Request['modal'], 'blockedActions'>
+			modal: Omit<CopyAttack.Request['modal'], 'availableAttacks'>
 		},
 		before = false,
 	) {

--- a/common/models/game-model.ts
+++ b/common/models/game-model.ts
@@ -417,11 +417,20 @@ export class GameModel {
 		)
 			blockedActions.push('SECONDARY_ATTACK')
 
-		const requestWithBlockedActions = {
-			...newRequest,
-			modal: {...modal, blockedActions: []},
+		let attacks: Array<'primary' | 'secondary'> = ['primary', 'secondary']
+
+		if (blockedActions.includes('PRIMARY_ATTACK')) {
+			attacks.filter((x) => x != 'primary')
 		}
-		this.addModalRequest(requestWithBlockedActions, before)
+		if (blockedActions.includes('SECONDARY_ATTACK')) {
+			attacks.filter((x) => x != 'secondary')
+		}
+
+		const request: CopyAttack.Request = {
+			...newRequest,
+			modal: {...modal, availableAttacks: attacks},
+		}
+		this.addModalRequest(request, before)
 	}
 
 	public removeModalRequest(index = 0, timeout = true) {

--- a/common/models/game-model.ts
+++ b/common/models/game-model.ts
@@ -1,4 +1,5 @@
 import assert from 'assert'
+import JoeHillsRare from '../cards/hermits/joehills-rare'
 import {
 	CardComponent,
 	PlayerComponent,
@@ -9,6 +10,15 @@ import {
 import query, {ComponentQuery} from '../components/query'
 import {CONFIG, DEBUG_CONFIG} from '../config'
 import {PlayerEntity, SlotEntity} from '../entities'
+import {
+	MultiturnPrimaryAttackDisabledEffect,
+	MultiturnSecondaryAttackDisabledEffect,
+} from '../status-effects/multiturn-attack-disabled'
+import {
+	PrimaryAttackDisabledEffect,
+	SecondaryAttackDisabledEffect,
+} from '../status-effects/singleturn-attack-disabled'
+import TimeSkipDisabledEffect from '../status-effects/time-skip-disabled'
 import {AttackDefs} from '../types/attack'
 import ComponentTable from '../types/ecs'
 import {
@@ -37,16 +47,6 @@ import {
 } from '../utils/state-gen'
 import {AttackModel, ReadonlyAttackModel} from './attack-model'
 import {BattleLogModel} from './battle-log-model'
-import {
-	PrimaryAttackDisabledEffect,
-	SecondaryAttackDisabledEffect,
-} from '../status-effects/singleturn-attack-disabled'
-import {
-	MultiturnPrimaryAttackDisabledEffect,
-	MultiturnSecondaryAttackDisabledEffect,
-} from '../status-effects/multiturn-attack-disabled'
-import TimeSkipDisabledEffect from '../status-effects/time-skip-disabled'
-import JoeHillsRare from '../cards/hermits/joehills-rare'
 
 export type GameSettings = {
 	maxTurnTime: number

--- a/common/models/game-model.ts
+++ b/common/models/game-model.ts
@@ -4,6 +4,7 @@ import {
 	PlayerComponent,
 	RowComponent,
 	SlotComponent,
+	StatusEffectComponent,
 } from '../components'
 import query, {ComponentQuery} from '../components/query'
 import {CONFIG, DEBUG_CONFIG} from '../config'
@@ -36,6 +37,16 @@ import {
 } from '../utils/state-gen'
 import {AttackModel, ReadonlyAttackModel} from './attack-model'
 import {BattleLogModel} from './battle-log-model'
+import {
+	PrimaryAttackDisabledEffect,
+	SecondaryAttackDisabledEffect,
+} from '../status-effects/singleturn-attack-disabled'
+import {
+	MultiturnPrimaryAttackDisabledEffect,
+	MultiturnSecondaryAttackDisabledEffect,
+} from '../status-effects/multiturn-attack-disabled'
+import TimeSkipDisabledEffect from '../status-effects/time-skip-disabled'
+import JoeHillsRare from '../cards/hermits/joehills-rare'
 
 export type GameSettings = {
 	maxTurnTime: number
@@ -342,6 +353,77 @@ export class GameModel {
 			this.state.modalRequests.push(newRequest)
 		}
 	}
+
+	public addCopyAttackModalRequest(
+		newRequest: Omit<CopyAttack.Request, 'modal'> & {
+			modal: Omit<CopyAttack.Request['modal'], 'blockedActions'>
+		},
+		before = false,
+	) {
+		let modal = newRequest.modal
+		let hermitCard = this.components.get(modal.hermitCard)!
+		let blockedActions = hermitCard.player.hooks.blockedActions.callSome(
+			[[]],
+			(observerEntity) => {
+				let observer = this.components.get(observerEntity)
+				return observer?.wrappingEntity === hermitCard.entity
+			},
+		)
+
+		/* Due to an issue with the blocked actions system, we have to check if our target has thier action
+		 * blocked by status effects here.
+		 */
+		if (
+			this.components.exists(
+				StatusEffectComponent,
+				query.effect.is(
+					PrimaryAttackDisabledEffect,
+					MultiturnPrimaryAttackDisabledEffect,
+				),
+				query.effect.targetIsCardAnd(
+					query.card.entity(hermitCard.entity),
+					query.card.currentPlayer,
+				),
+			) ||
+			(hermitCard.isHermit() && hermitCard.props.primary.passive)
+		) {
+			blockedActions.push('PRIMARY_ATTACK')
+		}
+
+		if (
+			this.components.exists(
+				StatusEffectComponent,
+				query.effect.is(
+					SecondaryAttackDisabledEffect,
+					MultiturnSecondaryAttackDisabledEffect,
+				),
+				query.effect.targetIsCardAnd(
+					query.card.entity(hermitCard.entity),
+					query.card.currentPlayer,
+				),
+			) ||
+			(hermitCard.isHermit() && hermitCard.props.secondary.passive)
+		) {
+			blockedActions.push('SECONDARY_ATTACK')
+		}
+
+		if (
+			this.components.exists(
+				StatusEffectComponent,
+				query.effect.is(TimeSkipDisabledEffect),
+				query.effect.targetIsPlayerAnd(query.player.currentPlayer),
+			) &&
+			query.card.is(JoeHillsRare)(this, hermitCard)
+		)
+			blockedActions.push('SECONDARY_ATTACK')
+
+		const requestWithBlockedActions = {
+			...newRequest,
+			modal: {...modal, blockedActions: []},
+		}
+		this.addModalRequest(requestWithBlockedActions, before)
+	}
+
 	public removeModalRequest(index = 0, timeout = true) {
 		if (this.state.modalRequests[index] !== undefined) {
 			const request = this.state.modalRequests.splice(index, 1)[0]

--- a/common/models/game-model.ts
+++ b/common/models/game-model.ts
@@ -420,10 +420,10 @@ export class GameModel {
 		let attacks: Array<'primary' | 'secondary'> = ['primary', 'secondary']
 
 		if (blockedActions.includes('PRIMARY_ATTACK')) {
-			attacks.filter((x) => x != 'primary')
+			attacks = attacks.filter((x) => x != 'primary')
 		}
 		if (blockedActions.includes('SECONDARY_ATTACK')) {
-			attacks.filter((x) => x != 'secondary')
+			attacks = attacks.filter((x) => x != 'secondary')
 		}
 
 		const request: CopyAttack.Request = {

--- a/common/types/modal-requests.ts
+++ b/common/types/modal-requests.ts
@@ -1,6 +1,5 @@
 import {CardComponent} from '../components'
 import {CardEntity, PlayerEntity} from '../entities'
-import {TurnAction} from './game-state'
 
 export type ModalRequest =
 	| SelectCards.Request
@@ -120,7 +119,7 @@ export namespace CopyAttack {
 		/** Show a close button on this modal. */
 		cancelable: boolean
 		/** The actions that can not be used in this modal */
-		blockedActions: Array<TurnAction>
+		availableAttacks: Array<'primary' | 'secondary'>
 	}
 
 	export type Result =

--- a/common/types/modal-requests.ts
+++ b/common/types/modal-requests.ts
@@ -1,5 +1,6 @@
 import {CardComponent} from '../components'
 import {CardEntity, PlayerEntity} from '../entities'
+import {TurnAction} from './game-state'
 
 export type ModalRequest =
 	| SelectCards.Request
@@ -118,6 +119,8 @@ export namespace CopyAttack {
 		hermitCard: CardEntity
 		/** Show a close button on this modal. */
 		cancelable: boolean
+		/** The actions that can not be used in this modal */
+		blockedActions: Array<TurnAction>
 	}
 
 	export type Result =

--- a/common/types/server-requests.ts
+++ b/common/types/server-requests.ts
@@ -11,7 +11,6 @@ import {StatusEffect} from '../status-effects/status-effect'
 import {ButtonVariant} from './buttons'
 import {SlotTypeT} from './cards'
 import {Deck} from './deck'
-import {TurnActions} from './game-state'
 
 export type PlayerInfo = {
 	playerName: string
@@ -127,7 +126,7 @@ export namespace LocalCopyAttack {
 		name: string
 		description: string
 		hermitCard: LocalCardInstance
-		blockedActions: TurnActions
+		availableAttacks: Array<'primary' | 'secondary'>
 		cancelable: boolean
 	}
 

--- a/server/src/routines/turn-actions.ts
+++ b/server/src/routines/turn-actions.ts
@@ -20,7 +20,6 @@ import {
 } from 'common/types/turn-action-data'
 import {executeAttacks} from 'common/utils/attacks'
 import {applySingleUse} from 'common/utils/board'
-import {getLocalModalData} from '../utils/state-gen'
 
 function getAttack(
 	game: GameModel,
@@ -331,9 +330,9 @@ export function modalRequestAction(
 		let modal = modalResult as CopyAttack.Result
 		assert(
 			!modal.pick ||
-				!(
-					getLocalModalData(game, modalRequest.modal) as LocalCopyAttack.Data
-				).blockedActions.includes(attackToAttackAction[modal.pick]),
+				!modalRequest.modal.blockedActions.includes(
+					attackToAttackAction[modal.pick],
+				),
 			`Client picked a blocked attack to copy: ${modal.pick}`,
 		)
 		modalRequest_.onResult(modal)

--- a/server/src/routines/turn-actions.ts
+++ b/server/src/routines/turn-actions.ts
@@ -329,11 +329,8 @@ export function modalRequestAction(
 		let modalRequest_ = modalRequest as CopyAttack.Request
 		let modal = modalResult as CopyAttack.Result
 		assert(
-			!modal.pick ||
-				!modalRequest.modal.blockedActions.includes(
-					attackToAttackAction[modal.pick],
-				),
-			`Client picked a blocked attack to copy: ${modal.pick}`,
+			!modal.pick || modalRequest.modal.availableAttacks.includes(modal.pick),
+			`Client picked an action that was not available to copy: ${modal.pick}`,
 		)
 		modalRequest_.onResult(modal)
 	} else throw Error('Unknown modal type')

--- a/server/src/utils/state-gen.ts
+++ b/server/src/utils/state-gen.ts
@@ -101,65 +101,9 @@ export function getLocalModalData(
 		}
 	} else if (modal.type === 'copyAttack') {
 		let hermitCard = game.components.get(modal.hermitCard)!
-		let blockedActions = hermitCard.player.hooks.blockedActions.callSome(
-			[[]],
-			(observerEntity) => {
-				let observer = game.components.get(observerEntity)
-				return observer?.wrappingEntity === hermitCard.entity
-			},
-		)
-
-		/* Due to an issue with the blocked actions system, we have to check if our target has thier action
-		 * blocked by status effects here.
-		 */
-		if (
-			game.components.exists(
-				StatusEffectComponent,
-				query.effect.is(
-					PrimaryAttackDisabledEffect,
-					MultiturnPrimaryAttackDisabledEffect,
-				),
-				query.effect.targetIsCardAnd(
-					query.card.entity(hermitCard.entity),
-					query.card.currentPlayer,
-				),
-			) ||
-			(hermitCard.isHermit() && hermitCard.props.primary.passive)
-		) {
-			blockedActions.push('PRIMARY_ATTACK')
-		}
-
-		if (
-			game.components.exists(
-				StatusEffectComponent,
-				query.effect.is(
-					SecondaryAttackDisabledEffect,
-					MultiturnSecondaryAttackDisabledEffect,
-				),
-				query.effect.targetIsCardAnd(
-					query.card.entity(hermitCard.entity),
-					query.card.currentPlayer,
-				),
-			) ||
-			(hermitCard.isHermit() && hermitCard.props.secondary.passive)
-		) {
-			blockedActions.push('SECONDARY_ATTACK')
-		}
-
-		if (
-			game.components.exists(
-				StatusEffectComponent,
-				query.effect.is(TimeSkipDisabledEffect),
-				query.effect.targetIsPlayerAnd(query.player.currentPlayer),
-			) &&
-			query.card.is(JoeHillsRare)(game, hermitCard)
-		)
-			blockedActions.push('SECONDARY_ATTACK')
-
 		return {
 			...modal,
 			hermitCard: getLocalCard(game, hermitCard),
-			blockedActions: blockedActions,
 		}
 	}
 

--- a/server/src/utils/state-gen.ts
+++ b/server/src/utils/state-gen.ts
@@ -1,4 +1,3 @@
-import JoeHillsRare from 'common/cards/hermits/joehills-rare'
 import {Card} from 'common/cards/types'
 import {
 	CardComponent,
@@ -10,15 +9,6 @@ import {
 import query from 'common/components/query'
 import {PlayerEntity} from 'common/entities'
 import {GameModel} from 'common/models/game-model'
-import {
-	MultiturnPrimaryAttackDisabledEffect,
-	MultiturnSecondaryAttackDisabledEffect,
-} from 'common/status-effects/multiturn-attack-disabled'
-import {
-	PrimaryAttackDisabledEffect,
-	SecondaryAttackDisabledEffect,
-} from 'common/status-effects/singleturn-attack-disabled'
-import TimeSkipDisabledEffect from 'common/status-effects/time-skip-disabled'
 import {
 	CurrentCoinFlip,
 	LocalCurrentCoinFlip,

--- a/tests/fuzz/fuzz-ai.ts
+++ b/tests/fuzz/fuzz-ai.ts
@@ -256,7 +256,7 @@ function getNextTurnAction(
 				),
 				game.rng,
 			)
-			if (game.rng() <= 0.3) {
+			if (game.rng() <= 0.3 && modal.cancelable) {
 				action = 'cancel'
 			}
 

--- a/tests/fuzz/fuzz-ai.ts
+++ b/tests/fuzz/fuzz-ai.ts
@@ -251,8 +251,8 @@ function getNextTurnAction(
 			}
 		} else if (modal.type === 'copyAttack') {
 			let action = choose(
-				['PRIMARY_ATTACK', 'SECONDARY_ATTACK'].filter(
-					(x) => !modal.blockedActions.includes(x as TurnAction),
+				['primary', 'secondary'].filter((x) =>
+					modal.availableAttacks.includes(x as any),
 				),
 				game.rng,
 			)
@@ -260,14 +260,14 @@ function getNextTurnAction(
 				action = 'cancel'
 			}
 
-			if (action === 'PRIMARY_ATTACK') {
+			if (action === 'primary') {
 				return {
 					type: 'MODAL_REQUEST',
 					modalResult: {
 						pick: 'primary',
 					},
 				}
-			} else if (action === 'SECONDARY_ATTACK') {
+			} else if (action === 'secondary') {
 				return {
 					type: 'MODAL_REQUEST',
 					modalResult: {

--- a/tests/fuzz/fuzz-ai.ts
+++ b/tests/fuzz/fuzz-ai.ts
@@ -250,31 +250,36 @@ function getNextTurnAction(
 				},
 			}
 		} else if (modal.type === 'copyAttack') {
-			let rng = game.rng()
-			if (modal.cancelable && rng < 0.3) {
+			let action = choose(
+				['PRIMARY_ATTACK', 'SECONDARY_ATTACK'].filter(
+					(x) => !modal.blockedActions.includes(x as TurnAction),
+				),
+				game.rng,
+			)
+			if (game.rng() <= 0.3) {
+				action = 'cancel'
+			}
+
+			if (action === 'PRIMARY_ATTACK') {
 				return {
 					type: 'MODAL_REQUEST',
 					modalResult: {
-						cancel: true,
+						pick: 'primary',
 					},
 				}
-			} else {
-				let rng = game.rng()
-				if (modal.cancelable && rng < 0.5) {
-					return {
-						type: 'MODAL_REQUEST',
-						modalResult: {
-							pick: 'primary',
-						},
-					}
-				} else {
-					return {
-						type: 'MODAL_REQUEST',
-						modalResult: {
-							pick: 'secondary',
-						},
-					}
+			} else if (action === 'SECONDARY_ATTACK') {
+				return {
+					type: 'MODAL_REQUEST',
+					modalResult: {
+						pick: 'secondary',
+					},
 				}
+			}
+			return {
+				type: 'MODAL_REQUEST',
+				modalResult: {
+					cancel: true,
+				},
 			}
 		} else if (modal.type === 'dragCards') {
 			let rng = game.rng()

--- a/tests/unit/game/advent-of-tcg/hermits/zookeeperscar-rare.test.ts
+++ b/tests/unit/game/advent-of-tcg/hermits/zookeeperscar-rare.test.ts
@@ -13,8 +13,7 @@ import Mending from 'common/cards/single-use/mending'
 import {CardComponent, StatusEffectComponent} from 'common/components'
 import query from 'common/components/query'
 import {SingleTurnMiningFatigueEffect} from 'common/status-effects/mining-fatigue'
-import {LocalCopyAttack} from 'common/types/server-requests'
-import {getLocalModalData} from 'server/utils/state-gen'
+import {CopyAttack} from 'common/types/modal-requests'
 import {
 	applyEffect,
 	attack,
@@ -261,13 +260,9 @@ describe('Test Zookeeper Scar', () => {
 						query.slot.rowIndex(0),
 					)
 					expect(
-						(
-							getLocalModalData(
-								game,
-								game.state.modalRequests[0].modal,
-							) as LocalCopyAttack.Data
-						).blockedActions,
-					).toContain('PRIMARY_ATTACK')
+						(game.state.modalRequests[0].modal as CopyAttack.Data)
+							.availableAttacks,
+					).not.toContain('primary')
 					yield* finishModalRequest(game, {pick: 'secondary'})
 					expect(game.state.modalRequests).toStrictEqual([])
 					yield* endTurn(game)

--- a/tests/unit/game/hermits/rendog-rare.test.ts
+++ b/tests/unit/game/hermits/rendog-rare.test.ts
@@ -7,8 +7,7 @@ import ZombieCleoRare from 'common/cards/hermits/zombiecleo-rare'
 import Crossbow from 'common/cards/single-use/crossbow'
 import {RowComponent} from 'common/components'
 import query from 'common/components/query'
-import {LocalCopyAttack} from 'common/types/server-requests'
-import {getLocalModalData} from 'server/utils/state-gen'
+import {CopyAttack} from 'common/types/modal-requests'
 import {
 	attack,
 	changeActiveHermit,
@@ -41,13 +40,9 @@ describe('Test Rendog Role Play', () => {
 						query.slot.rowIndex(0),
 					)
 					expect(
-						(
-							getLocalModalData(
-								game,
-								game.state.modalRequests[0].modal,
-							) as LocalCopyAttack.Data
-						).blockedActions,
-					).toContain('SECONDARY_ATTACK')
+						(game.state.modalRequests[0].modal as CopyAttack.Data)
+							.availableAttacks,
+					).not.toContain('secondary')
 					yield* finishModalRequest(game, {pick: 'primary'})
 					yield* removeEffect(game)
 					expect(game.state.turn.availableActions).toContain('SECONDARY_ATTACK')
@@ -60,13 +55,9 @@ describe('Test Rendog Role Play', () => {
 						query.slot.rowIndex(0),
 					)
 					expect(
-						(
-							getLocalModalData(
-								game,
-								game.state.modalRequests[0].modal,
-							) as LocalCopyAttack.Data
-						).blockedActions,
-					).not.toContain('SECONDARY_ATTACK')
+						(game.state.modalRequests[0].modal as CopyAttack.Data)
+							.availableAttacks,
+					).toContain('secondary')
 					yield* finishModalRequest(game, {pick: 'secondary'})
 					yield* pick(
 						game,
@@ -111,13 +102,9 @@ describe('Test Rendog Role Play', () => {
 						query.slot.rowIndex(1),
 					)
 					expect(
-						(
-							getLocalModalData(
-								game,
-								game.state.modalRequests[0].modal,
-							) as LocalCopyAttack.Data
-						).blockedActions,
-					).toContain('SECONDARY_ATTACK')
+						(game.state.modalRequests[0].modal as CopyAttack.Data)
+							.availableAttacks,
+					).not.toContain('secondary')
 					yield* finishModalRequest(game, {pick: 'primary'})
 					yield* removeEffect(game)
 					yield* attack(game, 'secondary')
@@ -143,13 +130,9 @@ describe('Test Rendog Role Play', () => {
 						query.slot.rowIndex(1),
 					)
 					expect(
-						(
-							getLocalModalData(
-								game,
-								game.state.modalRequests[0].modal,
-							) as LocalCopyAttack.Data
-						).blockedActions,
-					).not.toContain('SECONDARY_ATTACK')
+						(game.state.modalRequests[0].modal as CopyAttack.Data)
+							.availableAttacks,
+					).toContain('secondary')
 					yield* finishModalRequest(game, {pick: 'secondary'})
 					yield* pick(
 						game,
@@ -206,13 +189,9 @@ describe('Test Rendog Role Play', () => {
 						query.slot.rowIndex(1),
 					)
 					expect(
-						(
-							getLocalModalData(
-								game,
-								game.state.modalRequests[0].modal,
-							) as LocalCopyAttack.Data
-						).blockedActions,
-					).toContain('SECONDARY_ATTACK')
+						(game.state.modalRequests[0].modal as CopyAttack.Data)
+							.availableAttacks,
+					).not.toContain('secondary')
 					yield* finishModalRequest(game, {pick: 'primary'})
 					yield* removeEffect(game)
 					yield* attack(game, 'secondary')

--- a/tests/unit/game/hermits/zombie-cleo-rare.test.ts
+++ b/tests/unit/game/hermits/zombie-cleo-rare.test.ts
@@ -22,8 +22,7 @@ import query from 'common/components/query'
 import {GameModel} from 'common/models/game-model'
 import ChromaKeyedEffect from 'common/status-effects/chroma-keyed'
 import {SecondaryAttackDisabledEffect} from 'common/status-effects/singleturn-attack-disabled'
-import {LocalCopyAttack} from 'common/types/server-requests'
-import {getLocalModalData} from 'server/utils/state-gen'
+import {CopyAttack} from 'common/types/modal-requests'
 import {
 	attack,
 	changeActiveHermit,
@@ -128,13 +127,8 @@ function* testAmnesiaBlocksPuppetryMock(game: GameModel) {
 		query.slot.rowIndex(0),
 	)
 	expect(
-		(
-			getLocalModalData(
-				game,
-				game.state.modalRequests[0].modal,
-			) as LocalCopyAttack.Data
-		).blockedActions,
-	).toContain('SECONDARY_ATTACK')
+		(game.state.modalRequests[0].modal as CopyAttack.Data).availableAttacks,
+	).not.toContain('secondary')
 	yield* finishModalRequest(game, {pick: 'primary'})
 }
 
@@ -390,13 +384,8 @@ function* testPuppetingTimeSkip(game: GameModel) {
 		query.slot.rowIndex(1),
 	)
 	expect(
-		(
-			getLocalModalData(
-				game,
-				game.state.modalRequests[0].modal,
-			) as LocalCopyAttack.Data
-		).blockedActions,
-	).toContain('SECONDARY_ATTACK')
+		(game.state.modalRequests[0].modal as CopyAttack.Data).availableAttacks,
+	).not.toContain('secondary')
 	yield* finishModalRequest(game, {pick: 'primary'})
 	yield* removeEffect(game)
 	yield* attack(game, 'secondary')


### PR DESCRIPTION
This gives the Fuzz Tester access to the blocked actions which it did not have before. It also makes the turn action file no longer require checking the client's version of the modal.
I am not sure if this breaks Evilx or Evilx was always like this.

Closes #1207 