### PR TITLE
Optimize Slot Empty Query

### DIFF
--- a/common/cards/advent-of-tcg/attach/brewing-stand.ts
+++ b/common/cards/advent-of-tcg/attach/brewing-stand.ts
@@ -49,7 +49,7 @@ const BrewingStand: Attach = {
 					if (!pickedSlot.inRow()) return
 
 					pickedSlot.row.heal(50)
-					pickedSlot.getCard()?.discard()
+					pickedSlot.card?.discard()
 				},
 			})
 		})

--- a/common/cards/advent-of-tcg/hermits/dungeontango-rare.ts
+++ b/common/cards/advent-of-tcg/hermits/dungeontango-rare.ts
@@ -58,7 +58,7 @@ const DungeonTangoRare: Hermit = {
 				if (!activeRow) return
 
 				const items = (activeRow.getItemSlots() as SlotComponent[]).filter(
-					(slot) => slot.getCard() && !query.slot.frozen(game, slot),
+					(slot) => slot.card && !query.slot.frozen(game, slot),
 				)
 				const pickCondition = (_game: GameModel, value: SlotComponent) =>
 					items.includes(value)
@@ -74,12 +74,12 @@ const DungeonTangoRare: Hermit = {
 					message: 'Choose an item card to discard',
 					canPick: pickCondition,
 					onResult(pickedSlot) {
-						pickedCard = pickedSlot.getCard()
+						pickedCard = pickedSlot.card
 					},
 					onTimeout() {
 						const firstItem = game.components.find(SlotComponent, pickCondition)
 						if (!firstItem) return
-						pickedCard = firstItem.getCard()
+						pickedCard = firstItem.card
 					},
 				})
 			},

--- a/common/cards/advent-of-tcg/hermits/monkeyfarm-rare.ts
+++ b/common/cards/advent-of-tcg/hermits/monkeyfarm-rare.ts
@@ -68,7 +68,7 @@ const MonkeyfarmRare: Hermit = {
 					message: "Pick one of your opponent's AFK Hermit's item cards",
 					canPick: pickCondition,
 					onResult(pickedSlot) {
-						pickedSlot.getCard()?.discard()
+						pickedSlot.card?.discard()
 					},
 				})
 			},

--- a/common/cards/advent-of-tcg/hermits/orionsound-rare.ts
+++ b/common/cards/advent-of-tcg/hermits/orionsound-rare.ts
@@ -70,7 +70,7 @@ const OrionSoundRare: Hermit = {
 					message: 'Choose an Active or AFK Hermit to heal.',
 					canPick: pickCondition,
 					onResult(pickedSlot) {
-						const pickedCard = pickedSlot.getCard()
+						const pickedCard = pickedSlot.card
 						if (!pickedCard) return
 
 						game.components

--- a/common/cards/advent-of-tcg/hermits/pharaoh-rare.ts
+++ b/common/cards/advent-of-tcg/hermits/pharaoh-rare.ts
@@ -127,7 +127,7 @@ const PharaohRare: Hermit = {
 					onResult(pickedSlot) {
 						if (!pickedSlot.inRow()) return
 						pickedSlot.row.heal(healAmount)
-						const healedHermit = pickedSlot.getCard()
+						const healedHermit = pickedSlot.card
 						game.battleLog.addEntry(
 							player.entity,
 							`$${healedHermit?.player === component.player ? 'p' : 'o'}${healedHermit?.props.name} (${

--- a/common/cards/advent-of-tcg/hermits/smajor1995.ts
+++ b/common/cards/advent-of-tcg/hermits/smajor1995.ts
@@ -72,7 +72,7 @@ const Smajor1995Rare: Hermit = {
 					message: 'Choose an AFK Hermit to dye.',
 					canPick: pickCondition,
 					onResult(pickedSlot) {
-						const pickedCard = pickedSlot.getCard()
+						const pickedCard = pickedSlot.card
 						if (!pickedCard) return
 
 						game.components

--- a/common/cards/advent-of-tcg/hermits/solidaritygaming-rare.ts
+++ b/common/cards/advent-of-tcg/hermits/solidaritygaming-rare.ts
@@ -65,11 +65,11 @@ const SolidaritygamingRare: Hermit = {
 					message: 'Choose an AFK Hermit to protect',
 					canPick: pickCondition,
 					onResult(pickedSlot) {
-						if (!pickedSlot.inRow() || !pickedSlot.getCard()) return
+						if (!pickedSlot.inRow() || !pickedSlot.card) return
 
 						game.components
 							.new(StatusEffectComponent, ProtectedEffect, component.entity)
-							.apply(pickedSlot.getCard()?.entity)
+							.apply(pickedSlot.card?.entity)
 					},
 				})
 			},

--- a/common/cards/advent-of-tcg/single-use/allay.ts
+++ b/common/cards/advent-of-tcg/single-use/allay.ts
@@ -15,7 +15,7 @@ const pickCondition = query.every(
 	query.slot.hand,
 	query.not(query.slot.has(Clock)),
 	(game, slot) => {
-		const card = slot.getCard()
+		const card = slot.card
 		if (!card?.isSingleUse() && !card?.isAttach()) return false
 		// Prevent infinite loop
 		if (query.card.is(Allay)(game, card)) return false
@@ -58,7 +58,7 @@ const Allay: SingleUse = {
 			message: 'Pick an effect card in your hand to show your opponent.',
 			canPick: pickCondition,
 			onResult(pickedSlot) {
-				const pickedCard = pickedSlot.getCard()
+				const pickedCard = pickedSlot.card
 
 				if (!pickedCard) return
 

--- a/common/cards/advent-of-tcg/single-use/powder-snow-bucket.ts
+++ b/common/cards/advent-of-tcg/single-use/powder-snow-bucket.ts
@@ -45,7 +45,7 @@ const PowderSnowBucket: SingleUse = {
 
 				game.components
 					.new(StatusEffectComponent, FrozenEffect, component.entity)
-					.apply(pickedSlot.getCard()?.entity)
+					.apply(pickedSlot.card?.entity)
 			},
 		})
 	},

--- a/common/cards/advent-of-tcg/single-use/smithing-table.ts
+++ b/common/cards/advent-of-tcg/single-use/smithing-table.ts
@@ -9,7 +9,7 @@ const pickCondition = query.every(
 	query.slot.currentPlayer,
 	query.slot.hand,
 	(_game, slot) => {
-		const card = slot.getCard()
+		const card = slot.card
 		if (!card) return false
 		return card.isAttach() && !card.getStatusEffect(SmithingTableEffect)
 	},
@@ -43,7 +43,7 @@ const SmithingTable: SingleUse = {
 
 				game.components
 					.new(StatusEffectComponent, SmithingTableEffect, component.entity)
-					.apply(pickedSlot.getCard()?.entity)
+					.apply(pickedSlot.card?.entity)
 			},
 		})
 	},

--- a/common/cards/boss/hermits/evilxisuma_boss.ts
+++ b/common/cards/boss/hermits/evilxisuma_boss.ts
@@ -282,7 +282,7 @@ const EvilXisumaBoss: Hermit = {
 						query.slot.item,
 						query.not(query.slot.empty),
 						query.not(query.slot.frozen),
-						(_game, slot) => slot.getCard()?.isItem() === true,
+						(_game, slot) => slot.card?.isItem() === true,
 					)
 					if (
 						opponentPlayer.activeRow?.health &&
@@ -301,7 +301,7 @@ const EvilXisumaBoss: Hermit = {
 								const hermitCard = playerRow.getHermit()
 								if (!hermitCard || !playerRow.health) return
 
-								const card = pickedSlot.getCard()
+								const card = pickedSlot.card
 								if (!card || !card.isItem()) return
 
 								card.discard()

--- a/common/cards/hermits/hypnotizd-rare.ts
+++ b/common/cards/hermits/hypnotizd-rare.ts
@@ -67,7 +67,7 @@ const HypnotizdRare: Hermit = {
 				if (!activeRow) return
 
 				const items = (activeRow.getItemSlots() as SlotComponent[]).filter(
-					(slot) => slot.getCard() && !query.slot.frozen(game, slot),
+					(slot) => slot.card && !query.slot.frozen(game, slot),
 				)
 				const pickCondition = (_game: GameModel, value: SlotComponent) =>
 					items.includes(value)
@@ -93,11 +93,11 @@ const HypnotizdRare: Hermit = {
 					message: 'Choose an item to discard from your active Hermit.',
 					canPick: pickCondition,
 					onResult(pickedSlot) {
-						item = pickedSlot.getCard()
+						item = pickedSlot.card
 					},
 					onTimeout() {
 						item =
-							game.components.find(SlotComponent, pickCondition)?.getCard() ||
+							game.components.find(SlotComponent, pickCondition)?.card ||
 							null
 					},
 				}

--- a/common/cards/hermits/hypnotizd-rare.ts
+++ b/common/cards/hermits/hypnotizd-rare.ts
@@ -97,8 +97,7 @@ const HypnotizdRare: Hermit = {
 					},
 					onTimeout() {
 						item =
-							game.components.find(SlotComponent, pickCondition)?.card ||
-							null
+							game.components.find(SlotComponent, pickCondition)?.card || null
 					},
 				}
 

--- a/common/cards/hermits/iskallman-rare.ts
+++ b/common/cards/hermits/iskallman-rare.ts
@@ -131,7 +131,7 @@ const IskallmanRare: Hermit = {
 				backlashAttack.shouldIgnoreCards.push(query.anything)
 				attack.addNewAttack(backlashAttack)
 
-				const hermitInfo = pickedAfkHermit.getCard()
+				const hermitInfo = pickedAfkHermit.card
 
 				if (hermitInfo) {
 					pickedAfkHermit.row.heal(50)

--- a/common/cards/hermits/jingler-rare.ts
+++ b/common/cards/hermits/jingler-rare.ts
@@ -56,7 +56,7 @@ const JinglerRare: Hermit = {
 					message: 'Pick 1 card from your hand to discard',
 					canPick: query.every(query.slot.opponent, query.slot.hand),
 					onResult(pickedSlot) {
-						pickedSlot.getCard()?.discard()
+						pickedSlot.card?.discard()
 					},
 					onTimeout() {
 						game.components

--- a/common/cards/hermits/kingjoel-rare.ts
+++ b/common/cards/hermits/kingjoel-rare.ts
@@ -75,7 +75,7 @@ const KingJoelRare: Hermit = {
 					message: "Pick an item card from your opponent's AFK Hermits",
 					canPick: firstPickCondition,
 					onResult(pickedSlot) {
-						firstPickedCard = pickedSlot.getCard()
+						firstPickedCard = pickedSlot.card
 					},
 				})
 

--- a/common/cards/hermits/princessgem-rare.ts
+++ b/common/cards/hermits/princessgem-rare.ts
@@ -78,7 +78,7 @@ const PrincessGemRare: Hermit = {
 								RoyalProtectionEffect,
 								component.entity,
 							)
-							.apply(pickedSlot.getCard()?.entity)
+							.apply(pickedSlot.card?.entity)
 					},
 				})
 			},

--- a/common/cards/hermits/rendog-rare.ts
+++ b/common/cards/hermits/rendog-rare.ts
@@ -116,7 +116,7 @@ const RendogRare: Hermit = {
 					message: "Pick one of your opponent's Hermits",
 					canPick: pickCondition,
 					onResult: (pickedSlot) => {
-						let pickedCard = pickedSlot.getCard() as CardComponent<Hermit>
+						let pickedCard = pickedSlot.card as CardComponent<Hermit>
 						if (!pickedCard) return
 
 						game.addCopyAttackModalRequest({

--- a/common/cards/hermits/zombiecleo-rare.ts
+++ b/common/cards/hermits/zombiecleo-rare.ts
@@ -95,7 +95,7 @@ const ZombieCleoRare: Hermit = {
 					canPick: pickCondition,
 					onResult: (pickedSlot) => {
 						const pickedCard =
-							pickedSlot.getCard() as CardComponent<Hermit> | null
+							pickedSlot.card as CardComponent<Hermit> | null
 						if (!pickedCard) return
 
 						game.addCopyAttackModalRequest({

--- a/common/cards/hermits/zombiecleo-rare.ts
+++ b/common/cards/hermits/zombiecleo-rare.ts
@@ -94,8 +94,7 @@ const ZombieCleoRare: Hermit = {
 					message: 'Pick one of your AFK Hermits',
 					canPick: pickCondition,
 					onResult: (pickedSlot) => {
-						const pickedCard =
-							pickedSlot.card as CardComponent<Hermit> | null
+						const pickedCard = pickedSlot.card as CardComponent<Hermit> | null
 						if (!pickedCard) return
 
 						game.addCopyAttackModalRequest({

--- a/common/cards/single-use/composter.ts
+++ b/common/cards/single-use/composter.ts
@@ -52,8 +52,8 @@ const Composter: SingleUse = {
 				)(game, pos)
 			},
 			onResult(pickedSlot) {
-				firstPickedSlot?.getCard()?.discard()
-				pickedSlot.getCard()?.discard()
+				firstPickedSlot?.card?.discard()
+				pickedSlot.card?.discard()
 
 				applySingleUse(game, component.slot)
 

--- a/common/cards/single-use/curse-of-vanishing.ts
+++ b/common/cards/single-use/curse-of-vanishing.ts
@@ -38,7 +38,7 @@ const CurseOfVanishing: SingleUse = {
 		observer.subscribe(player.hooks.onApply, () => {
 			game.components
 				.filter(SlotComponent, discardCondition)
-				.map((slot) => slot.getCard()?.discard())
+				.map((slot) => slot.card?.discard())
 		})
 	},
 }

--- a/common/cards/single-use/fire-charge.ts
+++ b/common/cards/single-use/fire-charge.ts
@@ -44,7 +44,7 @@ const FireCharge: SingleUse = {
 			canPick: pickCondition,
 			onResult(pickedSlot) {
 				applySingleUse(game, pickedSlot)
-				pickedSlot.getCard()?.discard()
+				pickedSlot.card?.discard()
 
 				if (component.slot.onBoard()) component.discard()
 				// Remove playing a single use from completed actions so it can be done again

--- a/common/cards/single-use/lead.ts
+++ b/common/cards/single-use/lead.ts
@@ -67,7 +67,7 @@ const Lead: SingleUse = {
 				game.battleLog.addEntry(
 					player.entity,
 					`$p{You|${player.playerName}}$ used $eLead$ to move $m${
-						itemSlot.getCard()?.props.name
+						itemSlot.card?.props.name
 					}$ to $o${pickedSlot.row.getHermit()?.props.name} (${pickedSlot.row.index})$`,
 				)
 

--- a/common/cards/single-use/looting.ts
+++ b/common/cards/single-use/looting.ts
@@ -47,7 +47,7 @@ const Looting: SingleUse = {
 				message: 'Pick an item card to add to your hand',
 				canPick: pickCondition,
 				onResult(pickedSlot) {
-					const card = pickedSlot.getCard()
+					const card = pickedSlot.card
 					if (!card) return
 					card.draw(player.entity)
 				},

--- a/common/cards/single-use/target-block.ts
+++ b/common/cards/single-use/target-block.ts
@@ -51,7 +51,7 @@ const TargetBlock: SingleUse = {
 				applySingleUse(game, pickedSlot)
 				game.components
 					.new(StatusEffectComponent, TargetBlockEffect, component.entity)
-					.apply(pickedSlot.getCard()?.entity)
+					.apply(pickedSlot.card?.entity)
 			},
 		})
 	},

--- a/common/components/card-component.ts
+++ b/common/components/card-component.ts
@@ -187,7 +187,9 @@ export class CardComponent<CardType extends Card = Card> {
 			this.player.hooks.onDetach.call(this)
 		}
 
+		this.slot.cardEntity = null
 		this.slotEntity = component.entity
+		component.cardEntity = this.entity
 
 		if (component.onBoard() && changingBoards) {
 			let observer = this.game.components.new(ObserverComponent, this.entity)

--- a/common/components/card-component.ts
+++ b/common/components/card-component.ts
@@ -170,8 +170,6 @@ export class CardComponent<CardType extends Card = Card> {
 			this.slot.onBoard() !== component.onBoard() ||
 			this.player.entity !== component.player.entity
 
-		this.slot.cardEntity = null
-
 		if (this.slot.onBoard() && !component.onBoard()) {
 			this.game.components
 				.filter(StatusEffectComponent, query.effect.targetEntity(this.entity))
@@ -190,6 +188,7 @@ export class CardComponent<CardType extends Card = Card> {
 			this.player.hooks.onDetach.call(this)
 		}
 
+		this.slot.cardEntity = null
 		this.slotEntity = component.entity
 		component.cardEntity = this.entity
 

--- a/common/components/card-component.ts
+++ b/common/components/card-component.ts
@@ -70,6 +70,7 @@ export class CardComponent<CardType extends Card = Card> {
 		}
 
 		this.slotEntity = slot
+		game.components.getOrError(slot).cardEntity = entity
 
 		if (this.slot.onBoard()) {
 			let observer = this.game.components.new(ObserverComponent, this.entity)
@@ -169,6 +170,8 @@ export class CardComponent<CardType extends Card = Card> {
 			this.slot.onBoard() !== component.onBoard() ||
 			this.player.entity !== component.player.entity
 
+		this.slot.cardEntity = null
+
 		if (this.slot.onBoard() && !component.onBoard()) {
 			this.game.components
 				.filter(StatusEffectComponent, query.effect.targetEntity(this.entity))
@@ -187,7 +190,6 @@ export class CardComponent<CardType extends Card = Card> {
 			this.player.hooks.onDetach.call(this)
 		}
 
-		this.slot.cardEntity = null
 		this.slotEntity = component.entity
 		component.cardEntity = this.entity
 

--- a/common/components/query/slot.ts
+++ b/common/components/query/slot.ts
@@ -29,8 +29,8 @@ export function player(
 }
 
 /** Return true if the spot is empty. */
-export const empty: ComponentQuery<SlotComponent> = (game, pos) => {
-	if (!pos.cardEntity) return true
+export const empty: ComponentQuery<SlotComponent> = (_game, pos) => {
+	if (pos.cardEntity === null) return true
 	// Slots will become empty if the row is at 0 health when knock-outs are checked
 	if (pos.inRow() && !pos.row.health) return true
 	return false

--- a/common/components/query/slot.ts
+++ b/common/components/query/slot.ts
@@ -30,7 +30,7 @@ export function player(
 
 /** Return true if the spot is empty. */
 export const empty: ComponentQuery<SlotComponent> = (_game, pos) => {
-	if (pos.cardEntity === null) return true
+	if (pos.getCard() === null) return true
 	// Slots will become empty if the row is at 0 health when knock-outs are checked
 	if (pos.inRow() && !pos.row.health) return true
 	return false

--- a/common/components/query/slot.ts
+++ b/common/components/query/slot.ts
@@ -128,12 +128,10 @@ export const entity = (
 }
 
 export const has = (...cards: Array<Card>): ComponentQuery<SlotComponent> => {
-	return (game, pos) => {
-		return game.components.exists(
-			CardComponent,
-			query.card.is(...cards),
-			query.card.slotEntity(pos.entity),
-		)
+	return (_game, pos) => {
+		let card = pos.getCard()
+		if (!card) return false
+		return cards.map((x) => x.id).includes(card.props.id)
 	}
 }
 

--- a/common/components/query/slot.ts
+++ b/common/components/query/slot.ts
@@ -1,11 +1,6 @@
 import {ComponentQuery} from '.'
 import query from '.'
-import {
-	CardComponent,
-	RowComponent,
-	SlotComponent,
-	StatusEffectComponent,
-} from '..'
+import {RowComponent, SlotComponent, StatusEffectComponent} from '..'
 import {Card} from '../../cards/types'
 import {PlayerEntity, RowEntity, SlotEntity} from '../../entities'
 import {StatusEffect} from '../../status-effects/status-effect'

--- a/common/components/query/slot.ts
+++ b/common/components/query/slot.ts
@@ -30,7 +30,7 @@ export function player(
 
 /** Return true if the spot is empty. */
 export const empty: ComponentQuery<SlotComponent> = (_game, pos) => {
-	if (pos.getCard() === null) return true
+	if (pos.card === null) return true
 	// Slots will become empty if the row is at 0 health when knock-outs are checked
 	if (pos.inRow() && !pos.row.health) return true
 	return false
@@ -129,7 +129,7 @@ export const entity = (
 
 export const has = (...cards: Array<Card>): ComponentQuery<SlotComponent> => {
 	return (_game, pos) => {
-		let card = pos.getCard()
+		let card = pos.card
 		if (!card) return false
 		return cards.map((x) => x.id).includes(card.props.id)
 	}

--- a/common/components/query/slot.ts
+++ b/common/components/query/slot.ts
@@ -30,11 +30,7 @@ export function player(
 
 /** Return true if the spot is empty. */
 export const empty: ComponentQuery<SlotComponent> = (game, pos) => {
-	let card = game.components.find(
-		CardComponent,
-		query.card.slotEntity(pos.entity),
-	)
-	if (!card) return true
+	if (!pos.cardEntity) return true
 	// Slots will become empty if the row is at 0 health when knock-outs are checked
 	if (pos.inRow() && !pos.row.health) return true
 	return false

--- a/common/components/row-component.ts
+++ b/common/components/row-component.ts
@@ -69,7 +69,7 @@ export class RowComponent {
 							'cyberpunkimpulse_rare' === value.getHermit()?.props.id,
 					),
 					(_game, value) => {
-						const card = value.getCard()
+						const card = value.card
 						if (!card?.isItem()) return false
 						return card.props.energy.includes('farm')
 					},

--- a/common/components/slot-component.ts
+++ b/common/components/slot-component.ts
@@ -29,6 +29,7 @@ export class SlotComponent {
 		this.entity = entity
 		this.game = game
 		this.defs = defs
+		this.cardEntity = null
 	}
 
 	// The implementation of these type guards are in the subclasses. The regular slot component

--- a/common/components/slot-component.ts
+++ b/common/components/slot-component.ts
@@ -79,7 +79,7 @@ export class SlotComponent {
 		)
 	}
 
-	public getCard() {
+	get card() {
 		return this.game.components.get(this.cardEntity)
 	}
 }

--- a/common/components/slot-component.ts
+++ b/common/components/slot-component.ts
@@ -1,5 +1,5 @@
 import type {PlayerEntity, RowEntity, SlotEntity} from '../entities'
-import { CardEntity } from '../entities'
+import {CardEntity} from '../entities'
 import type {GameModel} from '../models/game-model'
 import type {SlotTypeT} from '../types/cards'
 import {CardComponent} from './card-component'

--- a/common/components/slot-component.ts
+++ b/common/components/slot-component.ts
@@ -1,4 +1,5 @@
 import type {PlayerEntity, RowEntity, SlotEntity} from '../entities'
+import { CardEntity } from '../entities'
 import type {GameModel} from '../models/game-model'
 import type {SlotTypeT} from '../types/cards'
 import {CardComponent} from './card-component'
@@ -21,6 +22,8 @@ export class SlotComponent {
 	readonly game: GameModel
 	readonly entity: SlotEntity
 	private readonly defs: BoardSlotDefs
+
+	cardEntity: CardEntity | null
 
 	constructor(game: GameModel, entity: SlotEntity, defs: BoardSlotDefs) {
 		this.entity = entity

--- a/common/components/slot-component.ts
+++ b/common/components/slot-component.ts
@@ -79,10 +79,7 @@ export class SlotComponent {
 	}
 
 	public getCard() {
-		return this.game.components.find(
-			CardComponent,
-			query.card.slotEntity(this.entity),
-		)
+		return this.game.components.get(this.cardEntity)
 	}
 }
 

--- a/common/models/battle-log-model.ts
+++ b/common/models/battle-log-model.ts
@@ -141,7 +141,7 @@ export class BattleLogModel {
 
 		const cardRow = card.slot.inRow() ? card.slot.row : null
 		const pickedRow = pickedSlot?.inRow() ? pickedSlot.row : null
-		const pickedCard = pickedSlot?.getCard()
+		const pickedCard = pickedSlot?.card
 
 		const thisFlip = coinFlips.find((flip) => flip.card == card.entity)
 		const invalid = '$bINVALID VALUE$'

--- a/common/models/game-model.ts
+++ b/common/models/game-model.ts
@@ -470,21 +470,21 @@ export class GameModel {
 	): void {
 		if (!slotA || !slotB) return
 
-		const slotACards = this.components.filter(
+		const slotACard = this.components.find(
 			CardComponent,
 			query.card.slotEntity(slotA.entity),
 		)
-		const slotBCards = this.components.filter(
+		const slotBCard = this.components.find(
 			CardComponent,
 			query.card.slotEntity(slotB.entity),
 		)
 
-		slotACards.forEach((card) => {
-			card.attach(slotB)
-		})
-		slotBCards.forEach((card) => {
-			card.attach(slotA)
-		})
+		slotACard?.attach(slotB)
+		slotBCard?.attach(slotA)
+
+		/* I don't know why these two lines are required, but don't delete them because the tests fail! */
+		slotA.cardEntity = slotBCard?.entity ?? null
+		slotB.cardEntity = slotACard?.entity ?? null
 	}
 
 	public getPickableSlots(

--- a/common/utils/turn-action-compressor.ts
+++ b/common/utils/turn-action-compressor.ts
@@ -349,7 +349,7 @@ export const replayActions: Record<TurnAction, ReplayAction> = {
 					const opponentSlot = Boolean((slotType & 0b1000) >> 3)
 
 					if ((slotType & 0b0111) === 0) {
-						const retrievedCard = unpackBoardSlot(game, argument)?.getCard()
+						const retrievedCard = unpackBoardSlot(game, argument)?.card
 						if (retrievedCard) cards.push(retrievedCard.entity)
 					} else if ((slotType & 0b0111) === 1) {
 						if (opponentSlot) {

--- a/server/src/routines/turn-actions.ts
+++ b/server/src/routines/turn-actions.ts
@@ -153,7 +153,7 @@ export function playCardAction(
 	)
 
 	assert(
-		!pickedSlot.getCard(),
+		!pickedSlot.card,
 		'You can not play a card in a slot with a card in it',
 	)
 
@@ -375,7 +375,7 @@ export function pickRequestAction(
 
 	assert(canPick, 'Invalid slots can not be picked.')
 
-	const card = slotInfo.getCard()
+	const card = slotInfo.card
 
 	// Because Worm Man, all cards need to be flipped over to normal once they're picked
 	if (card) card.turnedOver = false

--- a/server/src/utils/index.ts
+++ b/server/src/utils/index.ts
@@ -167,7 +167,7 @@ export function printBoardState(game: GameModel) {
 	buffer.push(game.logHeader + '\n')
 
 	const printSlot = (slot: SlotComponent) => {
-		let card = slot.getCard()
+		let card = slot.card
 
 		if (card) {
 			let name = card.props.name

--- a/tests/unit/game/advent-of-tcg/hermits/cyberpunkimpulse-rare.test.ts
+++ b/tests/unit/game/advent-of-tcg/hermits/cyberpunkimpulse-rare.test.ts
@@ -243,26 +243,22 @@ describe('Test Cyberpunk Impulse', () => {
 				yield* endTurn(game)
 
 				expect(
-					game.components
-						.find(
-							SlotComponent,
-							query.slot.currentPlayer,
-							query.slot.item,
-							query.slot.rowIndex(0),
-							query.slot.index(0),
-						)
-						?.card?.props,
+					game.components.find(
+						SlotComponent,
+						query.slot.currentPlayer,
+						query.slot.item,
+						query.slot.rowIndex(0),
+						query.slot.index(0),
+					)?.card?.props,
 				).toStrictEqual(FarmDoubleItem)
 				expect(
-					game.components
-						.find(
-							SlotComponent,
-							query.slot.currentPlayer,
-							query.slot.item,
-							query.slot.rowIndex(1),
-							query.slot.index(0),
-						)
-						?.card?.props,
+					game.components.find(
+						SlotComponent,
+						query.slot.currentPlayer,
+						query.slot.item,
+						query.slot.rowIndex(1),
+						query.slot.index(0),
+					)?.card?.props,
 				).toStrictEqual(FarmItem)
 				expect(
 					game.currentPlayer.getDiscarded().map((card) => card.props),

--- a/tests/unit/game/advent-of-tcg/hermits/cyberpunkimpulse-rare.test.ts
+++ b/tests/unit/game/advent-of-tcg/hermits/cyberpunkimpulse-rare.test.ts
@@ -251,7 +251,7 @@ describe('Test Cyberpunk Impulse', () => {
 							query.slot.rowIndex(0),
 							query.slot.index(0),
 						)
-						?.getCard()?.props,
+						?.card?.props,
 				).toStrictEqual(FarmDoubleItem)
 				expect(
 					game.components
@@ -262,7 +262,7 @@ describe('Test Cyberpunk Impulse', () => {
 							query.slot.rowIndex(1),
 							query.slot.index(0),
 						)
-						?.getCard()?.props,
+						?.card?.props,
 				).toStrictEqual(FarmItem)
 				expect(
 					game.currentPlayer.getDiscarded().map((card) => card.props),

--- a/tests/unit/game/advent-of-tcg/hermits/dungeontango-rare.test.ts
+++ b/tests/unit/game/advent-of-tcg/hermits/dungeontango-rare.test.ts
@@ -103,15 +103,13 @@ describe('Test DM Tango Lackey', () => {
 				yield* attack(game, 'primary')
 				expect(game.state.pickRequests).toHaveLength(0)
 				expect(
-					game.components
-						.find(
-							SlotComponent,
-							query.slot.currentPlayer,
-							query.slot.item,
-							query.slot.rowIndex(1),
-							query.slot.index(0),
-						)
-						?.card?.props,
+					game.components.find(
+						SlotComponent,
+						query.slot.currentPlayer,
+						query.slot.item,
+						query.slot.rowIndex(1),
+						query.slot.index(0),
+					)?.card?.props,
 				).toStrictEqual(MinerItem)
 			},
 		})
@@ -136,15 +134,13 @@ describe('Test DM Tango Lackey', () => {
 					query.slot.index(0),
 				)
 				expect(
-					game.components
-						.find(
-							SlotComponent,
-							query.slot.currentPlayer,
-							query.slot.item,
-							query.slot.rowIndex(0),
-							query.slot.index(0),
-						)
-						?.card?.props,
+					game.components.find(
+						SlotComponent,
+						query.slot.currentPlayer,
+						query.slot.item,
+						query.slot.rowIndex(0),
+						query.slot.index(0),
+					)?.card?.props,
 				).toStrictEqual(MinerItem)
 			},
 		})

--- a/tests/unit/game/advent-of-tcg/hermits/dungeontango-rare.test.ts
+++ b/tests/unit/game/advent-of-tcg/hermits/dungeontango-rare.test.ts
@@ -111,7 +111,7 @@ describe('Test DM Tango Lackey', () => {
 							query.slot.rowIndex(1),
 							query.slot.index(0),
 						)
-						?.getCard()?.props,
+						?.card?.props,
 				).toStrictEqual(MinerItem)
 			},
 		})
@@ -144,7 +144,7 @@ describe('Test DM Tango Lackey', () => {
 							query.slot.rowIndex(0),
 							query.slot.index(0),
 						)
-						?.getCard()?.props,
+						?.card?.props,
 				).toStrictEqual(MinerItem)
 			},
 		})

--- a/tests/unit/game/effects/ladder.test.ts
+++ b/tests/unit/game/effects/ladder.test.ts
@@ -42,14 +42,12 @@ describe('Test Ladder', () => {
 					)
 
 					expect(
-						game.components
-							.find(
-								SlotComponent,
-								query.slot.currentPlayer,
-								query.slot.hermit,
-								query.slot.rowIndex(0),
-							)
-							?.card?.props,
+						game.components.find(
+							SlotComponent,
+							query.slot.currentPlayer,
+							query.slot.hermit,
+							query.slot.rowIndex(0),
+						)?.card?.props,
 					).toBe(SmallishbeansCommon)
 
 					expect(
@@ -61,37 +59,31 @@ describe('Test Ladder', () => {
 					).toBe(EthosLabCommon.health - EthosLabCommon.primary.damage)
 
 					expect(
-						game.components
-							.find(
-								SlotComponent,
-								query.slot.currentPlayer,
-								query.slot.item,
-								query.slot.index(0),
-								query.slot.rowIndex(0),
-							)
-							?.card,
+						game.components.find(
+							SlotComponent,
+							query.slot.currentPlayer,
+							query.slot.item,
+							query.slot.index(0),
+							query.slot.rowIndex(0),
+						)?.card,
 					).not.toBe(null)
 
 					expect(
-						game.components
-							.find(
-								SlotComponent,
-								query.slot.currentPlayer,
-								query.slot.attach,
-								query.slot.rowIndex(0),
-							)
-							?.card,
+						game.components.find(
+							SlotComponent,
+							query.slot.currentPlayer,
+							query.slot.attach,
+							query.slot.rowIndex(0),
+						)?.card,
 					).not.toBe(null)
 
 					expect(
-						game.components
-							.find(
-								SlotComponent,
-								query.slot.currentPlayer,
-								query.slot.hermit,
-								query.slot.rowIndex(1),
-							)
-							?.card?.props,
+						game.components.find(
+							SlotComponent,
+							query.slot.currentPlayer,
+							query.slot.hermit,
+							query.slot.rowIndex(1),
+						)?.card?.props,
 					).toBe(EthosLabCommon)
 
 					expect(
@@ -103,26 +95,22 @@ describe('Test Ladder', () => {
 					).toBe(SmallishbeansCommon.health)
 
 					expect(
-						game.components
-							.find(
-								SlotComponent,
-								query.slot.currentPlayer,
-								query.slot.item,
-								query.slot.index(0),
-								query.slot.rowIndex(1),
-							)
-							?.card,
+						game.components.find(
+							SlotComponent,
+							query.slot.currentPlayer,
+							query.slot.item,
+							query.slot.index(0),
+							query.slot.rowIndex(1),
+						)?.card,
 					).toBe(null)
 
 					expect(
-						game.components
-							.find(
-								SlotComponent,
-								query.slot.currentPlayer,
-								query.slot.attach,
-								query.slot.rowIndex(1),
-							)
-							?.card,
+						game.components.find(
+							SlotComponent,
+							query.slot.currentPlayer,
+							query.slot.attach,
+							query.slot.rowIndex(1),
+						)?.card,
 					).toBe(null)
 				},
 			},

--- a/tests/unit/game/effects/ladder.test.ts
+++ b/tests/unit/game/effects/ladder.test.ts
@@ -49,7 +49,7 @@ describe('Test Ladder', () => {
 								query.slot.hermit,
 								query.slot.rowIndex(0),
 							)
-							?.getCard()?.props,
+							?.card?.props,
 					).toBe(SmallishbeansCommon)
 
 					expect(
@@ -69,7 +69,7 @@ describe('Test Ladder', () => {
 								query.slot.index(0),
 								query.slot.rowIndex(0),
 							)
-							?.getCard(),
+							?.card,
 					).not.toBe(null)
 
 					expect(
@@ -80,7 +80,7 @@ describe('Test Ladder', () => {
 								query.slot.attach,
 								query.slot.rowIndex(0),
 							)
-							?.getCard(),
+							?.card,
 					).not.toBe(null)
 
 					expect(
@@ -91,7 +91,7 @@ describe('Test Ladder', () => {
 								query.slot.hermit,
 								query.slot.rowIndex(1),
 							)
-							?.getCard()?.props,
+							?.card?.props,
 					).toBe(EthosLabCommon)
 
 					expect(
@@ -111,7 +111,7 @@ describe('Test Ladder', () => {
 								query.slot.index(0),
 								query.slot.rowIndex(1),
 							)
-							?.getCard(),
+							?.card,
 					).toBe(null)
 
 					expect(
@@ -122,7 +122,7 @@ describe('Test Ladder', () => {
 								query.slot.attach,
 								query.slot.rowIndex(1),
 							)
-							?.getCard(),
+							?.card,
 					).toBe(null)
 				},
 			},

--- a/tests/unit/game/effects/shield.test.ts
+++ b/tests/unit/game/effects/shield.test.ts
@@ -38,7 +38,7 @@ describe('Test Shield', () => {
 								query.slot.attach,
 								query.slot.rowIndex(0),
 							)
-							?.getCard(),
+							?.card,
 					).toBe(null)
 				},
 			},

--- a/tests/unit/game/effects/shield.test.ts
+++ b/tests/unit/game/effects/shield.test.ts
@@ -31,14 +31,12 @@ describe('Test Shield', () => {
 					)
 
 					expect(
-						game.components
-							.find(
-								SlotComponent,
-								query.slot.opponent,
-								query.slot.attach,
-								query.slot.rowIndex(0),
-							)
-							?.card,
+						game.components.find(
+							SlotComponent,
+							query.slot.opponent,
+							query.slot.attach,
+							query.slot.rowIndex(0),
+						)?.card,
 					).toBe(null)
 				},
 			},

--- a/tests/unit/game/hermits/hypnotizd-rare.test.ts
+++ b/tests/unit/game/hermits/hypnotizd-rare.test.ts
@@ -96,7 +96,7 @@ describe('Test Rare Hypnotizd', () => {
 								query.slot.rowIndex(0),
 								query.slot.index(0),
 							)
-							?.getCard(),
+							?.card,
 					).toBe(null)
 				},
 			},
@@ -229,7 +229,7 @@ describe('Test Rare Hypnotizd', () => {
 								query.slot.rowIndex(0),
 								query.slot.index(0),
 							)
-							?.getCard(),
+							?.card,
 					).not.toBe(null)
 				},
 			},

--- a/tests/unit/game/hermits/hypnotizd-rare.test.ts
+++ b/tests/unit/game/hermits/hypnotizd-rare.test.ts
@@ -88,15 +88,13 @@ describe('Test Rare Hypnotizd', () => {
 					).toBe(EthosLabCommon.health - 40 /*Bow damage*/)
 
 					expect(
-						game.components
-							.find(
-								SlotComponent,
-								query.slot.currentPlayer,
-								query.slot.item,
-								query.slot.rowIndex(0),
-								query.slot.index(0),
-							)
-							?.card,
+						game.components.find(
+							SlotComponent,
+							query.slot.currentPlayer,
+							query.slot.item,
+							query.slot.rowIndex(0),
+							query.slot.index(0),
+						)?.card,
 					).toBe(null)
 				},
 			},
@@ -221,15 +219,13 @@ describe('Test Rare Hypnotizd', () => {
 					).toBe(EthosLabCommon.health)
 
 					expect(
-						game.components
-							.find(
-								SlotComponent,
-								query.slot.currentPlayer,
-								query.slot.item,
-								query.slot.rowIndex(0),
-								query.slot.index(0),
-							)
-							?.card,
+						game.components.find(
+							SlotComponent,
+							query.slot.currentPlayer,
+							query.slot.item,
+							query.slot.rowIndex(0),
+							query.slot.index(0),
+						)?.card,
 					).not.toBe(null)
 				},
 			},

--- a/tests/unit/game/hermits/zombie-cleo-rare.test.ts
+++ b/tests/unit/game/hermits/zombie-cleo-rare.test.ts
@@ -307,7 +307,7 @@ function* testPuppetryDiscardingItem(game: GameModel) {
 				query.slot.rowIndex(0),
 				query.slot.index(0),
 			)
-			?.getCard(),
+			?.card,
 	).toBe(null)
 }
 

--- a/tests/unit/game/hermits/zombie-cleo-rare.test.ts
+++ b/tests/unit/game/hermits/zombie-cleo-rare.test.ts
@@ -299,15 +299,13 @@ function* testPuppetryDiscardingItem(game: GameModel) {
 	)
 
 	expect(
-		game.components
-			.find(
-				SlotComponent,
-				query.slot.currentPlayer,
-				query.slot.item,
-				query.slot.rowIndex(0),
-				query.slot.index(0),
-			)
-			?.card,
+		game.components.find(
+			SlotComponent,
+			query.slot.currentPlayer,
+			query.slot.item,
+			query.slot.rowIndex(0),
+			query.slot.index(0),
+		)?.card,
 	).toBe(null)
 }
 


### PR DESCRIPTION
This PR optimizes the `slot.empty` query to run in `O(1)` time. Now that we are getting more players, I am finally looking back to optimizing this system at the cost of complexity.
Note that now we can't link multiple cards to one slot, but we didn't do that a single time since the system was made so I seriously doubt this is important.