### PR TITLE
Fix "Channeling" achievement

### DIFF
--- a/common/achievements/channeling.ts
+++ b/common/achievements/channeling.ts
@@ -1,6 +1,6 @@
 import LightningRod from '../cards/attach/lightning-rod'
 import {CardComponent} from '../components'
-import {afterAttack} from '../types/priorities'
+import {afterAttack, beforeAttack} from '../types/priorities'
 import {achievement} from './defaults'
 import {Achievement} from './types'
 
@@ -17,29 +17,38 @@ const Channeling: Achievement = {
 		},
 	],
 	onGameStart(game, player, component, observer) {
+		const {opponentPlayer} = player
+
+		let damageRedirected = 0
+
+		observer.subscribe(opponentPlayer.hooks.onTurnStart, () => {
+			damageRedirected = 0
+		})
+
+		observer.subscribeWithPriority(
+			game.hooks.beforeAttack,
+			beforeAttack.RESOLVE_AFTER_MODIFIERS,
+			(attack) => {
+				if (attack.player.entity !== opponentPlayer.entity) return
+				const history = attack.getHistory('redirect').find((history) => {
+					let creator = game.components.get(history.source as any)
+					if (!(creator instanceof CardComponent)) return false
+					return creator.props.id === LightningRod.id
+				})
+				if (!history || history.value.from !== player.activeRowEntity) return
+				damageRedirected += attack.calculateDamage()
+			},
+		)
+
 		observer.subscribeWithPriority(
 			game.hooks.afterAttack,
 			afterAttack.ACHIEVEMENTS,
-			(attack) => {
-				if (attack.player.entity !== player.opponentPlayer.entity) return
-				const target = attack.target
-				if (target === player.activeRowEntity) return
-				if (!target || target.health) return
-				if (
-					!attack.getHistory('redirect').find((history) => {
-						let creator = game.components.get(history.source as any)
-						if (!(creator instanceof CardComponent)) return
-						return creator.props.id === LightningRod.id
-					})
-				)
-					return
+			(_attack) => {
+				if (!player.activeRow?.health) return
+				if (damageRedirected < player.activeRow.health) return
 
-				if (
-					player.activeRow?.health &&
-					attack.getDamage() > player.activeRow.health
-				) {
-					component.incrementGoalProgress({goal: 0})
-				}
+				component.incrementGoalProgress({goal: 0})
+				damageRedirected = 0
 			},
 		)
 	},

--- a/common/achievements/channeling.ts
+++ b/common/achievements/channeling.ts
@@ -1,30 +1,8 @@
-import {
-	ChainmailArmor,
-	DiamondArmor,
-	GoldArmor,
-	IronArmor,
-	NetheriteArmor,
-} from '../cards/attach/armor'
 import LightningRod from '../cards/attach/lightning-rod'
-import Shield from '../cards/attach/shield'
-import {CardComponent, StatusEffectComponent} from '../components'
-import {WEAKNESS_DAMAGE} from '../const/damage'
-import {STRENGTHS} from '../const/strengths'
-import {ReadonlyAttackModel} from '../models/attack-model'
-import {IgnoreAttachSlotEffect} from '../status-effects/ignore-attach'
-import PoisonEffect from '../status-effects/poison'
-import WeaknessEffect from '../status-effects/weakness'
+import {CardComponent} from '../components'
 import {afterAttack, beforeAttack} from '../types/priorities'
 import {achievement} from './defaults'
 import {Achievement} from './types'
-
-const ATTACH_REDUCTION_MAP = {
-	[GoldArmor.id]: 10,
-	[IronArmor.id]: 20,
-	[DiamondArmor.id]: 20,
-	[NetheriteArmor.id]: 20,
-	[Shield.id]: 60,
-}
 
 const Channeling: Achievement = {
 	...achievement,
@@ -35,113 +13,48 @@ const Channeling: Achievement = {
 			name: 'Channeling',
 			steps: 1,
 			description:
-				'Redirect KO worthy damage away from your active Hermit with Lightning Rod.',
+				"While your active Hermit has red HP, use Lightning Rod to redirect an attack's damage away from them.",
 		},
 	],
 	onGameStart(game, player, component, observer) {
 		const {opponentPlayer} = player
 
-		let damageRedirected = 0,
-			attachReduction = 0,
+		let damageRedirected = false,
 			activeRow = player.activeRow
 
 		observer.subscribe(opponentPlayer.hooks.onTurnStart, () => {
-			damageRedirected = 0
-			attachReduction = 0
+			damageRedirected = false
 			activeRow = player.activeRow
 		})
-
-		/** Modified logic from `common/utils/attacks.ts > createWeaknessAttack` */
-		function redirectedWeakness(attack: ReadonlyAttackModel): boolean {
-			if (attack.createWeakness === 'never') return false
-			if (!attack.isType('primary', 'secondary')) return false
-			const attacker = attack.attacker
-			if (!(attacker instanceof CardComponent && attacker.isHermit()))
-				return false
-			const target = activeRow?.getHermit()
-			if (!target?.isHermit()) return false
-			const testAttack = game
-				.newAttack({
-					attacker: attacker.entity,
-					target: activeRow?.entity,
-					type: attack.type,
-				})
-				.addDamage(attacker.entity, attack.getDamage())
-			testAttack.createWeakness = attack.createWeakness
-			game.hooks.beforeAttack.callSome([testAttack], (observerEntity) => {
-				const wrappingComponent = game.components.get(
-					game.components.get(observerEntity)?.wrappingEntity || null,
-				)
-				return (
-					wrappingComponent instanceof StatusEffectComponent &&
-					wrappingComponent.props.id === WeaknessEffect.id
-				)
-			})
-			return (
-				testAttack.createWeakness === 'always' ||
-				STRENGTHS[attacker.props.type].includes(target.props.type)
-			)
-		}
 
 		observer.subscribeWithPriority(
 			game.hooks.beforeAttack,
 			beforeAttack.RESOLVE_AFTER_MODIFIERS,
 			(attack) => {
 				if (attack.player.entity !== opponentPlayer.entity) return
-				if (!activeRow) return
+				if (!activeRow?.health || activeRow.health > 90) return
+
 				const history = attack.getHistory('redirect').find((history) => {
-					let creator = game.components.get(history.source as any)
+					const creator = game.components.get(history.source as any)
 					if (!(creator instanceof CardComponent)) return false
 					return creator.props.id === LightningRod.id
 				})
 				if (!history || history.value.from !== activeRow.entity) return
-				let attackDamage = attack.calculateDamage()
 
-				const playerAttach = activeRow.getAttach()
-				if (
-					playerAttach &&
-					!activeRow.getHermit()?.getStatusEffect(IgnoreAttachSlotEffect)
-				) {
-					if (
-						!attachReduction &&
-						playerAttach.props.id in ATTACH_REDUCTION_MAP
-					) {
-						attachReduction = ATTACH_REDUCTION_MAP[playerAttach.props.id]
-					}
-					if (attack.isType('effect')) {
-						if (playerAttach.props.id === DiamondArmor.id) {
-							attackDamage -= 20
-						} else if (
-							playerAttach.props.id === NetheriteArmor.id ||
-							playerAttach.props.id === ChainmailArmor.id
-						)
-							return
-					}
-				}
-				if (attackDamage <= 0) return
-				if (redirectedWeakness(attack)) {
-					attackDamage += WEAKNESS_DAMAGE
-				}
-				damageRedirected += attackDamage
+				damageRedirected = attack.calculateDamage() > 0
 			},
 		)
 
 		observer.subscribeWithPriority(
 			game.hooks.afterAttack,
 			afterAttack.ACHIEVEMENTS,
-			(attack) => {
+			(_attack) => {
 				if (!activeRow?.health || game.currentPlayerEntity === player.entity)
 					return
-				if (
-					attack.attacker instanceof StatusEffectComponent &&
-					attack.attacker.props.id === PoisonEffect.id
-				) {
-					// Poison should not determine if redirected damage was "KO worthy"
-					damageRedirected = 0
-				}
-				if (damageRedirected - attachReduction < activeRow.health) return
+
+				if (!damageRedirected) return
 				component.incrementGoalProgress({goal: 0})
-				damageRedirected = 0
+				damageRedirected = false
 			},
 		)
 	},

--- a/common/achievements/channeling.ts
+++ b/common/achievements/channeling.ts
@@ -1,8 +1,30 @@
+import {
+	ChainmailArmor,
+	DiamondArmor,
+	GoldArmor,
+	IronArmor,
+	NetheriteArmor,
+} from '../cards/attach/armor'
 import LightningRod from '../cards/attach/lightning-rod'
-import {CardComponent} from '../components'
+import Shield from '../cards/attach/shield'
+import {CardComponent, StatusEffectComponent} from '../components'
+import {WEAKNESS_DAMAGE} from '../const/damage'
+import {STRENGTHS} from '../const/strengths'
+import {ReadonlyAttackModel} from '../models/attack-model'
+import {IgnoreAttachSlotEffect} from '../status-effects/ignore-attach'
+import PoisonEffect from '../status-effects/poison'
+import WeaknessEffect from '../status-effects/weakness'
 import {afterAttack, beforeAttack} from '../types/priorities'
 import {achievement} from './defaults'
 import {Achievement} from './types'
+
+const ATTACH_REDUCTION_MAP = {
+	[GoldArmor.id]: 10,
+	[IronArmor.id]: 20,
+	[DiamondArmor.id]: 20,
+	[NetheriteArmor.id]: 20,
+	[Shield.id]: 60,
+}
 
 const Channeling: Achievement = {
 	...achievement,
@@ -19,34 +41,105 @@ const Channeling: Achievement = {
 	onGameStart(game, player, component, observer) {
 		const {opponentPlayer} = player
 
-		let damageRedirected = 0
+		let damageRedirected = 0,
+			attachReduction = 0,
+			activeRow = player.activeRow
 
 		observer.subscribe(opponentPlayer.hooks.onTurnStart, () => {
 			damageRedirected = 0
+			attachReduction = 0
+			activeRow = player.activeRow
 		})
+
+		/** Modified logic from `common/utils/attacks.ts > createWeaknessAttack` */
+		function redirectedWeakness(attack: ReadonlyAttackModel): boolean {
+			if (attack.createWeakness === 'never') return false
+			if (!attack.isType('primary', 'secondary')) return false
+			const attacker = attack.attacker
+			if (!(attacker instanceof CardComponent && attacker.isHermit()))
+				return false
+			const target = activeRow?.getHermit()
+			if (!target?.isHermit()) return false
+			const testAttack = game
+				.newAttack({
+					attacker: attacker.entity,
+					target: activeRow?.entity,
+					type: attack.type,
+				})
+				.addDamage(attacker.entity, attack.getDamage())
+			testAttack.createWeakness = attack.createWeakness
+			game.hooks.beforeAttack.callSome([testAttack], (observerEntity) => {
+				const wrappingComponent = game.components.get(
+					game.components.get(observerEntity)?.wrappingEntity || null,
+				)
+				return (
+					wrappingComponent instanceof StatusEffectComponent &&
+					wrappingComponent.props.id === WeaknessEffect.id
+				)
+			})
+			return (
+				testAttack.createWeakness === 'always' ||
+				STRENGTHS[attacker.props.type].includes(target.props.type)
+			)
+		}
 
 		observer.subscribeWithPriority(
 			game.hooks.beforeAttack,
 			beforeAttack.RESOLVE_AFTER_MODIFIERS,
 			(attack) => {
 				if (attack.player.entity !== opponentPlayer.entity) return
+				if (!activeRow) return
 				const history = attack.getHistory('redirect').find((history) => {
 					let creator = game.components.get(history.source as any)
 					if (!(creator instanceof CardComponent)) return false
 					return creator.props.id === LightningRod.id
 				})
-				if (!history || history.value.from !== player.activeRowEntity) return
-				damageRedirected += attack.calculateDamage()
+				if (!history || history.value.from !== activeRow.entity) return
+				let attackDamage = attack.calculateDamage()
+
+				const playerAttach = activeRow.getAttach()
+				if (
+					playerAttach &&
+					!activeRow.getHermit()?.getStatusEffect(IgnoreAttachSlotEffect)
+				) {
+					if (
+						!attachReduction &&
+						playerAttach.props.id in ATTACH_REDUCTION_MAP
+					) {
+						attachReduction = ATTACH_REDUCTION_MAP[playerAttach.props.id]
+					}
+					if (attack.isType('effect')) {
+						if (playerAttach.props.id === DiamondArmor.id) {
+							attackDamage -= 20
+						} else if (
+							playerAttach.props.id === NetheriteArmor.id ||
+							playerAttach.props.id === ChainmailArmor.id
+						)
+							return
+					}
+				}
+				if (attackDamage <= 0) return
+				if (redirectedWeakness(attack)) {
+					attackDamage += WEAKNESS_DAMAGE
+				}
+				damageRedirected += attackDamage
 			},
 		)
 
 		observer.subscribeWithPriority(
 			game.hooks.afterAttack,
 			afterAttack.ACHIEVEMENTS,
-			(_attack) => {
-				if (!player.activeRow?.health) return
-				if (damageRedirected < player.activeRow.health) return
-
+			(attack) => {
+				if (!activeRow?.health || game.currentPlayerEntity === player.entity)
+					return
+				if (
+					attack.attacker instanceof StatusEffectComponent &&
+					attack.attacker.props.id === PoisonEffect.id
+				) {
+					// Poison should not determine if redirected damage was "KO worthy"
+					damageRedirected = 0
+				}
+				if (damageRedirected - attachReduction < activeRow.health) return
 				component.incrementGoalProgress({goal: 0})
 				damageRedirected = 0
 			},

--- a/common/cards/attach/lightning-rod.ts
+++ b/common/cards/attach/lightning-rod.ts
@@ -54,7 +54,12 @@ const LightningRod: Attach = {
 			game.hooks.beforeAttack,
 			beforeAttack.RESOLVE_AFTER_MODIFIERS,
 			(attack) => {
-				if (!attack.getHistory('redirect').find(entry => entry.source === component.entity)) return
+				if (
+					!attack
+						.getHistory('redirect')
+						.find((entry) => entry.source === component.entity)
+				)
+					return
 				if (attack.calculateDamage() <= 0) return
 
 				used = true

--- a/common/cards/attach/lightning-rod.ts
+++ b/common/cards/attach/lightning-rod.ts
@@ -54,11 +54,7 @@ const LightningRod: Attach = {
 			game.hooks.beforeAttack,
 			beforeAttack.RESOLVE_AFTER_MODIFIERS,
 			(attack) => {
-				if (attack.player.entity !== opponentPlayer.entity) return
-				if (!component.slot?.onBoard() || !component.slot.row) return
-				if (attack.type === 'status-effect' || attack.isBacklash) return
-				if (game.currentPlayer.entity !== opponentPlayer.entity) return
-				if (attack.target?.player.entity !== player.entity) return
+				if (!attack.getHistory('redirect').find(entry => entry.source === component.entity)) return
 				if (attack.calculateDamage() <= 0) return
 
 				used = true

--- a/common/models/attack-model.ts
+++ b/common/models/attack-model.ts
@@ -217,8 +217,8 @@ export class AttackModel {
 
 	/** Redirect the attack to another hermit. Unlike setTarget, this will trigger Chainmail Armor. */
 	public redirect(sourceId: AttackerEntity, target: RowEntity | null) {
+		this.addHistory(sourceId, 'redirect', {from: this.targetEntity, to: target})
 		this.targetEntity = target
-		this.addHistory(sourceId, 'redirect', target)
 		return this
 	}
 

--- a/common/types/priorities.ts
+++ b/common/types/priorities.ts
@@ -41,10 +41,10 @@ export const beforeAttack = createPriorityDictionary({
 	ADD_ATTACK: null,
 	/** Effects, Hermits, and Status Effects that modify damage of additional attacks along with the main attack.  */
 	MODIFY_DAMAGE: null,
-	/** Listeners that call after damage modifiers are applied.  */
-	RESOLVE_AFTER_MODIFIERS: null,
 	/** Hermit attack abilities that modify state before any damage is dealt */
 	HERMIT_APPLY_ATTACK: null,
+	/** Listeners that call after damage modifiers are applied.  */
+	RESOLVE_AFTER_MODIFIERS: null,
 	/** Any attacking single-use cards must call `applySingleUse` at this stage */
 	APPLY_SINGLE_USE_ATTACK: null,
 	/** Hermits blocking all damage done by certain attacks */

--- a/tests/unit/game/achievements/channeling.test.ts
+++ b/tests/unit/game/achievements/channeling.test.ts
@@ -1,10 +1,9 @@
 import {describe, expect, test} from '@jest/globals'
 import Channeling from 'common/achievements/channeling'
-import {IronArmor, NetheriteArmor} from 'common/cards/attach/armor'
 import LightningRod from 'common/cards/attach/lightning-rod'
+import BdoubleO100Rare from 'common/cards/hermits/bdoubleo100-rare'
 import EthosLabCommon from 'common/cards/hermits/ethoslab-common'
 import GoatfatherRare from 'common/cards/hermits/goatfather-rare'
-import TinFoilChefUltraRare from 'common/cards/hermits/tinfoilchef-ultra-rare'
 import Anvil from 'common/cards/single-use/anvil'
 import {
 	attack,
@@ -29,7 +28,7 @@ describe('Test Channeling achievement', () => {
 
 					yield* playCardFromHand(game, GoatfatherRare, 'hermit', 0)
 					yield* playCardFromHand(game, Anvil, 'single_use')
-					game.opponentPlayer.activeRow!.health = 140
+					game.opponentPlayer.activeRow!.health = 90
 					yield* attack(game, 'secondary')
 
 					yield* forfeit(game.opponentPlayer.entity)
@@ -41,7 +40,33 @@ describe('Test Channeling achievement', () => {
 			{noItemRequirements: true, forceCoinFlip: true},
 		)
 	})
-	test('"Channeling" does not increase if the lightning rod didn\'t save any Hermit', () => {
+	test('"Channeling" does not increase if the lightning rod didn\'t redirect damage from active Hermit', () => {
+		testAchivement(
+			{
+				achievement: Channeling,
+				playerOneDeck: [EthosLabCommon, EthosLabCommon, LightningRod],
+				playerTwoDeck: [BdoubleO100Rare, Anvil],
+				playGame: function* (game) {
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 1)
+					yield* playCardFromHand(game, LightningRod, 'attach', 1)
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, BdoubleO100Rare, 'hermit', 1)
+					yield* playCardFromHand(game, Anvil, 'single_use')
+					game.opponentPlayer.activeRow!.health = 90
+					yield* attack(game, 'secondary')
+
+					yield* forfeit(game.opponentPlayer.entity)
+				},
+				checkAchivement(_game, achievement, _outcome) {
+					expect(Channeling.getProgress(achievement.goals)).toBeFalsy()
+				},
+			},
+			{noItemRequirements: true},
+		)
+	})
+	test('"Channeling" does not increase if the active Hermit has at least 100hp', () => {
 		testAchivement(
 			{
 				achievement: Channeling,
@@ -55,39 +80,7 @@ describe('Test Channeling achievement', () => {
 
 					yield* playCardFromHand(game, GoatfatherRare, 'hermit', 1)
 					yield* playCardFromHand(game, Anvil, 'single_use')
-					game.opponentPlayer.activeRow!.health = 120
-					yield* attack(game, 'secondary')
-
-					yield* forfeit(game.opponentPlayer.entity)
-				},
-				checkAchivement(_game, achievement, _outcome) {
-					expect(Channeling.getProgress(achievement.goals)).toBeFalsy()
-				},
-			},
-			{noItemRequirements: true, forceCoinFlip: true},
-		)
-	})
-	test('"Channeling" does not increase if the lightning rod didn\'t save any Hermit because they had armor', () => {
-		testAchivement(
-			{
-				achievement: Channeling,
-				playerOneDeck: [
-					EthosLabCommon,
-					EthosLabCommon,
-					LightningRod,
-					NetheriteArmor,
-				],
-				playerTwoDeck: [GoatfatherRare, Anvil],
-				playGame: function* (game) {
-					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
-					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 1)
-					yield* playCardFromHand(game, NetheriteArmor, 'attach', 0)
-					yield* playCardFromHand(game, LightningRod, 'attach', 1)
-					yield* endTurn(game)
-
-					yield* playCardFromHand(game, GoatfatherRare, 'hermit', 0)
-					yield* playCardFromHand(game, Anvil, 'single_use')
-					game.opponentPlayer.activeRow!.health = 120
+					game.opponentPlayer.activeRow!.health = 100
 					yield* attack(game, 'secondary')
 
 					yield* forfeit(game.opponentPlayer.entity)
@@ -122,37 +115,6 @@ describe('Test Channeling achievement', () => {
 				},
 			},
 			{noItemRequirements: true},
-		)
-	})
-	test('"Channeling" increases when type-advantage + TFC "Take It Easy" heads would have caused a KO', () => {
-		testAchivement(
-			{
-				achievement: Channeling,
-				playerOneDeck: [
-					GoatfatherRare,
-					EthosLabCommon,
-					IronArmor,
-					LightningRod,
-				],
-				playerTwoDeck: [TinFoilChefUltraRare, Anvil],
-				playGame: function* (game) {
-					yield* playCardFromHand(game, GoatfatherRare, 'hermit', 0)
-					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 1)
-					yield* playCardFromHand(game, IronArmor, 'attach', 0)
-					yield* playCardFromHand(game, LightningRod, 'attach', 1)
-					yield* endTurn(game)
-
-					yield* playCardFromHand(game, TinFoilChefUltraRare, 'hermit', 0)
-					game.opponentPlayer.activeRow!.health = 120
-					yield* attack(game, 'secondary')
-
-					yield* forfeit(game.opponentPlayer.entity)
-				},
-				checkAchivement(_game, achievement, _outcome) {
-					expect(Channeling.getProgress(achievement.goals)).toEqual(1)
-				},
-			},
-			{noItemRequirements: true, forceCoinFlip: true},
 		)
 	})
 })

--- a/tests/unit/game/achievements/channeling.test.ts
+++ b/tests/unit/game/achievements/channeling.test.ts
@@ -1,8 +1,11 @@
 import {describe, expect, test} from '@jest/globals'
 import Channeling from 'common/achievements/channeling'
+import {IronArmor, NetheriteArmor} from 'common/cards/attach/armor'
 import LightningRod from 'common/cards/attach/lightning-rod'
 import EthosLabCommon from 'common/cards/hermits/ethoslab-common'
 import GoatfatherRare from 'common/cards/hermits/goatfather-rare'
+import TinFoilChefUltraRare from 'common/cards/hermits/tinfoilchef-ultra-rare'
+import Anvil from 'common/cards/single-use/anvil'
 import {
 	attack,
 	endTurn,
@@ -10,7 +13,6 @@ import {
 	playCardFromHand,
 	testAchivement,
 } from '../utils'
-import Anvil from 'common/cards/single-use/anvil'
 
 describe('Test Channeling achievement', () => {
 	test('"Channeling" increases properly', () => {
@@ -28,7 +30,6 @@ describe('Test Channeling achievement', () => {
 					yield* playCardFromHand(game, GoatfatherRare, 'hermit', 0)
 					yield* playCardFromHand(game, Anvil, 'single_use')
 					game.opponentPlayer.activeRow!.health = 140
-
 					yield* attack(game, 'secondary')
 
 					yield* forfeit(game.opponentPlayer.entity)
@@ -66,6 +67,38 @@ describe('Test Channeling achievement', () => {
 			{noItemRequirements: true, forceCoinFlip: true},
 		)
 	})
+	test('"Channeling" does not increase if the lightning rod didn\'t save any Hermit because they had armor', () => {
+		testAchivement(
+			{
+				achievement: Channeling,
+				playerOneDeck: [
+					EthosLabCommon,
+					EthosLabCommon,
+					LightningRod,
+					NetheriteArmor,
+				],
+				playerTwoDeck: [GoatfatherRare, Anvil],
+				playGame: function* (game) {
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 1)
+					yield* playCardFromHand(game, NetheriteArmor, 'attach', 0)
+					yield* playCardFromHand(game, LightningRod, 'attach', 1)
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, GoatfatherRare, 'hermit', 0)
+					yield* playCardFromHand(game, Anvil, 'single_use')
+					game.opponentPlayer.activeRow!.health = 120
+					yield* attack(game, 'secondary')
+
+					yield* forfeit(game.opponentPlayer.entity)
+				},
+				checkAchivement(_game, achievement, _outcome) {
+					expect(Channeling.getProgress(achievement.goals)).toBeFalsy()
+				},
+			},
+			{noItemRequirements: true, forceCoinFlip: true},
+		)
+	})
 	test('"Channeling" does not increase when Lightning Rod on active row', () => {
 		testAchivement(
 			{
@@ -89,6 +122,37 @@ describe('Test Channeling achievement', () => {
 				},
 			},
 			{noItemRequirements: true},
+		)
+	})
+	test('"Channeling" increases when type-advantage + TFC "Take It Easy" heads would have caused a KO', () => {
+		testAchivement(
+			{
+				achievement: Channeling,
+				playerOneDeck: [
+					GoatfatherRare,
+					EthosLabCommon,
+					IronArmor,
+					LightningRod,
+				],
+				playerTwoDeck: [TinFoilChefUltraRare, Anvil],
+				playGame: function* (game) {
+					yield* playCardFromHand(game, GoatfatherRare, 'hermit', 0)
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 1)
+					yield* playCardFromHand(game, IronArmor, 'attach', 0)
+					yield* playCardFromHand(game, LightningRod, 'attach', 1)
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, TinFoilChefUltraRare, 'hermit', 0)
+					game.opponentPlayer.activeRow!.health = 120
+					yield* attack(game, 'secondary')
+
+					yield* forfeit(game.opponentPlayer.entity)
+				},
+				checkAchivement(_game, achievement, _outcome) {
+					expect(Channeling.getProgress(achievement.goals)).toEqual(1)
+				},
+			},
+			{noItemRequirements: true, forceCoinFlip: true},
 		)
 	})
 })

--- a/tests/unit/game/achievements/channeling.test.ts
+++ b/tests/unit/game/achievements/channeling.test.ts
@@ -3,15 +3,14 @@ import Channeling from 'common/achievements/channeling'
 import LightningRod from 'common/cards/attach/lightning-rod'
 import EthosLabCommon from 'common/cards/hermits/ethoslab-common'
 import GoatfatherRare from 'common/cards/hermits/goatfather-rare'
-import {RowComponent} from 'common/components'
 import {
 	attack,
-	changeActiveHermit,
 	endTurn,
 	forfeit,
 	playCardFromHand,
 	testAchivement,
 } from '../utils'
+import Anvil from 'common/cards/single-use/anvil'
 
 describe('Test Channeling achievement', () => {
 	test('"Channeling" increases properly', () => {
@@ -19,7 +18,7 @@ describe('Test Channeling achievement', () => {
 			{
 				achievement: Channeling,
 				playerOneDeck: [EthosLabCommon, EthosLabCommon, LightningRod],
-				playerTwoDeck: [GoatfatherRare],
+				playerTwoDeck: [GoatfatherRare, Anvil],
 				playGame: function* (game) {
 					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
 					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 1)
@@ -27,10 +26,8 @@ describe('Test Channeling achievement', () => {
 					yield* endTurn(game)
 
 					yield* playCardFromHand(game, GoatfatherRare, 'hermit', 0)
-
-					for (const hermit of game.components.filter(RowComponent)) {
-						if (hermit.health) hermit.health = 10
-					}
+					yield* playCardFromHand(game, Anvil, 'single_use')
+					game.opponentPlayer.activeRow!.health = 140
 
 					yield* attack(game, 'secondary')
 
@@ -48,15 +45,16 @@ describe('Test Channeling achievement', () => {
 			{
 				achievement: Channeling,
 				playerOneDeck: [EthosLabCommon, EthosLabCommon, LightningRod],
-				playerTwoDeck: [GoatfatherRare],
+				playerTwoDeck: [GoatfatherRare, Anvil],
 				playGame: function* (game) {
 					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
 					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 1)
 					yield* playCardFromHand(game, LightningRod, 'attach', 1)
 					yield* endTurn(game)
 
-					yield* playCardFromHand(game, GoatfatherRare, 'hermit', 0)
-
+					yield* playCardFromHand(game, GoatfatherRare, 'hermit', 1)
+					yield* playCardFromHand(game, Anvil, 'single_use')
+					game.opponentPlayer.activeRow!.health = 120
 					yield* attack(game, 'secondary')
 
 					yield* forfeit(game.opponentPlayer.entity)
@@ -77,19 +75,11 @@ describe('Test Channeling achievement', () => {
 				playGame: function* (game) {
 					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
 					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 1)
-					yield* playCardFromHand(game, LightningRod, 'attach', 1)
-
+					yield* playCardFromHand(game, LightningRod, 'attach', 0)
 					yield* endTurn(game)
+
 					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
-					yield* endTurn(game)
-
-					yield* changeActiveHermit(game, 1)
-					yield* endTurn(game)
-
-					for (const hermit of game.components.filter(RowComponent)) {
-						if (hermit.health) hermit.health = 10
-					}
-
+					game.opponentPlayer.activeRow!.health = 10
 					yield* attack(game, 'secondary')
 
 					yield* forfeit(game.opponentPlayer.entity)


### PR DESCRIPTION
- Fixes achievement only granting if AFK Hermit is knocked-out and _base_ damage is strictly greater than active row health
- New description: "While your active Hermit has red HP, use Lightning Rod to redirect an attack's damage away from them."