### PR TITLE
Disallow clicks on right overlay when game mode button is closed

### DIFF
--- a/client/src/components/game-mode-button/game-mode-button.module.scss
+++ b/client/src/components/game-mode-button/game-mode-button.module.scss
@@ -238,6 +238,10 @@ $expandedHeight: $mobileHeight * 3 + 1.5 * 3;
 	opacity: 0%;
 	height: 100%;
 	width: calc(100% - $width);
+
+	&.disallowClicks {
+		pointer-events: none;
+	}
 }
 
 .spacer {

--- a/client/src/components/game-mode-button/game-mode-button.tsx
+++ b/client/src/components/game-mode-button/game-mode-button.tsx
@@ -311,7 +311,13 @@ function GameModeButton({
 						)}
 					</div>
 				</div>
-				<div ref={rightOverlayRef} className={css.rightOverlay}>
+				<div
+					ref={rightOverlayRef}
+					className={classNames(
+						css.rightOverlay,
+						activeMode !== mode && css.disallowClicks,
+					)}
+				>
 					{activeMode === mode && children}
 				</div>
 			</div>


### PR DESCRIPTION
This fixes a problem with accidentally opening the tag filter on mobile or accidentally selecting a deck before the window was visible