### PR TITLE
Front end updates

### DIFF
--- a/client/src/app/game/end-game-overlay/end-game-overlay.module.scss
+++ b/client/src/app/game/end-game-overlay/end-game-overlay.module.scss
@@ -110,7 +110,7 @@
 	position: absolute;
 	height: 100%;
 	width: 75%;
-	top: 37%;
+	top: 32%;
 }
 
 .nameAndProgress {

--- a/client/src/app/game/end-game-overlay/end-game-overlay.module.scss
+++ b/client/src/app/game/end-game-overlay/end-game-overlay.module.scss
@@ -171,3 +171,32 @@
 		transform: translateY(-5px);
 	}
 }
+
+@media screen and (max-width: 720px) {
+	.description {
+		padding: 0.5rem;
+		padding-top: 2rem;
+	}
+
+	.animation {
+		top: -2.7rem;
+	}
+
+	.smallAchievementBox {
+		top: 23.5%;
+	}
+
+	.nameAndProgress {
+		font-size: 0.9rem;
+		text-wrap: nowrap;
+		text-overflow: ellipsis;
+	}
+
+	.endOptions {
+		grid-template-areas:
+			"playAgain"
+			"rematch"
+			"board"
+			"mainMenu";
+	}
+}

--- a/client/src/app/game/end-game-overlay/end-game-overlay.tsx
+++ b/client/src/app/game/end-game-overlay/end-game-overlay.tsx
@@ -11,6 +11,7 @@ import css from './end-game-overlay.module.scss'
 type Props = {
 	outcome: GameOutcome
 	earnedAchievements: Array<EarnedAchievement>
+	gameEndTime: number
 	viewer:
 		| {
 				type: 'player'
@@ -150,14 +151,20 @@ const SmallAchievement = ({
 	)
 }
 
-const ReplayTimer = ({displayFakeTime}: {displayFakeTime: boolean}) => {
+const ReplayTimer = ({
+	displayFakeTime,
+	timerStart,
+}: {displayFakeTime: boolean; timerStart: number}) => {
 	if (displayFakeTime) {
 		return <div className={css.rematchTimeRemaining}>0</div>
 	}
 
+	const timerLength = serverConfig.limits.rematchTime
+
 	const [replayTimeRemaining, setReplayTimeRemaining] = useState<number>(
-		serverConfig.limits.rematchTime / 1000 - 1,
+		Math.max(Math.floor((timerStart - Date.now() + timerLength) / 1000), 0),
 	)
+
 	useEffect(() => {
 		const timeout = setTimeout(() => {
 			setReplayTimeRemaining(replayTimeRemaining - 1)
@@ -177,6 +184,7 @@ const ReplayTimer = ({displayFakeTime}: {displayFakeTime: boolean}) => {
 const EndGameOverlay = ({
 	outcome,
 	earnedAchievements,
+	gameEndTime,
 	viewer,
 	onClose,
 	nameOfWinner,
@@ -335,7 +343,10 @@ const EndGameOverlay = ({
 						}}
 					>
 						Rematch
-						<ReplayTimer displayFakeTime={displayFakeTime}></ReplayTimer>
+						<ReplayTimer
+							displayFakeTime={displayFakeTime}
+							timerStart={gameEndTime}
+						></ReplayTimer>
 					</Button>
 					<Button id={css.board} onClick={onClose}>
 						View Board

--- a/client/src/app/game/end-game-overlay/end-game-overlay.tsx
+++ b/client/src/app/game/end-game-overlay/end-game-overlay.tsx
@@ -46,6 +46,10 @@ const SmallAchievement = ({
 	const [init, setInit] = useState<boolean>(false)
 	const [offset, setOffset] = useState<number>(index)
 
+	const onMobile = window.screen.width <= 720
+
+	const ma = onMobile ? 85 : 75
+
 	const gap = 1
 
 	const setPosition = () => {
@@ -59,10 +63,10 @@ const SmallAchievement = ({
 			barRef.current?.animate(
 				{
 					left: [
-						`${12.5 + offset * (75 + gap)}%`,
-						`${12.5 + offset * (75 + gap)}%`,
-						`${12.5 + (offset - 1) * (75 + gap)}%`,
-						`${12.5 + (offset - 1) * (75 + gap)}%`,
+						`${12.5 + offset * (ma + gap)}%`,
+						`${12.5 + offset * (ma + gap)}%`,
+						`${12.5 + (offset - 1) * (ma + gap)}%`,
+						`${12.5 + (offset - 1) * (ma + gap)}%`,
 					],
 					offset: [0.0, 0.8, 0.99, 1.0],
 				},

--- a/client/src/app/game/player-info/player-info.module.scss
+++ b/client/src/app/game/player-info/player-info.module.scss
@@ -53,6 +53,7 @@
 	margin-left: -19px;
 	backdrop-filter: grayscale(80%) brightness(60%);
 	border: 3px solid var(--gray-900);
+	pointer-events: none;
 
 	&.active {
 		display: none;

--- a/client/src/app/game/toolbar/toolbar.tsx
+++ b/client/src/app/game/toolbar/toolbar.tsx
@@ -114,10 +114,9 @@ function Toolbar({
 			{!isSpectator && !gameOver && <ForfeitItem />}
 
 			{/* Forfeit Game */}
-			{isSpectator ||
-				(gameOver && (
-					<ExitItem gameOver={gameOver} gameEndButton={gameEndButton} />
-				))}
+			{(isSpectator || gameOver) && (
+				<ExitItem gameOver={gameOver} gameEndButton={gameEndButton} />
+			)}
 		</div>
 	)
 }

--- a/client/src/app/main-menu/achievements.module.scss
+++ b/client/src/app/main-menu/achievements.module.scss
@@ -360,4 +360,8 @@ h2 {
 	.hideOnMobile {
 		display: none;
 	}
+
+	.tooltip {
+		max-width: 90vw;
+	}
 }

--- a/client/src/app/main-menu/achievements.tsx
+++ b/client/src/app/main-menu/achievements.tsx
@@ -25,6 +25,7 @@ import {getSession} from 'logic/session/session-selectors'
 import {useRef, useState} from 'react'
 import {useDispatch, useSelector} from 'react-redux'
 import css from './achievements.module.scss'
+import {Achievement} from 'common/achievements/types'
 
 type Pages = 'achievements' | 'rewards'
 
@@ -85,7 +86,10 @@ export function CosmeticPreview() {
 	)
 }
 
-const CosmeticItem = ({cosmetic}: {cosmetic: Cosmetic}) => {
+const CosmeticItem = ({
+	cosmetic,
+	achievement,
+}: {cosmetic: Cosmetic; achievement: Achievement | null}) => {
 	const dispatch = useDispatch()
 	const achievementProgress = useSelector(getAchievements)
 	const appearance = useSelector(getAppearance)
@@ -102,10 +106,6 @@ const CosmeticItem = ({cosmetic}: {cosmetic: Cosmetic}) => {
 	let isUnlocked = true
 
 	let isSelected = cosmetics.find((c) => c.id === cosmetic.id)
-
-	const achievement = cosmetic.requires
-		? ACHIEVEMENTS[cosmetic.requires.achievement]
-		: null
 
 	if (cosmetic.requires && achievement && !debugConfig.unlockAllCosmetics) {
 		isUnlocked =
@@ -186,6 +186,25 @@ const CosmeticItem = ({cosmetic}: {cosmetic: Cosmetic}) => {
 		</div>
 	)
 
+	return (
+		<div className={css.cosmeticBox}>
+			{item}
+			{cosmetic.type !== 'title' && (
+				<div
+					className={classNames(css.cosmeticName, isUnlocked && css.unlocked)}
+				>
+					{cosmetic.name}
+				</div>
+			)}
+		</div>
+	)
+}
+
+const CosmeticTooltipItem = ({cosmetic}: {cosmetic: Cosmetic}) => {
+	const achievement = cosmetic.requires
+		? ACHIEVEMENTS[cosmetic.requires.achievement]
+		: null
+
 	const tooltip = achievement ? (
 		<div className={css.tooltip}>
 			<b>{achievement.levels[cosmetic.requires?.level || 0].name}</b>
@@ -198,20 +217,9 @@ const CosmeticItem = ({cosmetic}: {cosmetic: Cosmetic}) => {
 	)
 
 	return (
-		<div className={css.cosmeticBox}>
-			{achievement || cosmetic.name.length > 0 ? (
-				<Tooltip tooltip={tooltip}>{item}</Tooltip>
-			) : (
-				item
-			)}
-			{cosmetic.type !== 'title' && (
-				<div
-					className={classNames(css.cosmeticName, isUnlocked && css.unlocked)}
-				>
-					{cosmetic.name}
-				</div>
-			)}
-		</div>
+		<Tooltip tooltip={tooltip}>
+			<CosmeticItem cosmetic={cosmetic} achievement={achievement} />
+		</Tooltip>
 	)
 }
 
@@ -280,31 +288,41 @@ function Cosmetics({setMenuSection, page}: Props) {
 									<div className={css.sectionHeader}>Backgrounds</div>
 									<div className={css.cosmetics}>
 										{sortedCosmetics.background.map((cosmetic) => (
-											<CosmeticItem cosmetic={cosmetic}></CosmeticItem>
+											<CosmeticTooltipItem
+												cosmetic={cosmetic}
+											></CosmeticTooltipItem>
 										))}
 									</div>
 									<div className={css.sectionHeader}>Borders</div>
 									<div className={css.cosmetics}>
 										{sortedCosmetics.border.map((cosmetic) => (
-											<CosmeticItem cosmetic={cosmetic}></CosmeticItem>
+											<CosmeticTooltipItem
+												cosmetic={cosmetic}
+											></CosmeticTooltipItem>
 										))}
 									</div>
 									<div className={css.sectionHeader}>Coins</div>
 									<div className={css.cosmetics}>
 										{sortedCosmetics.coin.map((cosmetic) => (
-											<CosmeticItem cosmetic={cosmetic}></CosmeticItem>
+											<CosmeticTooltipItem
+												cosmetic={cosmetic}
+											></CosmeticTooltipItem>
 										))}
 									</div>
 									<div className={css.sectionHeader}>Hearts</div>
 									<div className={css.cosmetics}>
 										{sortedCosmetics.heart.map((cosmetic) => (
-											<CosmeticItem cosmetic={cosmetic}></CosmeticItem>
+											<CosmeticTooltipItem
+												cosmetic={cosmetic}
+											></CosmeticTooltipItem>
 										))}
 									</div>
 									<div className={css.sectionHeader}>Titles</div>
 									<div className={css.cosmetics}>
 										{sortedCosmetics.title.map((cosmetic) => (
-											<CosmeticItem cosmetic={cosmetic}></CosmeticItem>
+											<CosmeticTooltipItem
+												cosmetic={cosmetic}
+											></CosmeticTooltipItem>
 										))}
 									</div>
 								</div>

--- a/client/src/app/main-menu/achievements.tsx
+++ b/client/src/app/main-menu/achievements.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames'
 import {ACHIEVEMENTS, ACHIEVEMENTS_LIST} from 'common/achievements'
+import {Achievement} from 'common/achievements/types'
 import debugConfig from 'common/config/debug-config'
 import {ALL_COSMETICS} from 'common/cosmetics'
 import {COINS} from 'common/cosmetics/coins'
@@ -25,7 +26,6 @@ import {getSession} from 'logic/session/session-selectors'
 import {useRef, useState} from 'react'
 import {useDispatch, useSelector} from 'react-redux'
 import css from './achievements.module.scss'
-import {Achievement} from 'common/achievements/types'
 
 type Pages = 'achievements' | 'rewards'
 

--- a/client/src/app/main-menu/play-select.module.scss
+++ b/client/src/app/main-menu/play-select.module.scss
@@ -45,10 +45,6 @@
 	grid-auto-flow: column;
 	justify-content: center;
 	grid-gap: 3vh;
-
-	.fourButtons {
-		grid-gap: 2vh;
-	}
 }
 
 .top {

--- a/client/src/app/main-menu/play-select.module.scss
+++ b/client/src/app/main-menu/play-select.module.scss
@@ -126,3 +126,8 @@
 		border: 2px black solid;
 	}
 }
+
+.rematchWindow {
+	position: absolute;
+	left: 0;
+}

--- a/client/src/app/main-menu/play-select.tsx
+++ b/client/src/app/main-menu/play-select.tsx
@@ -730,7 +730,7 @@ during the battle."
 					<i>Click to change</i>
 				</p>
 				<div
-					className={matchmaking ? undefined : css.appearance}
+					className={css.appearance}
 					onClick={() => !matchmaking && setMenuSection('cosmetics')}
 				>
 					<CosmeticPreview />

--- a/client/src/app/main-menu/play-select.tsx
+++ b/client/src/app/main-menu/play-select.tsx
@@ -656,6 +656,8 @@ during the battle."
 								onSelectDeck={onSelectDeck}
 							/>
 						</GameModeButton>
+					</div>
+					<div className={css.rematchWindow}>
 						{activeMode === 'rematch' && (
 							<GameModeButton
 								image={'fiveampearl'}

--- a/client/src/app/main-menu/play-select.tsx
+++ b/client/src/app/main-menu/play-select.tsx
@@ -104,6 +104,11 @@ function PlaySelect({setMenuSection, defaultSection}: Props) {
 	const [hasRematch, setHasRematch] = useState<boolean>(rematch ? true : false)
 	const [rematchDisabled, setRematchDisabled] = useState<boolean>(false)
 
+	const rematchCancel = () => {
+		if (!rematch) return
+		dispatch({type: localMessages.CANCEL_REMATCH})
+	}
+
 	if (hasRematch && !rematch) {
 		setHasRematch(false)
 		setRematchDisabled(true)
@@ -298,6 +303,7 @@ function PlaySelect({setMenuSection, defaultSection}: Props) {
 								addMenuWithBack('rematchChooseDeck')
 								sortDecksByActive()
 							}}
+							onRematchCancel={rematchCancel}
 						>
 							<GameModeButton.ChooseDeck
 								activeButtonMenu={activeButtonMenu}
@@ -363,6 +369,7 @@ function PlaySelect({setMenuSection, defaultSection}: Props) {
 								addMenuWithBack('rematchChooseDeck')
 								sortDecksByActive()
 							}}
+							onRematchCancel={rematchCancel}
 						>
 							<GameModeButton.OptionsSelect
 								activeButtonMenu={activeButtonMenu}

--- a/client/src/app/main-menu/play-select.tsx
+++ b/client/src/app/main-menu/play-select.tsx
@@ -103,7 +103,6 @@ function PlaySelect({setMenuSection, defaultSection}: Props) {
 
 	const [hasRematch, setHasRematch] = useState<boolean>(rematch ? true : false)
 	const [rematchDisabled, setRematchDisabled] = useState<boolean>(false)
-	const [buttonAmount, _setButtonAmount] = useState<number>(rematch ? 4 : 3)
 
 	if (hasRematch && !rematch) {
 		setHasRematch(false)
@@ -275,12 +274,7 @@ function PlaySelect({setMenuSection, defaultSection}: Props) {
 			>
 				<h2 className={css.header}>{header}</h2>
 				<div className={css.gameTypes}>
-					<div
-						className={classNames(
-							css.gameTypesButtons,
-							buttonAmount === 4 && css.fourButtons,
-						)}
-					>
+					<div className={classNames(css.gameTypesButtons)}>
 						<GameModeButton
 							image={'vintagebeef'}
 							backgroundImage={'gamemodes/public'}
@@ -297,7 +291,13 @@ function PlaySelect({setMenuSection, defaultSection}: Props) {
 							}}
 							onBack={goBack}
 							disableBack={!!matchmaking}
-							buttonAmount={buttonAmount}
+							enableRematch={!!rematch && !rematch.spectatorCode}
+							timerStart={rematch?.time}
+							timerLength={serverConfig.limits.rematchTime}
+							onRematchSelect={() => {
+								addMenuWithBack('rematchChooseDeck')
+								sortDecksByActive()
+							}}
 						>
 							<GameModeButton.ChooseDeck
 								activeButtonMenu={activeButtonMenu}
@@ -356,7 +356,13 @@ function PlaySelect({setMenuSection, defaultSection}: Props) {
 							}}
 							onBack={goBack}
 							disableBack={!!matchmaking}
-							buttonAmount={buttonAmount}
+							enableRematch={!!rematch && !!rematch.spectatorCode}
+							timerStart={rematch?.time}
+							timerLength={serverConfig.limits.rematchTime}
+							onRematchSelect={() => {
+								addMenuWithBack('rematchChooseDeck')
+								sortDecksByActive()
+							}}
 						>
 							<GameModeButton.OptionsSelect
 								activeButtonMenu={activeButtonMenu}
@@ -525,7 +531,7 @@ or create your own game to challenge someone else."
 							setActiveMode={setActiveMode}
 							onBack={goBack}
 							disableBack={!!matchmaking}
-							buttonAmount={buttonAmount}
+							enableRematch={false}
 						>
 							<GameModeButton.OptionsSelect
 								id="bossSelect"
@@ -650,7 +656,7 @@ during the battle."
 								onSelectDeck={onSelectDeck}
 							/>
 						</GameModeButton>
-						{(rematch || rematchDisabled) && (
+						{activeMode === 'rematch' && (
 							<GameModeButton
 								image={'fiveampearl'}
 								backgroundImage={'gamemodes/rematch'}
@@ -669,8 +675,8 @@ during the battle."
 								disableBack={!!matchmaking}
 								timerStart={rematch?.time || 0}
 								timerLength={serverConfig.limits.rematchTime}
-								buttonAmount={buttonAmount}
 								disabled={rematchDisabled}
+								enableRematch={false}
 							>
 								<GameModeButton.ChooseDeck
 									activeButtonMenu={activeButtonMenu}

--- a/client/src/components/game-mode-button/game-mode-button.module.scss
+++ b/client/src/components/game-mode-button/game-mode-button.module.scss
@@ -185,14 +185,22 @@ $expandedHeight: 67vh;
 			inset 1px 1px 0 0 var(--gray-100),
 			inset -1px -5px 0 0 var(--gray-100);
 		margin-left: 2vh;
-		margin-top: 2vh;
-		height: 5rem;
+		margin-top: 0.5vh;
 		scale: 1;
 		transform: scale(1);
 		transform-origin: center;
 		opacity: 100%;
+		height: min-content;
 		transition: scale 0.05s ease-out, opacity 0.1s ease-in,
 			transform 0.2s ease-in, height 0.2s ease-in, margin-top 0.2s ease-in;
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		gap: 0.25rem;
+
+		> div {
+			transform: translateY(-0.75rem);
+		}
 
 		&.hide {
 			transform: scale(0);

--- a/client/src/components/game-mode-button/game-mode-button.module.scss
+++ b/client/src/components/game-mode-button/game-mode-button.module.scss
@@ -28,6 +28,12 @@ $expandedHeight: 67vh;
 	transform-origin: center;
 	overflow: hidden;
 	z-index: 90;
+	scale: 1;
+	transition: scale 0.05s ease-out;
+
+	.rightOverlay {
+		pointer-events: none;
+	}
 
 	&.grow {
 		animation: grow $time forwards;
@@ -36,6 +42,7 @@ $expandedHeight: 67vh;
 		.rightOverlay,
 		.returnButton {
 			opacity: 100%;
+			pointer-events: all;
 		}
 	}
 
@@ -69,9 +76,7 @@ $expandedHeight: 67vh;
 		}
 	}
 
-	&.disabled {
-		filter: grayscale(100%);
-
+	&:has(> .leftOverlay > .button > .rematch:hover) {
 		&:hover {
 			scale: 1;
 		}
@@ -171,6 +176,40 @@ $expandedHeight: 67vh;
 	h1 {
 		font-size: 2vh;
 		padding-bottom: 0.5vh;
+	}
+
+	&.rematch {
+		width: calc($width - 4vh);
+		background-color: var(--gray-900);
+		box-shadow: inset 0 -4px 0 0 var(--gray-500),
+			inset 1px 1px 0 0 var(--gray-100),
+			inset -1px -5px 0 0 var(--gray-100);
+		margin-left: 2vh;
+		margin-top: 2vh;
+		height: 5rem;
+		scale: 1;
+		transform: scale(1);
+		transform-origin: center;
+		opacity: 100%;
+		transition: scale 0.05s ease-out, opacity 0.1s ease-in,
+			transform 0.2s ease-in, height 0.2s ease-in, margin-top 0.2s ease-in;
+
+		&.hide {
+			transform: scale(0);
+			opacity: 0%;
+			height: 0px;
+			margin-top: -2vh;
+		}
+
+		&:hover {
+			background-color: var(--gray-700);
+			scale: 1.05;
+		}
+
+		.title {
+			padding-bottom: 0;
+			font-size: 1rem;
+		}
 	}
 }
 
@@ -590,17 +629,15 @@ $expandedHeight: 67vh;
 .rematchTimeRemaining {
 	background-color: rgb(217, 119, 147);
 	color: black;
-	transform: translateY(-0.125rem);
 	width: max-content;
-	padding: 5px;
-	margin-top: 0.5rem;
 	margin-left: -3px;
-	margin-bottom: 0.5rem;
 	align-items: baseline;
 	text-align: center;
 	justify-content: center;
 	border-radius: 5px;
 	font-size: 1rem;
+	line-height: 1rem;
+	padding: 5px;
 }
 
 @keyframes timedShow {
@@ -617,11 +654,6 @@ $expandedHeight: 67vh;
 	.buttonContainer {
 		width: $mobileWidth;
 		height: $mobileHeight;
-
-		&.fourButtons {
-			width: $mobileWidth;
-			height: calc($mobileHeight - 4vh);
-		}
 	}
 
 	.backgroundContainer {
@@ -629,11 +661,6 @@ $expandedHeight: 67vh;
 		height: $mobileHeight;
 		top: 0;
 		left: auto;
-
-		&.fourButtons {
-			width: $mobileWidth;
-			height: calc($mobileHeight - 4vh);
-		}
 	}
 
 	@keyframes grow {
@@ -682,6 +709,11 @@ $expandedHeight: 67vh;
 		position: absolute;
 		left: 0px;
 		top: 5vh;
+		transition: top 0.2s ease-in-out;
+
+		&.makeHigherOnMobile {
+			top: 2vh;
+		}
 	}
 
 	.vingette {
@@ -718,10 +750,24 @@ $expandedHeight: 67vh;
 		border: 2px black solid;
 	}
 
+	.text {
+		&.rematch {
+			top: 65%;
+			height: min-content;
+			line-height: 1rem;
+			margin-top: 0;
+			display: flex;
+			flex-direction: row;
+			gap: 0.5rem;
+			width: min-content;
+			text-wrap: nowrap;
+			align-items: center;
+			justify-content: center;
+			padding: 0.5rem;
+		}
+	}
+
 	.rematchTimeRemaining {
-		position: absolute;
-		top: 0px;
-		right: 5.5rem;
-		scale: 0.8;
+		margin-left: 0px;
 	}
 }

--- a/client/src/components/game-mode-button/game-mode-button.module.scss
+++ b/client/src/components/game-mode-button/game-mode-button.module.scss
@@ -762,6 +762,7 @@ $expandedHeight: 67vh;
 		&.rematch {
 			top: 65%;
 			height: min-content;
+			height: 2.5rem;
 			line-height: 1rem;
 			margin-top: 0;
 			display: flex;
@@ -772,6 +773,14 @@ $expandedHeight: 67vh;
 			align-items: center;
 			justify-content: center;
 			padding: 0.5rem;
+
+			> div {
+				transform: translateY(-0.125rem);
+			}
+		}
+
+		&.cancel {
+			left: 42%;
 		}
 	}
 

--- a/client/src/components/game-mode-button/game-mode-button.tsx
+++ b/client/src/components/game-mode-button/game-mode-button.tsx
@@ -281,7 +281,7 @@ function GameModeButton({
 								}}
 							>
 								<div className={css.title}>
-									Rematch {!onMobile && 'your last '} opponent
+									Rematch {!onMobile && 'your last opponent'}
 								</div>
 								<div className={css.rematchTimeRemaining}>
 									{timer}s {!onMobile && 'Remaining'}
@@ -293,6 +293,7 @@ function GameModeButton({
 								className={classNames(
 									css.text,
 									css.rematch,
+									css.cancel,
 									activeMode === mode && css.hide,
 								)}
 								onMouseDown={(ev) => {
@@ -303,7 +304,7 @@ function GameModeButton({
 									onRematchCancel()
 								}}
 							>
-								<div className={css.title}>Cancel Rematch</div>
+								<div className={css.title}>Cancel {!onMobile && 'Rematch'}</div>
 							</div>
 						)}
 					</div>

--- a/client/src/components/game-mode-button/game-mode-button.tsx
+++ b/client/src/components/game-mode-button/game-mode-button.tsx
@@ -37,6 +37,7 @@ interface GameModeButtonProps {
 	timerLength?: number
 	enableRematch: boolean
 	onRematchSelect?: () => void
+	onRematchCancel?: () => void
 }
 
 function GameModeButton({
@@ -56,6 +57,7 @@ function GameModeButton({
 	timerLength,
 	enableRematch,
 	onRematchSelect,
+	onRematchCancel,
 }: GameModeButtonProps) {
 	const buttonRef = useRef<HTMLDivElement>(null)
 	const backgroundRef = useRef<HTMLDivElement>(null)
@@ -284,6 +286,24 @@ function GameModeButton({
 								<div className={css.rematchTimeRemaining}>
 									{timer}s {!onMobile && 'Remaining'}
 								</div>
+							</div>
+						)}
+						{enableRematch && (
+							<div
+								className={classNames(
+									css.text,
+									css.rematch,
+									activeMode === mode && css.hide,
+								)}
+								onMouseDown={(ev) => {
+									ev.stopPropagation()
+									if (ev.button !== 0) return
+									if (disabled) return
+									if (!onRematchCancel) return
+									onRematchCancel()
+								}}
+							>
+								<div className={css.title}>Cancel Rematch</div>
 							</div>
 						)}
 					</div>

--- a/client/src/components/game-mode-button/game-mode-button.tsx
+++ b/client/src/components/game-mode-button/game-mode-button.tsx
@@ -32,10 +32,11 @@ interface GameModeButtonProps {
 	onSelect: () => void
 	onBack: () => void
 	disableBack: boolean
-	buttonAmount: number
 	disabled?: boolean
 	timerStart?: number
 	timerLength?: number
+	enableRematch: boolean
+	onRematchSelect?: () => void
 }
 
 function GameModeButton({
@@ -50,10 +51,11 @@ function GameModeButton({
 	onSelect,
 	onBack,
 	disableBack,
-	buttonAmount,
 	disabled,
 	timerStart,
 	timerLength,
+	enableRematch,
+	onRematchSelect,
 }: GameModeButtonProps) {
 	const buttonRef = useRef<HTMLDivElement>(null)
 	const backgroundRef = useRef<HTMLDivElement>(null)
@@ -205,11 +207,7 @@ function GameModeButton({
 
 	return (
 		<div
-			className={classNames(
-				css.buttonContainer,
-				css.enablePointer,
-				buttonAmount === 4 && css.fourButtons,
-			)}
+			className={classNames(css.buttonContainer, css.enablePointer)}
 			onMouseDown={(ev) => {
 				if (ev.button !== 0) return
 				if (disabled) return
@@ -225,7 +223,6 @@ function GameModeButton({
 					css.backgroundContainer,
 					css.show,
 					disabled && css.disabled,
-					buttonAmount === 4 && css.fourButtons,
 				)}
 				ref={backgroundRef}
 			>
@@ -256,15 +253,39 @@ function GameModeButton({
 							className={css.hermitImage}
 						></img>
 						<div className={css.spacer}></div>
-						<div className={css.text}>
-							<h1>{title}</h1>
-							{timerStart !== undefined && timerLength !== undefined && (
-								<div className={css.rematchTimeRemaining}>
-									{timer}s Remaining
-								</div>
+						<div
+							className={classNames(
+								css.text,
+								enableRematch && activeMode !== mode && css.makeHigherOnMobile,
 							)}
+						>
+							<h1>{title}</h1>
 							<p>{description}</p>
 						</div>
+						{enableRematch && (
+							<div
+								className={classNames(
+									css.text,
+									css.rematch,
+									activeMode === mode && css.hide,
+								)}
+								onMouseDown={(ev) => {
+									ev.stopPropagation()
+									if (ev.button !== 0) return
+									if (disabled) return
+									if (!onRematchSelect) return
+									setActiveMode('rematch')
+									onRematchSelect()
+								}}
+							>
+								<div className={css.title}>
+									Rematch {!onMobile && 'your last '} opponent
+								</div>
+								<div className={css.rematchTimeRemaining}>
+									{timer}s {!onMobile && 'Remaining'}
+								</div>
+							</div>
+						)}
 					</div>
 				</div>
 				<div ref={rightOverlayRef} className={css.rightOverlay}>

--- a/client/src/components/tooltip/tooltip.tsx
+++ b/client/src/components/tooltip/tooltip.tsx
@@ -49,7 +49,7 @@ const Tooltip = memo(({children, tooltip, showAboveModal}: Props) => {
 
 	useEffect(() => {
 		setTooltipSize(null)
-	}, [showAdvancedTooltips, window.innerWidth])
+	}, [showAdvancedTooltips, window.screen.width])
 
 	useEffect(() => {
 		if (!tooltipSize) forceUpdate()

--- a/client/src/logic/game/game-reducer.ts
+++ b/client/src/logic/game/game-reducer.ts
@@ -52,7 +52,8 @@ const gameReducer = (
 			// I really don't know if its a good idea to automatically close modals besides the forfeit modal, but I am too scared
 			// too stop all modals from automatically closing.
 			let nextOpenedModal =
-				state.openedModal !== null && state.openedModal.id === 'forfeit'
+				state.openedModal !== null &&
+				(state.openedModal.id === 'forfeit' || state.openedModal.id === 'exit')
 					? state.openedModal
 					: null
 			const newGame: LocalGameRoot = {

--- a/client/src/logic/game/game-reducer.ts
+++ b/client/src/logic/game/game-reducer.ts
@@ -22,6 +22,7 @@ type LocalGameRoot = {
 	endGameOverlay: {
 		outcome: GameOutcome
 		earnedAchievements: Array<EarnedAchievement>
+		gameEndTime: number
 	} | null
 	chat: Array<Message>
 	battleLog: BattleLogModel | null
@@ -102,6 +103,7 @@ const gameReducer = (
 				endGameOverlay: {
 					outcome: action.outcome,
 					earnedAchievements: action.earnedAchievements,
+					gameEndTime: action.gameEndTime,
 				},
 			}
 		case localMessages.CHAT_UPDATE:

--- a/client/src/logic/game/game-saga.ts
+++ b/client/src/logic/game/game-saga.ts
@@ -243,6 +243,7 @@ function* gameSaga(initialGameState?: LocalGameState) {
 				gameState: newGameState,
 				outcome,
 				earnedAchievements,
+				gameEndTime,
 			} = result.gameEnd
 			if (newGameState) {
 				yield call(coinFlipSaga, newGameState)
@@ -256,6 +257,7 @@ function* gameSaga(initialGameState?: LocalGameState) {
 				type: localMessages.GAME_END_OVERLAY_SHOW,
 				outcome,
 				earnedAchievements,
+				gameEndTime,
 			})
 		}
 	} catch (err) {
@@ -264,6 +266,7 @@ function* gameSaga(initialGameState?: LocalGameState) {
 			type: localMessages.GAME_END_OVERLAY_SHOW,
 			outcome: {type: 'game-crash', error: `${(err as Error).stack}`},
 			earnedAchievements: [],
+			gameEndTime: Date.now(),
 		})
 	} finally {
 		const hasOverlay = yield* select(getEndGameOverlay)

--- a/client/src/logic/matchmaking/matchmaking-saga.ts
+++ b/client/src/logic/matchmaking/matchmaking-saga.ts
@@ -614,6 +614,13 @@ function* createRematchSaga() {
 	}
 }
 
+// Rematches
+function* cancelRematchSaga() {
+	const rematch = yield* select(getRematchData)
+	if (!rematch) return
+	yield* sendMsg({type: clientMessages.CANCEL_REMATCH, rematch})
+}
+
 // @TODO
 function* createReplayGameSaga(
 	action: LocalMessageTable[typeof localMessages.MATCHMAKING_REPLAY_GAME],
@@ -694,6 +701,7 @@ function* matchmakingSaga() {
 	})
 	// Rematch
 	yield* takeEvery(localMessages.MATCHMAKING_REMATCH, createRematchSaga)
+	yield* takeEvery(localMessages.CANCEL_REMATCH, cancelRematchSaga)
 }
 
 export default matchmakingSaga

--- a/client/src/logic/messages.ts
+++ b/client/src/logic/messages.ts
@@ -108,7 +108,6 @@ export const localMessages = messages('clientLocalMessages', {
 	OVERVIEW: null,
 	//Rematches
 	RECIEVE_REMATCH: null,
-	RECIEVE_OPPONENT_REMATCH: null,
 	CANCEL_REMATCH: null,
 	MATCHMAKING_REMATCH: null,
 })
@@ -288,7 +287,6 @@ type Messages = [
 	},
 	{type: typeof localMessages.COSMETIC_UPDATE; cosmetic: Cosmetic},
 	{type: typeof localMessages.RECIEVE_REMATCH; rematch: RematchData | null},
-	{type: typeof localMessages.RECIEVE_OPPONENT_REMATCH},
 	{type: typeof localMessages.CANCEL_REMATCH},
 	{type: typeof localMessages.MATCHMAKING_REMATCH},
 ]

--- a/client/src/logic/messages.ts
+++ b/client/src/logic/messages.ts
@@ -207,6 +207,7 @@ type Messages = [
 		type: typeof localMessages.GAME_END_OVERLAY_SHOW
 		outcome: GameOutcome
 		earnedAchievements: Array<EarnedAchievement>
+		gameEndTime: number
 	},
 	{
 		type: typeof localMessages.GAME_CLOSE

--- a/client/src/logic/session/session-saga.ts
+++ b/client/src/logic/session/session-saga.ts
@@ -306,6 +306,7 @@ export function* loginSaga() {
 				...socket.auth,
 				playerUuid: userResponse.uuid,
 				playerName: userResponse.username,
+				minecraftName: userResponse.minecraftName || userResponse.username,
 				version: getClientVersion(),
 			}
 			yield* put<LocalMessage>({type: localMessages.SOCKET_CONNECTING})
@@ -324,6 +325,7 @@ export function* loginSaga() {
 				...socket.auth,
 				playerUuid: userResponse.uuid,
 				playerName: userResponse.username,
+				minecraftName: userResponse.minecraftName || userResponse.username,
 				version: getClientVersion(),
 			}
 			yield* put<LocalMessage>({type: localMessages.SOCKET_CONNECTING})
@@ -430,6 +432,9 @@ export function* loginSaga() {
 			...socket.auth,
 			playerUuid: localStorage.getItem('database:userId') as string,
 			playerName: result.playerInfo.player.playerName,
+			minecraftName:
+				result.playerInfo.player.minecraftName ||
+				result.playerInfo.player.playerName,
 			playerId: result.playerInfo.player.playerId,
 			playerSecret: result.playerInfo.player.playerSecret,
 		}

--- a/client/src/logic/socket/socket-reducer.ts
+++ b/client/src/logic/socket/socket-reducer.ts
@@ -7,6 +7,7 @@ export type SocketType = {
 	auth: {
 		version: string | null
 		playerName: string
+		minecraftName: string
 		playerId: PlayerId
 		playerUuid: string
 		playerSecret: string

--- a/common/config/server-config.js
+++ b/common/config/server-config.js
@@ -1,15 +1,15 @@
 export default {
 	port: 9000,
 	clientDevPort: 3002,
-	clientPath: 'client/dist',
+	clientPath: "client/dist",
 	cors: [
-		'http://localhost:3002',
-		'https://hc-tcg-beta.fly.dev',
-		'https://hc-tcg-testing.fly.dev',
-		'https://hc-tcg.online',
-		'https://testing.hc-tcg.online',
+		"http://localhost:3002",
+		"https://hc-tcg-beta.fly.dev",
+		"https://hc-tcg-testing.fly.dev",
+		"https://hc-tcg.online",
+		"https://testing.hc-tcg.online",
 	],
-	world: 'LTF42',
+	world: "LTF42",
 	limits: {
 		maxTurnTime: 90,
 		extraActionTime: 30,
@@ -17,9 +17,9 @@ export default {
 		maxCards: 42,
 		maxDuplicates: 3,
 		maxDeckCost: 42,
-		bannedCards: ['evilxisuma_boss', 'feather', 'item_any_rare'],
-		disabledCards: ['iskallman_common', 'iskallman_rare'],
-		rematchTime: 60000,
+		bannedCards: ["evilxisuma_boss", "feather", "item_any_rare"],
+		disabledCards: ["iskallman_common", "iskallman_rare"],
+		rematchTime: 90 * 1000,
 	},
-	logoSubText: '10k games since 1.0!',
-}
+	logoSubText: "10k games since 1.0!",
+};

--- a/common/config/server-config.js
+++ b/common/config/server-config.js
@@ -1,15 +1,15 @@
 export default {
 	port: 9000,
 	clientDevPort: 3002,
-	clientPath: "client/dist",
+	clientPath: 'client/dist',
 	cors: [
-		"http://localhost:3002",
-		"https://hc-tcg-beta.fly.dev",
-		"https://hc-tcg-testing.fly.dev",
-		"https://hc-tcg.online",
-		"https://testing.hc-tcg.online",
+		'http://localhost:3002',
+		'https://hc-tcg-beta.fly.dev',
+		'https://hc-tcg-testing.fly.dev',
+		'https://hc-tcg.online',
+		'https://testing.hc-tcg.online',
 	],
-	world: "LTF42",
+	world: 'LTF42',
 	limits: {
 		maxTurnTime: 90,
 		extraActionTime: 30,
@@ -17,9 +17,9 @@ export default {
 		maxCards: 42,
 		maxDuplicates: 3,
 		maxDeckCost: 42,
-		bannedCards: ["evilxisuma_boss", "feather", "item_any_rare"],
-		disabledCards: ["iskallman_common", "iskallman_rare"],
+		bannedCards: ['evilxisuma_boss', 'feather', 'item_any_rare'],
+		disabledCards: ['iskallman_common', 'iskallman_rare'],
 		rematchTime: 90 * 1000,
 	},
-	logoSubText: "10k games since 1.0!",
-};
+	logoSubText: '10k games since 1.0!',
+}

--- a/common/socket-messages/client-messages.ts
+++ b/common/socket-messages/client-messages.ts
@@ -18,6 +18,7 @@ export const clientMessages = messages('clientMessages', {
 	CREATE_BOSS_GAME: null,
 	CREATE_REMATCH_GAME: null,
 	CREATE_REPLAY_GAME: null,
+	LEAVE_REMATCH_GAME: null,
 	REPLAY_OVERVIEW: null,
 	TURN_ACTION: null,
 	FORFEIT: null,
@@ -102,7 +103,8 @@ export type ClientMessages = [
 		databaseConnected: true
 		activeDeckCode: string
 		opponentId: string
-		score: number
+		playerScore: number
+		opponentScore: number
 		spectatorCode: string | null
 	},
 	{
@@ -110,9 +112,11 @@ export type ClientMessages = [
 		databaseConnected: false
 		activeDeck: Deck
 		opponentId: string
-		score: number
+		playerScore: number
+		opponentScore: number
 		spectatorCode: string | null
 	},
+	{type: typeof clientMessages.LEAVE_REMATCH_GAME},
 	{
 		type: typeof clientMessages.TURN_ACTION
 		playerEntity: PlayerEntity

--- a/common/socket-messages/client-messages.ts
+++ b/common/socket-messages/client-messages.ts
@@ -2,6 +2,7 @@ import {Cosmetic} from '../cosmetics/types'
 import {PlayerEntity} from '../entities'
 import {PlayerId} from '../models/player-model'
 import {Message, MessageTable, messages} from '../redux-messages'
+import {RematchData} from '../types/app'
 import {Deck, Tag} from '../types/deck'
 import {AnyTurnActionData} from '../types/turn-action-data'
 
@@ -19,6 +20,7 @@ export const clientMessages = messages('clientMessages', {
 	CREATE_REMATCH_GAME: null,
 	CREATE_REPLAY_GAME: null,
 	LEAVE_REMATCH_GAME: null,
+	CANCEL_REMATCH: null,
 	REPLAY_OVERVIEW: null,
 	TURN_ACTION: null,
 	FORFEIT: null,
@@ -162,6 +164,7 @@ export type ClientMessages = [
 	{type: typeof clientMessages.DELETE_TAG; tag: Tag},
 	{type: typeof clientMessages.SET_COSMETIC; cosmetic: Cosmetic['id']},
 	{type: typeof clientMessages.REPLAY_OVERVIEW; id: number},
+	{type: typeof clientMessages.CANCEL_REMATCH; rematch: RematchData},
 ]
 
 export type ClientMessage = Message<ClientMessages>

--- a/common/socket-messages/server-messages.ts
+++ b/common/socket-messages/server-messages.ts
@@ -85,6 +85,7 @@ export type ServerMessages = [
 		gameState: LocalGameState | null
 		outcome: GameOutcome
 		earnedAchievements: Array<EarnedAchievement>
+		gameEndTime: number
 	},
 	{type: typeof serverMessages.PRIVATE_GAME_TIMEOUT},
 	{type: typeof serverMessages.LEAVE_QUEUE_SUCCESS},

--- a/server/src/root-model.ts
+++ b/server/src/root-model.ts
@@ -30,8 +30,8 @@ export class RootModel {
 		{
 			playerId: string
 			opponentId: string
-			existingScore: number
-			joinedScore: number
+			playerScore: number
+			opponentScore: number
 			spectatorCode: string | undefined
 			spectatorsWaiting: Array<string>
 		}

--- a/server/src/routines/handle-client-message.ts
+++ b/server/src/routines/handle-client-message.ts
@@ -30,6 +30,7 @@ import {
 	joinPublicQueue,
 	leavePrivateQueue,
 	leavePublicQueue,
+	leaveRematchGame,
 	spectatePrivateGame,
 } from './matchmaking'
 import {
@@ -91,6 +92,10 @@ function* handler(message: RecievedClientMessage) {
 			)
 		case clientMessages.LEAVE_PRIVATE_QUEUE:
 			return yield* leavePrivateQueue(
+				message as RecievedClientMessage<typeof message.type>,
+			)
+		case clientMessages.LEAVE_REMATCH_GAME:
+			return yield* leaveRematchGame(
 				message as RecievedClientMessage<typeof message.type>,
 			)
 		case clientMessages.CREATE_REPLAY_GAME:

--- a/server/src/routines/handle-client-message.ts
+++ b/server/src/routines/handle-client-message.ts
@@ -22,6 +22,7 @@ import {chatMessage} from './background/chat'
 import spectatorLeaveSaga from './background/spectators'
 import {
 	cancelPrivateGame,
+	cancelRematch,
 	createBossGame,
 	createPrivateGame,
 	createRematchGame,
@@ -96,6 +97,10 @@ function* handler(message: RecievedClientMessage) {
 			)
 		case clientMessages.LEAVE_REMATCH_GAME:
 			return yield* leaveRematchGame(
+				message as RecievedClientMessage<typeof message.type>,
+			)
+		case clientMessages.CANCEL_REMATCH:
+			return yield* cancelRematch(
 				message as RecievedClientMessage<typeof message.type>,
 			)
 		case clientMessages.CREATE_REPLAY_GAME:

--- a/server/src/routines/matchmaking.ts
+++ b/server/src/routines/matchmaking.ts
@@ -847,6 +847,16 @@ export function* leaveRematchGame(
 	delete root.awaitingRematch[playerId]
 }
 
+export function* cancelRematch(
+	msg: RecievedClientMessage<typeof clientMessages.CANCEL_REMATCH>,
+) {
+	const player = root.players[msg.playerId]
+	const opponentPlayer = root.players[msg.payload.rematch.opponentId]
+	delete root.awaitingRematch[opponentPlayer.id]
+	delete root.awaitingRematch[player.id]
+	broadcast([player, opponentPlayer], {type: serverMessages.REMATCH_DENIED})
+}
+
 export function* createBossGame(
 	msg: RecievedClientMessage<typeof clientMessages.CREATE_BOSS_GAME>,
 ) {

--- a/server/src/routines/matchmaking.ts
+++ b/server/src/routines/matchmaking.ts
@@ -838,6 +838,15 @@ export function* leavePrivateQueue(
 	}
 }
 
+export function* leaveRematchGame(
+	msg: RecievedClientMessage<typeof clientMessages.LEAVE_REMATCH_GAME>,
+) {
+	const player = root.players[msg.playerId]
+	console.info(`[Rematch] ${player.name} left the rematch game they started.`)
+	const {playerId} = msg
+	delete root.awaitingRematch[playerId]
+}
+
 export function* createBossGame(
 	msg: RecievedClientMessage<typeof clientMessages.CREATE_BOSS_GAME>,
 ) {
@@ -933,7 +942,7 @@ export function* createRematchGame(
 	msg: RecievedClientMessage<typeof clientMessages.CREATE_REMATCH_GAME>,
 ) {
 	const playerId = msg.playerId
-	const {opponentId, spectatorCode, score} = msg.payload
+	const {opponentId, spectatorCode, playerScore, opponentScore} = msg.payload
 	const player = root.players[playerId]
 	const opponent = root.players[opponentId]
 
@@ -972,13 +981,15 @@ export function* createRematchGame(
 		root.awaitingRematch[playerId] = {
 			playerId: playerId,
 			opponentId: opponentId,
-			existingScore: score,
-			joinedScore: 0,
+			playerScore: playerScore,
+			opponentScore: opponentScore,
 			spectatorCode: spectatorCode || undefined,
 			spectatorsWaiting: [],
 		}
 		broadcast([player], {type: serverMessages.CREATE_REMATCH_SUCCESS})
-		console.info(`${player.name} requested a rematch from their last opponent`)
+		console.info(
+			`[Rematch] ${player.name} requested a rematch from their last opponent`,
+		)
 		broadcast([opponent], {
 			type: serverMessages.REMATCH_REQUESTED,
 			opponentName: opponent.name,
@@ -991,9 +1002,7 @@ export function* createRematchGame(
 
 	// If we want to join our own game, that is an error
 	if (waitingInfo.playerId === player.id) {
-		console.info(
-			'[Join rematch game]: Player attempted to join their own rematch!',
-		)
+		console.info('[Rematch]: Player attempted to join their own rematch!')
 		broadcast([player], {type: serverMessages.CREATE_REMATCH_FAILURE})
 		return
 	}
@@ -1001,33 +1010,29 @@ export function* createRematchGame(
 	// Create new game for these 2 players
 	const existingPlayer = root.players[opponentId]
 	if (!existingPlayer) {
-		console.info(
-			'[Join rematch game]: Player waiting in queue no longer exists!',
-		)
+		console.info('[Rematch]: Player waiting in queue no longer exists!')
 		broadcast([player], {type: serverMessages.CREATE_REMATCH_FAILURE})
 		return
 	}
 
 	if (!existingPlayer.deck) {
-		console.info('[Join rematch game]: Player waiting in queue has no deck!')
+		console.info('[Rematch]: Player waiting in queue has no deck!')
 		broadcast([player], {type: serverMessages.CREATE_REMATCH_FAILURE})
 		return
 	}
-
-	waitingInfo.joinedScore = score
 
 	const newGame = setupGame(
 		player,
 		existingPlayer,
 		player.deck,
 		existingPlayer.deck,
-		waitingInfo.joinedScore,
-		waitingInfo.existingScore,
+		waitingInfo.opponentScore,
+		waitingInfo.playerScore,
 		spectatorCode || undefined,
 	)
 	root.addGame(newGame)
 
-	console.info(`Joining rematch game: ${player.name}.`)
+	console.info(`[Rematch] Joining rematch game: ${player.name}.`)
 
 	broadcast([player], {type: serverMessages.CREATE_REMATCH_SUCCESS})
 

--- a/server/src/routines/matchmaking.ts
+++ b/server/src/routines/matchmaking.ts
@@ -265,6 +265,7 @@ function* gameManager(con: GameController) {
 				earnedAchievements: !viewer.spectator
 					? newAchievements[viewer.playerOnLeftEntity]
 					: [],
+				gameEndTime: Date.now(),
 			})
 		}
 
@@ -1158,6 +1159,7 @@ export function* createReplayGame(
 			? con.game.outcome
 			: {type: 'game-crash', error: 'The replay game did not save properly.'},
 		earnedAchievements: [],
+		gameEndTime: Date.now(),
 	})
 
 	delete root.games[con.id]

--- a/tests/ct/end-game-overlay.spec.tsx
+++ b/tests/ct/end-game-overlay.spec.tsx
@@ -19,6 +19,7 @@ test('You won by killing all hermits!', async ({mount}) => {
 				entity: entity,
 			}}
 			earnedAchievements={[]}
+			gameEndTime={Date.now()}
 			displayFakeTime={true}
 		/>,
 	)
@@ -44,6 +45,7 @@ test('You lost because your hermits were killed.', async ({mount}) => {
 				entity: playerTwoEntity,
 			}}
 			earnedAchievements={[]}
+			gameEndTime={Date.now()}
 			displayFakeTime={true}
 		/>,
 	)
@@ -68,6 +70,7 @@ test('You won because your opponent disconnected!', async ({mount}) => {
 				entity: entity,
 			}}
 			earnedAchievements={[]}
+			gameEndTime={Date.now()}
 			displayFakeTime={true}
 		/>,
 	)
@@ -93,6 +96,7 @@ test('You lost because you disconnected.', async ({mount}) => {
 				entity: playerTwoEntity,
 			}}
 			earnedAchievements={[]}
+			gameEndTime={Date.now()}
 			displayFakeTime={true}
 		/>,
 	)
@@ -116,6 +120,7 @@ test('Viewing as spectator shows victory.', async ({mount}) => {
 				type: 'spectator',
 			}}
 			earnedAchievements={[]}
+			gameEndTime={Date.now()}
 			displayFakeTime={true}
 		/>,
 	)
@@ -133,6 +138,7 @@ test('Game crash displays correctly.', async ({mount}) => {
 				type: 'spectator',
 			}}
 			earnedAchievements={[]}
+			gameEndTime={Date.now()}
 			displayFakeTime={true}
 		/>,
 	)
@@ -150,6 +156,7 @@ test('Game timeout displays correctly.', async ({mount}) => {
 				type: 'spectator',
 			}}
 			earnedAchievements={[]}
+			gameEndTime={Date.now()}
 			displayFakeTime={true}
 		/>,
 	)


### PR DESCRIPTION
- Fixes rematch button
- Fixes tooltips in achievements screen, dropdowns on mobile
- Fixes Minecraft head being undefined after login 
- Fixes timer on end game overlay resetting
- Fix "exit" button not showing for spectators or replayers
- Fixes issue with still queuing into a rematch after leaving
- Fix matchmaking making appearance box small
- Add "Cancel rematch" button that removes the option for opponent