### PR TITLE
Allow Healing SUs to Heal Opposing Hermits

### DIFF
--- a/common/cards/single-use/golden-apple.ts
+++ b/common/cards/single-use/golden-apple.ts
@@ -19,7 +19,7 @@ const GoldenApple: SingleUse = {
 	expansion: 'default',
 	rarity: 'ultra_rare',
 	tokens: 2,
-	description: 'Heal one of your AFK Hermits 100hp.',
+	description: 'Heal any AFK Hermit 100hp.',
 	log: (values) =>
 		`${values.defaultLog} on $p${values.pick.name}$ and healed $g100hp$`,
 	attachCondition: query.every(
@@ -37,7 +37,7 @@ const GoldenApple: SingleUse = {
 		game.addPickRequest({
 			player: player.entity,
 			id: component.entity,
-			message: 'Pick one of your AFK Hermits',
+			message: 'Pick an AFK Hermit',
 			canPick: pickCondition,
 			onResult(pickedSlot) {
 				if (!pickedSlot.onBoard())

--- a/common/cards/single-use/instant-health.ts
+++ b/common/cards/single-use/instant-health.ts
@@ -8,7 +8,6 @@ import {SingleUse} from '../types'
 
 const pickCondition = query.every(
 	query.slot.hermit,
-	query.slot.currentPlayer,
 	query.not(query.slot.empty),
 )
 
@@ -30,7 +29,7 @@ function newInstantHealth(
 		expansion: 'default',
 		rarity: props.rarity,
 		tokens: props.tokens,
-		description: `Heal one of your Hermits ${amount}hp.`,
+		description: `Heal any Hermit ${amount}hp.`,
 		attachCondition: query.every(
 			singleUse.attachCondition,
 			query.slot.playerHasActiveHermit,


### PR DESCRIPTION
Description:
The HC descriptions of these cards didn't specify whose hermits they can heal; the clause was only included upon rewording for clarification. Following the interpretation for Keralis Rare, it would make sense to allow them to do the same.

Original Suggestor:
Rvtar

Supported By:
ElementL0rd, shortweekly, InterimName, Tyrannicodin