### PR TITLE
Fix EvilX Achievments

### DIFF
--- a/common/achievements/defeat-evil-x.ts
+++ b/common/achievements/defeat-evil-x.ts
@@ -5,7 +5,7 @@ const DefeatEvilX: Achievement = {
 	...achievement,
 	numericId: 6,
 	id: 'defeat_evil_x',
-	progressInBossGame: true,
+	evilXAchievement: true,
 	levels: [
 		{
 			name: 'Evil X-Terminator',
@@ -13,8 +13,7 @@ const DefeatEvilX: Achievement = {
 			steps: 1,
 		},
 	],
-	onGameEnd(game, player, component, outcome) {
-		if (!game.state.isEvilXBossGame) return
+	onGameEnd(_game, player, component, outcome) {
 		if (outcome.type !== 'player-won') return
 		if (outcome.winner !== player.entity) return
 		component.incrementGoalProgress({goal: 0})

--- a/common/achievements/no-derpcoins.ts
+++ b/common/achievements/no-derpcoins.ts
@@ -16,7 +16,6 @@ const NoDerpcoins: Achievement = {
 	],
 	onGameStart(game, player, component, observer) {
 		const cost = getDeckCost(player.getDeck().map((card) => card.props))
-		console.log(cost)
 		if (cost > 0) return
 		observer.subscribe(game.hooks.onGameEnd, (outcome) => {
 			if (outcome.type !== 'player-won') return

--- a/common/achievements/no-derpcoins.ts
+++ b/common/achievements/no-derpcoins.ts
@@ -1,5 +1,3 @@
-import {CardComponent} from '../components'
-import query from '../components/query'
 import {getDeckCost} from '../utils/ranks'
 import {achievement} from './defaults'
 import {Achievement} from './types'
@@ -17,10 +15,7 @@ const NoDerpcoins: Achievement = {
 		},
 	],
 	onGameStart(game, player, component, observer) {
-		const cost = getDeckCost(
-			player.getDeck()
-				.map((card) => card.props),
-		)
+		const cost = getDeckCost(player.getDeck().map((card) => card.props))
 		console.log(cost)
 		if (cost > 0) return
 		observer.subscribe(game.hooks.onGameEnd, (outcome) => {

--- a/common/achievements/no-derpcoins.ts
+++ b/common/achievements/no-derpcoins.ts
@@ -8,7 +8,7 @@ const NoDerpcoins: Achievement = {
 	...achievement,
 	numericId: 7,
 	id: 'no_derpcoins',
-	progressInBossGame: true,
+	evilXAchievement: true,
 	levels: [
 		{
 			name: 'No Derpcoins Required',
@@ -17,12 +17,11 @@ const NoDerpcoins: Achievement = {
 		},
 	],
 	onGameStart(game, player, component, observer) {
-		if (!game.state.isEvilXBossGame) return
 		const cost = getDeckCost(
-			game.components
-				.filter(CardComponent, query.card.player(player.entity))
+			player.getDeck()
 				.map((card) => card.props),
 		)
+		console.log(cost)
 		if (cost > 0) return
 		observer.subscribe(game.hooks.onGameEnd, (outcome) => {
 			if (outcome.type !== 'player-won') return

--- a/common/achievements/types.ts
+++ b/common/achievements/types.ts
@@ -12,7 +12,7 @@ export type Achievement = {
 	numericId: number
 	getProgress: (goals: Record<number, number>) => number | undefined
 	getGoals?: (goals: Record<number, number>) => Array<Goal>
-	progressInBossGame?: boolean
+	evilXAchievement?: boolean
 
 	levels: Array<{
 		name: string

--- a/server/src/game-controller.ts
+++ b/server/src/game-controller.ts
@@ -157,7 +157,9 @@ export class GameController {
 	) {
 		if (player.achievementProgress) {
 			ACHIEVEMENTS_LIST.forEach((achievement) => {
-				if (restriction === 'boss' && !achievement.progressInBossGame) return
+				if (restriction === 'boss' && !achievement.evilXAchievement) return
+				if (restriction == 'all' && achievement.evilXAchievement) return
+
 				if (!player.achievementProgress[achievement.numericId]) {
 					player.achievementProgress[achievement.numericId] = {
 						goals: {},


### PR DESCRIPTION
Reworks evil x achievments to not rely on the `isEvilXGame` boolean. This boolean is set after achievements are added which causes issues. I think this system is better as well.