### PR TITLE
Make Efficiency Actually Last The Whole Turn

### DIFF
--- a/common/status-effects/efficiency.ts
+++ b/common/status-effects/efficiency.ts
@@ -16,15 +16,6 @@ const EfficiencyEffect: StatusEffect<PlayerComponent> = {
 		})
 
 		observer.subscribeWithPriority(
-			game.hooks.afterAttack,
-			afterAttack.UPDATE_POST_ATTACK_STATE,
-			(_attack) => {
-				effect.remove()
-			},
-		)
-
-		// In case the player does not attack
-		observer.subscribeWithPriority(
 			player.hooks.onTurnEnd,
 			onTurnEnd.BEFORE_STATUS_EFFECT_TIMEOUT,
 			() => {

--- a/common/status-effects/efficiency.ts
+++ b/common/status-effects/efficiency.ts
@@ -9,7 +9,10 @@ const EfficiencyEffect: StatusEffect<PlayerComponent> = {
 	icon: 'efficiency',
 	description:
 		'You may use attacks on this turn without having the necessary item cards attached.',
-	onApply(game, effect, player, observer) {
+	applyCondition: (_game, value) =>
+		value instanceof PlayerComponent &&
+		!value.hasStatusEffect(EfficiencyEffect),
+	onApply(_game, effect, player, observer) {
 		observer.subscribe(player.hooks.availableEnergy, (_availableEnergy) => {
 			// Unliimited powwa
 			return ['any', 'any', 'any', 'any']

--- a/tests/unit/game/hermits/hypnotizd-rare.test.ts
+++ b/tests/unit/game/hermits/hypnotizd-rare.test.ts
@@ -128,13 +128,6 @@ describe('Test Rare Hypnotizd', () => {
 
 					expect(
 						game.components.find(
-							StatusEffectComponent,
-							query.effect.is(EfficiencyEffect),
-							query.effect.targetIsPlayerAnd(query.player.currentPlayer),
-						),
-					).toBe(null)
-					expect(
-						game.components.find(
 							RowComponent,
 							query.row.opponentPlayer,
 							query.row.index(0),


### PR DESCRIPTION
The description says "for this turn". Therefore, one should be able to attack multiple times without necessary items if they have used efficiency this turn i.e. Efficiency should not remove itself after an attack.