### PR TITLE
Up CPU To Shared 4x

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -40,6 +40,4 @@ kill_timeout = '15s'
     grace_period = '4s'
 
 [[vm]]
-  memory = '1gb'
-  cpu_kind = 'shared'
-  cpus = 1
+  size = 'shared-cpu-4x'


### PR DESCRIPTION
Increase our allowed CPU to 4x the current compute. This will give us wiggle room if we get many more players. This also increases our ram.