### PR TITLE
Fix Evil X being unable to disable Puppetry if attacker has 0 afk Hermits

### DIFF
--- a/common/cards/hermits/evilxisuma_rare.ts
+++ b/common/cards/hermits/evilxisuma_rare.ts
@@ -70,7 +70,7 @@ const EvilXisumaRare: Hermit = {
 				)
 				if (!opponentActiveHermit?.isAlive()) return
 
-				game.addCopyAttackModalRequest(
+				game.addPickAttackModalRequest(
 					{
 						player: player.entity,
 						modal: {

--- a/common/cards/hermits/evilxisuma_rare.ts
+++ b/common/cards/hermits/evilxisuma_rare.ts
@@ -70,41 +70,44 @@ const EvilXisumaRare: Hermit = {
 				)
 				if (!opponentActiveHermit?.isAlive()) return
 
-				game.addCopyAttackModalRequest({
-					player: player.entity,
-					modal: {
-						type: 'copyAttack',
-						name: 'Evil X: Disable an attack for 1 turn',
-						description:
-							"Which of the opponent's attacks do you want to disable?",
-						hermitCard: opponentActiveHermit.entity,
-						cancelable: false,
-					},
-					onResult(modalResult) {
-						assert(modalResult.pick)
+				game.addCopyAttackModalRequest(
+					{
+						player: player.entity,
+						modal: {
+							type: 'copyAttack',
+							name: 'Evil X: Disable an attack for 1 turn',
+							description:
+								"Which of the opponent's attacks do you want to disable?",
+							hermitCard: opponentActiveHermit.entity,
+							cancelable: false,
+						},
+						onResult(modalResult) {
+							assert(modalResult.pick)
 
-						const actionToBlock =
-							modalResult.pick === 'primary'
-								? PrimaryAttackDisabledEffect
-								: SecondaryAttackDisabledEffect
+							const actionToBlock =
+								modalResult.pick === 'primary'
+									? PrimaryAttackDisabledEffect
+									: SecondaryAttackDisabledEffect
 
-						// This will add a blocked action for the duration of their turn
-						game.components
-							.new(StatusEffectComponent, actionToBlock, component.entity)
-							.apply(opponentPlayer.getActiveHermit()?.entity)
-						return
+							// This will add a blocked action for the duration of their turn
+							game.components
+								.new(StatusEffectComponent, actionToBlock, component.entity)
+								.apply(opponentPlayer.getActiveHermit()?.entity)
+							return
+						},
+						onTimeout() {
+							// Disable the secondary attack if we didn't choose one
+							game.components
+								.new(
+									StatusEffectComponent,
+									SecondaryAttackDisabledEffect,
+									component.entity,
+								)
+								.apply(opponentPlayer.getActiveHermit()?.entity)
+						},
 					},
-					onTimeout() {
-						// Disable the secondary attack if we didn't choose one
-						game.components
-							.new(
-								StatusEffectComponent,
-								SecondaryAttackDisabledEffect,
-								component.entity,
-							)
-							.apply(opponentPlayer.getActiveHermit()?.entity)
-					},
-				})
+					'disable',
+				)
 			},
 		)
 	},

--- a/common/cards/hermits/rendog-rare.ts
+++ b/common/cards/hermits/rendog-rare.ts
@@ -119,7 +119,7 @@ const RendogRare: Hermit = {
 						let pickedCard = pickedSlot.card as CardComponent<Hermit>
 						if (!pickedCard) return
 
-						game.addCopyAttackModalRequest(
+						game.addPickAttackModalRequest(
 							{
 								player: player.entity,
 								modal: {

--- a/common/cards/hermits/rendog-rare.ts
+++ b/common/cards/hermits/rendog-rare.ts
@@ -119,40 +119,48 @@ const RendogRare: Hermit = {
 						let pickedCard = pickedSlot.card as CardComponent<Hermit>
 						if (!pickedCard) return
 
-						game.addCopyAttackModalRequest({
-							player: player.entity,
-							modal: {
-								type: 'copyAttack',
-								name: 'Rendog: Choose an attack to copy',
-								description:
-									"Which of the Hermit's attacks do you want to copy?",
-								hermitCard: pickedCard.entity,
-								cancelable: true,
-							},
-							onResult: (modalResult) => {
-								if (!modalResult) return
-								if (modalResult.cancel) {
-									// Cancel this attack so player can choose a different hermit to imitate
-									game.state.turn.currentAttack = null
-									game.cancelPickRequests()
+						game.addCopyAttackModalRequest(
+							{
+								player: player.entity,
+								modal: {
+									type: 'copyAttack',
+									name: 'Rendog: Choose an attack to copy',
+									description:
+										"Which of the Hermit's attacks do you want to copy?",
+									hermitCard: pickedCard.entity,
+									cancelable: true,
+								},
+								onResult: (modalResult) => {
+									if (!modalResult) return
+									if (modalResult.cancel) {
+										// Cancel this attack so player can choose a different hermit to imitate
+										game.state.turn.currentAttack = null
+										game.cancelPickRequests()
+										return
+									}
+
+									// Store the chosen attack to copy
+									mockedAttacks.set(
+										component,
+										setupMockCard(
+											game,
+											component,
+											pickedCard,
+											modalResult.pick,
+										),
+									)
+
 									return
-								}
-
-								// Store the chosen attack to copy
-								mockedAttacks.set(
-									component,
-									setupMockCard(game, component, pickedCard, modalResult.pick),
-								)
-
-								return
+								},
+								onTimeout: () => {
+									mockedAttacks.set(
+										component,
+										setupMockCard(game, component, pickedCard, 'primary'),
+									)
+								},
 							},
-							onTimeout: () => {
-								mockedAttacks.set(
-									component,
-									setupMockCard(game, component, pickedCard, 'primary'),
-								)
-							},
-						})
+							'copy',
+						)
 					},
 					onTimeout() {
 						// We didn't pick someone to imitate so do nothing

--- a/common/cards/hermits/zombiecleo-rare.ts
+++ b/common/cards/hermits/zombiecleo-rare.ts
@@ -97,7 +97,7 @@ const ZombieCleoRare: Hermit = {
 						const pickedCard = pickedSlot.card as CardComponent<Hermit> | null
 						if (!pickedCard) return
 
-						game.addCopyAttackModalRequest(
+						game.addPickAttackModalRequest(
 							{
 								player: player.entity,
 								modal: {

--- a/common/cards/hermits/zombiecleo-rare.ts
+++ b/common/cards/hermits/zombiecleo-rare.ts
@@ -97,41 +97,49 @@ const ZombieCleoRare: Hermit = {
 						const pickedCard = pickedSlot.card as CardComponent<Hermit> | null
 						if (!pickedCard) return
 
-						game.addCopyAttackModalRequest({
-							player: player.entity,
-							modal: {
-								type: 'copyAttack',
-								name: 'Cleo: Choose an attack to copy',
-								description:
-									"Which of the Hermit's attacks do you want to copy?",
-								hermitCard: pickedCard.entity,
-								cancelable: true,
-							},
-							onResult: (modalResult) => {
-								if (!modalResult) return
-								if (modalResult.cancel) {
-									// Cancel this attack so player can choose a different hermit to imitate
-									game.state.turn.currentAttack = null
-									game.cancelPickRequests()
+						game.addCopyAttackModalRequest(
+							{
+								player: player.entity,
+								modal: {
+									type: 'copyAttack',
+									name: 'Cleo: Choose an attack to copy',
+									description:
+										"Which of the Hermit's attacks do you want to copy?",
+									hermitCard: pickedCard.entity,
+									cancelable: true,
+								},
+								onResult: (modalResult) => {
+									if (!modalResult) return
+									if (modalResult.cancel) {
+										// Cancel this attack so player can choose a different hermit to imitate
+										game.state.turn.currentAttack = null
+										game.cancelPickRequests()
+										return
+									}
+									if (!modalResult.pick) return
+
+									// Store the card to copy when creating the attack
+									mockedAttacks.set(
+										component,
+										setupMockCard(
+											game,
+											component,
+											pickedCard,
+											modalResult.pick,
+										),
+									)
+
 									return
-								}
-								if (!modalResult.pick) return
-
-								// Store the card to copy when creating the attack
-								mockedAttacks.set(
-									component,
-									setupMockCard(game, component, pickedCard, modalResult.pick),
-								)
-
-								return
+								},
+								onTimeout: () => {
+									mockedAttacks.set(
+										component,
+										setupMockCard(game, component, pickedCard, 'primary'),
+									)
+								},
 							},
-							onTimeout: () => {
-								mockedAttacks.set(
-									component,
-									setupMockCard(game, component, pickedCard, 'primary'),
-								)
-							},
-						})
+							'copy',
+						)
 					},
 					onTimeout() {
 						// We didn't pick someone so do nothing

--- a/common/models/game-model.ts
+++ b/common/models/game-model.ts
@@ -398,16 +398,17 @@ export class GameModel {
 	) {
 		let modal = newRequest.modal
 		let hermitCard = this.components.get(modal.hermitCard)!
-		let blockedActions =
-			mode === 'copy'
-				? hermitCard.player.hooks.blockedActions.callSome(
-						[[]],
-						(observerEntity) => {
-							let observer = this.components.get(observerEntity)
-							return observer?.wrappingEntity === hermitCard.entity
-						},
-					)
-				: []
+		/** If true, prevents picking attacks that are unable to be used */
+		const excludeDisabledAttacks = mode === 'copy'
+		let blockedActions = excludeDisabledAttacks
+			? hermitCard.player.hooks.blockedActions.callSome(
+					[[]],
+					(observerEntity) => {
+						let observer = this.components.get(observerEntity)
+						return observer?.wrappingEntity === hermitCard.entity
+					},
+				)
+			: []
 
 		/* Due to an issue with the blocked actions system, we have to check if our target has thier action
 		 * blocked by status effects here.
@@ -447,6 +448,7 @@ export class GameModel {
 		}
 
 		if (
+			excludeDisabledAttacks &&
 			this.components.exists(
 				StatusEffectComponent,
 				query.effect.is(TimeSkipDisabledEffect),

--- a/common/models/game-model.ts
+++ b/common/models/game-model.ts
@@ -393,17 +393,21 @@ export class GameModel {
 		newRequest: Omit<CopyAttack.Request, 'modal'> & {
 			modal: Omit<CopyAttack.Request['modal'], 'availableAttacks'>
 		},
+		mode: 'copy' | 'disable',
 		before = false,
 	) {
 		let modal = newRequest.modal
 		let hermitCard = this.components.get(modal.hermitCard)!
-		let blockedActions = hermitCard.player.hooks.blockedActions.callSome(
-			[[]],
-			(observerEntity) => {
-				let observer = this.components.get(observerEntity)
-				return observer?.wrappingEntity === hermitCard.entity
-			},
-		)
+		let blockedActions =
+			mode === 'copy'
+				? hermitCard.player.hooks.blockedActions.callSome(
+						[[]],
+						(observerEntity) => {
+							let observer = this.components.get(observerEntity)
+							return observer?.wrappingEntity === hermitCard.entity
+						},
+					)
+				: []
 
 		/* Due to an issue with the blocked actions system, we have to check if our target has thier action
 		 * blocked by status effects here.

--- a/common/models/game-model.ts
+++ b/common/models/game-model.ts
@@ -389,7 +389,7 @@ export class GameModel {
 		}
 	}
 
-	public addCopyAttackModalRequest(
+	public addPickAttackModalRequest(
 		newRequest: Omit<CopyAttack.Request, 'modal'> & {
 			modal: Omit<CopyAttack.Request['modal'], 'availableAttacks'>
 		},

--- a/tests/unit/game/advent-of-tcg/hermits/zookeeperscar-rare.test.ts
+++ b/tests/unit/game/advent-of-tcg/hermits/zookeeperscar-rare.test.ts
@@ -4,6 +4,7 @@ import ElderGuardian from 'common/cards/advent-of-tcg/attach/elder-guardian'
 import ZookeeperScarRare from 'common/cards/advent-of-tcg/hermits/zookeeperscar-rare'
 import Wolf from 'common/cards/attach/wolf'
 import EthosLabCommon from 'common/cards/hermits/ethoslab-common'
+import EvilXisumaRare from 'common/cards/hermits/evilxisuma_rare'
 import RendogRare from 'common/cards/hermits/rendog-rare'
 import BalancedItem from 'common/cards/items/balanced-common'
 import Emerald from 'common/cards/single-use/emerald'
@@ -281,6 +282,30 @@ describe('Test Zookeeper Scar', () => {
 				},
 			},
 			{noItemRequirements: true},
+		)
+	})
+
+	test('Evil Xisuma cannot attempt to disable Lasso with Derpcoin', () => {
+		testGame(
+			{
+				playerOneDeck: [ZookeeperScarRare],
+				playerTwoDeck: [EvilXisumaRare],
+				saga: function* (game) {
+					yield* playCardFromHand(game, ZookeeperScarRare, 'hermit', 0)
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, EvilXisumaRare, 'hermit', 0)
+					yield* attack(game, 'secondary')
+					expect(
+						(game.state.modalRequests[0].modal as CopyAttack.Data)
+							.availableAttacks,
+					).not.toContain('primary')
+					yield* finishModalRequest(game, {pick: 'secondary'})
+					expect(game.state.modalRequests).toStrictEqual([])
+					yield* endTurn(game)
+				},
+			},
+			{noItemRequirements: true, forceCoinFlip: true},
 		)
 	})
 

--- a/tests/unit/game/hermits/evilxisuma-rare.test.ts
+++ b/tests/unit/game/hermits/evilxisuma-rare.test.ts
@@ -2,10 +2,12 @@ import {describe, expect, test} from '@jest/globals'
 import ArmorStand from 'common/cards/attach/armor-stand'
 import EthosLabCommon from 'common/cards/hermits/ethoslab-common'
 import EvilXisumaRare from 'common/cards/hermits/evilxisuma_rare'
+import ZombieCleoRare from 'common/cards/hermits/zombiecleo-rare'
 import {StatusEffectComponent} from 'common/components'
 import query from 'common/components/query'
 import {GameModel} from 'common/models/game-model'
 import {SecondaryAttackDisabledEffect} from 'common/status-effects/singleturn-attack-disabled'
+import {CopyAttack} from 'common/types/modal-requests'
 import {
 	attack,
 	endTurn,
@@ -82,6 +84,29 @@ describe('Test Evil X', () => {
 				},
 			},
 			{noItemRequirements: true, startWithAllCards: true, forceCoinFlip: true},
+		)
+	})
+	test('Test Evil X secondary with no afk hermits can disable Puppetry', () => {
+		testGame(
+			{
+				playerOneDeck: [ZombieCleoRare, EthosLabCommon],
+				playerTwoDeck: [EvilXisumaRare],
+				saga: function* (game) {
+					yield* playCardFromHand(game, ZombieCleoRare, 'hermit', 0)
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 1)
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, EvilXisumaRare, 'hermit', 0)
+					yield* attack(game, 'secondary')
+
+					expect(
+						(game.state.modalRequests[0].modal as CopyAttack.Data)
+							.availableAttacks,
+					).toContain('secondary')
+					yield* finishModalRequest(game, {pick: 'secondary'})
+				},
+			},
+			{noItemRequirements: true, forceCoinFlip: true},
 		)
 	})
 })


### PR DESCRIPTION
Adds a `mode` parameter to `GameModel.addCopyAttackModalRequest` to allow different setup behavior for `EvilXisumaRare` and `ZombieCleoRare`/`RendogRare`