### PR TITLE
Updates to docker-compose to enable full self hosting with local postgres DB.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,10 +129,10 @@ docker build . --build-arg APP_VERSION=$(git rev-parse --short HEAD)
 docker run -p 9000:9000 <Image Id>
 ```
 
-To host the project with the image on [docker hub](https://hub.docker.com/r/benji42/hc-tcg), install the docker-compose plugin then run the command:
+To host the project with the image on [docker hub](https://hub.docker.com/r/benji42/hc-tcg), install the docker-compose plugin, create a directory with the docker-compose.yml file (/etc/hctcg by default, can be changed by editing docker-compose.yml), create a directory in there for the db (mkdir -p /etc/hctcg/db or edit the docker-compose.yml if using a different directory) then run the command:
 
 ```sh
-docker compose up
+docker-compose up -d
 ```
 
-By default, the server will listen to requests on port 9000.
+By default, the server will listen to requests on port 9000.  The instance can be backed up by backing up the contents of /etc/hctcg (or whatever directory you specify)

--- a/README.md
+++ b/README.md
@@ -135,4 +135,4 @@ To host the project with the image on [docker hub](https://hub.docker.com/r/benj
 docker-compose up -d
 ```
 
-By default, the server will listen to requests on port 9000.  The instance can be backed up by backing up the contents of /etc/hctcg (or whatever directory you specify)
+By default, the server will listen to requests on port 9000.  The instance can be backed up by backing up the contents of /etc/hctcg (or whatever directory you specify).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,29 @@
-version: '2.1'
 services:
+  db:
+    image: postgres
+    restart: always
+    volumes:
+      - /etc/hctcg/db:/var/lib/postgresql/data
+    environment: 
+      - POSTGRES_USER=hctcg
+      - POSTGRES_PASSWORD=hctcg
+      - POSTGRES_DB=hctcg
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U hctcg"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
   hctcg:
     image: benji42/hc-tcg:latest
     container_name: hc-tcg
     ports:
       - 9000:9000
     restart: unless-stopped
+    links:
+      - db
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      - DATABASE_URL=postgresql://hctcg:hctcg@db:5432/hctcg
+


### PR DESCRIPTION
Updated docker-compose.yml to include local postgres container for full self-hosting; also updated the README to specify the default directories in the containers as storage is needed for the postgres container.