### PR TITLE
Fix achievement player queries

### DIFF
--- a/common/achievements/sheep-starer.ts
+++ b/common/achievements/sheep-starer.ts
@@ -34,6 +34,7 @@ const SheepStarer: Achievement = {
 				const thisTurnRedZedaphs = game.components.filterEntities(
 					CardComponent,
 					query.card.is(...zedaphCards),
+					query.card.currentPlayer,
 					query.card.row(
 						(_game, row) => row.health !== null && row.health <= 90,
 					),

--- a/common/achievements/type-wins.ts
+++ b/common/achievements/type-wins.ts
@@ -29,7 +29,7 @@ function getTypeWinAchievement(id: number, type: TypeT): Achievement {
 			if (
 				game.components.filter(
 					CardComponent,
-					query.card.currentPlayer,
+					query.card.player(playerEntity),
 					query.card.type(type),
 				).length < 7
 			) {


### PR DESCRIPTION
- "[Type] wins" now looks at the correct player's deck
- "Sheep Starer" no longer considers opponent's Zedaphs