### PR TITLE
Fix Monkeyfarm pickCondition including dying rows

### DIFF
--- a/common/cards/advent-of-tcg/hermits/monkeyfarm-rare.ts
+++ b/common/cards/advent-of-tcg/hermits/monkeyfarm-rare.ts
@@ -55,6 +55,7 @@ const MonkeyfarmRare: Hermit = {
 					query.not(query.slot.active),
 					query.not(query.slot.empty),
 					query.not(query.slot.frozen),
+					query.slot.row((_game, row) => !!row.health),
 				)
 
 				if (!game.components.exists(SlotComponent, pickCondition)) return

--- a/common/cards/advent-of-tcg/hermits/monkeyfarm-rare.ts
+++ b/common/cards/advent-of-tcg/hermits/monkeyfarm-rare.ts
@@ -55,7 +55,6 @@ const MonkeyfarmRare: Hermit = {
 					query.not(query.slot.active),
 					query.not(query.slot.empty),
 					query.not(query.slot.frozen),
-					query.slot.row((_game, row) => !!row.health),
 				)
 
 				if (!game.components.exists(SlotComponent, pickCondition)) return

--- a/common/cards/hermits/kingjoel-rare.ts
+++ b/common/cards/hermits/kingjoel-rare.ts
@@ -44,14 +44,13 @@ const KingJoelRare: Hermit = {
 			query.slot.item,
 			query.not(query.slot.empty),
 			query.not(query.slot.frozen),
-			query.slot.row((_game, row) => !!row.health),
 		)
 		const secondPickCondition = query.every(
 			query.slot.currentPlayer,
 			query.not(query.slot.active),
 			query.slot.item,
 			query.slot.empty,
-			query.slot.row(query.row.hasHermit, (_game, row) => !!row.health),
+			query.slot.row(query.row.hasHermit),
 		)
 
 		let firstPickedCard: CardComponent | null = null

--- a/common/components/query/slot.ts
+++ b/common/components/query/slot.ts
@@ -35,7 +35,8 @@ export const empty: ComponentQuery<SlotComponent> = (game, pos) => {
 		query.card.slotEntity(pos.entity),
 	)
 	if (!card) return true
-	if (card.isHermit() && !card.isAlive()) return true
+	// Slots will become empty if the row is at 0 health when knock-outs are checked
+	if (pos.inRow() && !pos.row.health) return true
 	return false
 }
 


### PR DESCRIPTION
Fixes Monkeyfarm adding a pick request for cards in rows with no health that have not been discarded yet
Fixes #1240 