### PR TITLE
Fix Update Modal Not Showing Up and Add Date

### DIFF
--- a/client/src/app/main-menu/main-menu.tsx
+++ b/client/src/app/main-menu/main-menu.tsx
@@ -87,7 +87,7 @@ function MainMenu({setMenuSection}: Props) {
 	let showUpdateModal =
 		(!latestUpdateView ||
 			(updates.length && updates[0].timestamp > parseInt(latestUpdateView))) &&
-		debugOptions.showUpdatesModal
+		debugOptions.showUpdatesModal !== false
 
 	return (
 		<>

--- a/client/src/app/main-menu/settings.tsx
+++ b/client/src/app/main-menu/settings.tsx
@@ -102,10 +102,6 @@ function Settings({setMenuSection}: Props) {
 				<UpdatesModal
 					onClose={() => {
 						setUpdatesOpen(!updatesOpen)
-						localStorage.setItem(
-							'latestUpdateView',
-							(new Date().valueOf() / 1000).toFixed(),
-						)
 					}}
 				/>
 			)}

--- a/client/src/components/updates/updates.module.scss
+++ b/client/src/components/updates/updates.module.scss
@@ -15,6 +15,13 @@
 	text-align: left;
 }
 
+h1 {
+    display: inline
+}
+
+.shortDate {
+	color: var(--text-light);
+}
 
 a:link {
 	color: inherit;

--- a/client/src/components/updates/updates.module.scss
+++ b/client/src/components/updates/updates.module.scss
@@ -5,7 +5,7 @@
 	overflow-y: auto;
 	color: var(--text-light);
 	gap: 10px;
-	max-height: 40vh;
+	max-height: 60vh;
 	height: 100%;
 }
 

--- a/client/src/components/updates/updates.tsx
+++ b/client/src/components/updates/updates.tsx
@@ -21,6 +21,11 @@ export function UpdatesModal({onClose}: UpdatesModalProps) {
 		})
 	})
 
+	localStorage.setItem(
+		'latestUpdateView',
+		(new Date().valueOf() / 1000).toFixed(),
+	)
+
 	return (
 		<Modal setOpen title="Latest Updates" onClose={onClose} disableCloseButton>
 			<Modal.Description>

--- a/client/src/components/updates/updates.tsx
+++ b/client/src/components/updates/updates.tsx
@@ -34,7 +34,7 @@ export function UpdatesModal({onClose}: UpdatesModalProps) {
 						For more updates, visit the HC-TCG discord.
 					</li>
 					{updates ? (
-						updates.map(({tag, description, link}, i) => {
+						updates.map(({tag, description, link, timestamp}, i) => {
 							return (
 								<>
 									<li
@@ -45,6 +45,9 @@ export function UpdatesModal({onClose}: UpdatesModalProps) {
 										<a href={link} target="_blank">
 											<h1 className={css.updateName}> Update {tag} </h1>
 										</a>
+										<span className={css.shortDate}>
+											{new Date(timestamp * 1000).toLocaleDateString()}
+										</span>
 										<div
 											dangerouslySetInnerHTML={{
 												__html: sanitize(toHTML(description)),

--- a/server/src/load-updates.ts
+++ b/server/src/load-updates.ts
@@ -16,7 +16,9 @@ export async function loadUpdates(): Promise<Array<Update> | null> {
 			tag: release.tag_name,
 			description: release.body,
 			link: release.html_url,
-			timestamp: new Date(release.created_at).valueOf(),
+			timestamp:
+				new Date(release.created_at).valueOf() /
+				1000 /** We need the update time in seconds, not ms */,
 		})
 	}
 


### PR DESCRIPTION
Fixes the update modal not showing up when the game is launched. The fix was the the github timestamps were parsed in ms but we save the last viewed timestamp in seconds. Additionally there was a bug with the debug config.