### PR TITLE
Make only new achievements sent over

### DIFF
--- a/server/src/api/auth.ts
+++ b/server/src/api/auth.ts
@@ -1,3 +1,4 @@
+import {AchievementProgress} from 'common/types/achievements'
 import root from 'serverRoot'
 import {z} from 'zod'
 
@@ -15,6 +16,7 @@ export async function authenticateApiKey(key: string) {
 export async function authenticateUser(
 	userId: string | undefined,
 	secret: string | undefined,
+	savedAchievements: string | undefined,
 ): Promise<[number, any]> {
 	if (!userId || !secret) {
 		return [
@@ -41,6 +43,21 @@ export async function authenticateUser(
 	if (userInfo.body.banned) {
 		return [401, 'You are banned']
 	}
+
+	if (!savedAchievements) return [200, userInfo.body]
+
+	const achievements = userInfo.body.achievements
+
+	const newAchievements: AchievementProgress = {}
+
+	Object.entries(achievements.achievementData).forEach((p) => {
+		const k = p[0]
+		const v = p[1]
+
+		if (!(k in achievements)) newAchievements[Number(k)] = v
+	})
+
+	userInfo.body.achievements = {achievementData: newAchievements}
 
 	return [200, userInfo.body]
 }

--- a/server/src/api/auth.ts
+++ b/server/src/api/auth.ts
@@ -54,7 +54,13 @@ export async function authenticateUser(
 		const k = p[0]
 		const v = p[1]
 
-		if (!(k in achievements)) newAchievements[Number(k)] = v
+		if (
+			!(k in achievements) ||
+			achievements.achievementData[Number(k)] !==
+				userInfo.body.achievements.achievementData[Number(k)]
+		) {
+			newAchievements[Number(k)] = v
+		}
 	})
 
 	userInfo.body.achievements = {achievementData: newAchievements}

--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -42,7 +42,8 @@ export function addApi(app: Express) {
 	app.get('/api/auth/', async (req, res) => {
 		const userId = req.get('userId')
 		const secret = req.get('secret')
-		let ret = await authenticateUser(userId, secret)
+		const savedAchievements = req.get('savedAchievements')
+		let ret = await authenticateUser(userId, secret, savedAchievements)
 		res.statusCode = ret[0]
 		res.send(ret[1])
 	})


### PR DESCRIPTION
This change makes it so that only achievements that have been changed since last login are sent to the client. This should help reduce server costs as decreases outgoing bandwidth