### PR TITLE
Remove other actions when single-use requires confirmation

### DIFF
--- a/tests/unit/game/advent-of-tcg/hermits/biffa2001-rare.test.ts
+++ b/tests/unit/game/advent-of-tcg/hermits/biffa2001-rare.test.ts
@@ -129,8 +129,10 @@ describe('Test Biffa Secondary', () => {
 
 					yield* playCardFromHand(game, Biffa2001Rare, 'hermit', 1)
 					yield* playCardFromHand(game, PotionOfSlowness, 'single_use')
-					if (!game.state.turn.availableActions.includes('SECONDARY_ATTACK'))
-						yield* removeEffect(game)
+					expect(game.state.turn.availableActions).not.toContain(
+						'SECONDARY_ATTACK',
+					)
+					yield* removeEffect(game)
 					yield* attack(game, 'secondary')
 					expect(game.opponentPlayer.activeRow?.health).toBe(
 						EthosLabCommon.health -


### PR DESCRIPTION
If a Single Use effect requires a confirmation modal to apply, available actions is limited to `APPLY_EFFECT`, `REMOVE_EFFECT`, and `END_TURN`
Fixes #1213