### PR TITLE
Fix Jingler Pick Request Not Working

### DIFF
--- a/common/cards/hermits/jingler-rare.ts
+++ b/common/cards/hermits/jingler-rare.ts
@@ -54,7 +54,7 @@ const JinglerRare: Hermit = {
 					player: opponentPlayer.entity,
 					id: component.entity,
 					message: 'Pick 1 card from your hand to discard',
-					canPick: query.every(query.slot.currentPlayer, query.slot.hand),
+					canPick: query.every(query.slot.opponent, query.slot.hand),
 					onResult(pickedSlot) {
 						pickedSlot.getCard()?.discard()
 					},

--- a/tests/fuzz/fuzz-ai.ts
+++ b/tests/fuzz/fuzz-ai.ts
@@ -209,6 +209,12 @@ function getNextTurnAction(
 			game.getPickableSlots(game.state.pickRequests[0].canPick),
 			game.rng,
 		)
+
+		assert(
+			query.slot.opponent(game, game.components.get(slot)!),
+			"Player's can not pick a card form their opponent's hand",
+		)
+
 		return {
 			type: 'PICK_REQUEST',
 			entity: slot,

--- a/tests/fuzz/fuzz-ai.ts
+++ b/tests/fuzz/fuzz-ai.ts
@@ -215,7 +215,7 @@ function getNextTurnAction(
 				query.not(query.slot.hand),
 				query.every(query.slot.hand, query.slot.currentPlayer),
 			)(game, game.components.get(slot)!),
-			"Player's can not pick a card form their opponent's hand",
+			"Players can not pick a card form their opponent's hand",
 		)
 
 		return {

--- a/tests/fuzz/fuzz-ai.ts
+++ b/tests/fuzz/fuzz-ai.ts
@@ -211,7 +211,10 @@ function getNextTurnAction(
 		)
 
 		assert(
-			query.slot.opponent(game, game.components.get(slot)!),
+			query.some(
+				query.not(query.slot.hand),
+				query.every(query.slot.hand, query.slot.currentPlayer),
+			)(game, game.components.get(slot)!),
 			"Player's can not pick a card form their opponent's hand",
 		)
 

--- a/tests/unit/game/hermits/jingler-rare.test.ts
+++ b/tests/unit/game/hermits/jingler-rare.test.ts
@@ -1,32 +1,8 @@
 import {describe, expect, test} from '@jest/globals'
-import {Thorns} from 'common/cards/attach/thorns'
-import Totem from 'common/cards/attach/totem'
 import EthosLabCommon from 'common/cards/hermits/ethoslab-common'
-import FarmerBeefCommon from 'common/cards/hermits/farmerbeef-common'
-import GoodTimesWithScarRare from 'common/cards/hermits/goodtimeswithscar-rare'
-import IJevinRare from 'common/cards/hermits/ijevin-rare'
-import PearlescentMoonCommon from 'common/cards/hermits/pearlescentmoon-common'
-import WelsknightCommon from 'common/cards/hermits/welsknight-common'
-import Bow from 'common/cards/single-use/bow'
-import LavaBucket from 'common/cards/single-use/lava-bucket'
-import TNT from 'common/cards/single-use/tnt'
-import {
-	CardComponent,
-	RowComponent,
-	StatusEffectComponent,
-} from 'common/components'
-import query from 'common/components/query'
-import {RevivedByDeathloopEffect} from 'common/status-effects/death-loop'
-import FireEffect from 'common/status-effects/fire'
-import {
-	applyEffect,
-	attack,
-	endTurn,
-	pick,
-	playCardFromHand,
-	testGame,
-} from '../utils'
 import JinglerRare from 'common/cards/hermits/jingler-rare'
+import query from 'common/components/query'
+import {attack, endTurn, pick, playCardFromHand, testGame} from '../utils'
 
 describe('Test Jingler Rare', () => {
 	test('Test Jingler forces opponent to discard one card', () => {

--- a/tests/unit/game/hermits/jingler-rare.test.ts
+++ b/tests/unit/game/hermits/jingler-rare.test.ts
@@ -29,7 +29,7 @@ import {
 import JinglerRare from 'common/cards/hermits/jingler-rare'
 
 describe('Test Jingler Rare', () => {
-	test('Test Jingler Forces Opponent To Discard Two Cards', () => {
+	test('Test Jingler forces opponent to discard one card', () => {
 		testGame(
 			{
 				playerOneDeck: [EthosLabCommon, EthosLabCommon],
@@ -42,6 +42,24 @@ describe('Test Jingler Rare', () => {
 					yield* attack(game, 'secondary')
 
 					yield* pick(game, query.slot.hand, query.slot.opponent)
+				},
+			},
+			{startWithAllCards: true, noItemRequirements: true},
+		)
+	})
+	test("Test Jingler does nothing when opponent's hand is empty", () => {
+		testGame(
+			{
+				playerOneDeck: [EthosLabCommon],
+				playerTwoDeck: [JinglerRare],
+				saga: function* (game) {
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, JinglerRare, 'hermit', 0)
+					yield* attack(game, 'secondary')
+
+					expect(game.state.pickRequests).toHaveLength(0)
 				},
 			},
 			{startWithAllCards: true, noItemRequirements: true},

--- a/tests/unit/game/hermits/jingler-rare.test.ts
+++ b/tests/unit/game/hermits/jingler-rare.test.ts
@@ -1,0 +1,50 @@
+import {describe, expect, test} from '@jest/globals'
+import {Thorns} from 'common/cards/attach/thorns'
+import Totem from 'common/cards/attach/totem'
+import EthosLabCommon from 'common/cards/hermits/ethoslab-common'
+import FarmerBeefCommon from 'common/cards/hermits/farmerbeef-common'
+import GoodTimesWithScarRare from 'common/cards/hermits/goodtimeswithscar-rare'
+import IJevinRare from 'common/cards/hermits/ijevin-rare'
+import PearlescentMoonCommon from 'common/cards/hermits/pearlescentmoon-common'
+import WelsknightCommon from 'common/cards/hermits/welsknight-common'
+import Bow from 'common/cards/single-use/bow'
+import LavaBucket from 'common/cards/single-use/lava-bucket'
+import TNT from 'common/cards/single-use/tnt'
+import {
+	CardComponent,
+	RowComponent,
+	StatusEffectComponent,
+} from 'common/components'
+import query from 'common/components/query'
+import {RevivedByDeathloopEffect} from 'common/status-effects/death-loop'
+import FireEffect from 'common/status-effects/fire'
+import {
+	applyEffect,
+	attack,
+	endTurn,
+	pick,
+	playCardFromHand,
+	testGame,
+} from '../utils'
+import JinglerRare from 'common/cards/hermits/jingler-rare'
+
+describe('Test Jingler Rare', () => {
+	test('Test Jingler Forces Opponent To Discard Two Cards', () => {
+		testGame(
+			{
+				playerOneDeck: [EthosLabCommon, EthosLabCommon],
+				playerTwoDeck: [JinglerRare],
+				saga: function* (game) {
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, JinglerRare, 'hermit', 0)
+					yield* attack(game, 'secondary')
+
+					yield* pick(game, query.slot.hand, query.slot.opponent)
+				},
+			},
+			{startWithAllCards: true, noItemRequirements: true},
+		)
+	})
+})


### PR DESCRIPTION
Fixes jingler pick request not working. Tested against #1201 to ensure this is not an aggression. Also testing 100 fuzz tests. Also added unit tests.