### PR TITLE
Add Back Preloading Without Warnings

### DIFF
--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -13,12 +13,23 @@ import {
 } from 'chart.js'
 import App from './app'
 import store from './store'
+import {CARDS_LIST} from 'common/cards'
+import {getRenderedCardImage} from 'common/cards/card'
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend)
 
 // Make the store available in the playwright test.
 // @ts-ignore
 global.getState = () => store.getState()
+
+function preloadCardImages() {
+	for (const card of CARDS_LIST) {
+		new Image().src = getRenderedCardImage(card, false, 'webp')
+		new Image().src = getRenderedCardImage(card, true, 'webp')
+	}
+}
+
+preloadCardImages()
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
 root.render(


### PR DESCRIPTION
Preload all card images with a different method that does not emit warnings