### PR TITLE
Rework Bed Mechanics

### DIFF
--- a/common/cards/attach/bed.ts
+++ b/common/cards/attach/bed.ts
@@ -44,9 +44,20 @@ const Bed: Attach = {
 			)
 		}
 
+		let slot = hermitCard()?.slot
+		if (!slot || slot === undefined || !slot.onBoard()) return
+		if (!slot.row?.health) return
+
+		slot.row?.fullHeal()
+
 		game.components
 			.new(StatusEffectComponent, SleepingEffect, component.entity)
 			.apply(hermitCard()?.entity)
+
+		game.battleLog.addEntry(
+			player.entity,
+			`$p${hermitCard()?.props.name}$ went to $eSleep$ and restored $gfull health$`,
+		)
 
 		observer.subscribe(player.hooks.onActiveRowChange, () => {
 			let hermit = hermitCard()

--- a/common/cards/hermits/bdoubleo100-rare.ts
+++ b/common/cards/hermits/bdoubleo100-rare.ts
@@ -49,9 +49,17 @@ const BdoubleO100Rare: Hermit = {
 			(attack) => {
 				if (!attack.isAttacker(component.entity) || attack.type !== 'secondary')
 					return
+
+				component.slot.inRow() && component.slot.row.fullHeal()
+
 				game.components
 					.new(StatusEffectComponent, SleepingEffect, component.entity)
 					.apply(component.entity)
+
+				game.battleLog.addEntry(
+					component.player.entity,
+					`$p${component.props.name}$ went to $eSleep$ and restored $gfull health$`,
+				)
 			},
 		)
 	},

--- a/common/components/row-component.ts
+++ b/common/components/row-component.ts
@@ -105,4 +105,15 @@ export class RowComponent {
 			Math.max(this.health, hermit.props.health),
 		)
 	}
+
+	public fullHeal() {
+		let hermit = this.game.components.find(
+			CardComponent,
+			query.card.isHermit,
+			query.card.rowEntity(this.entity),
+		)
+		if (this.health === null) return
+		if (!hermit?.isHealth()) return
+		this.health = Math.max(this.health, hermit.props.health)
+	}
 }

--- a/common/status-effects/sleeping.ts
+++ b/common/status-effects/sleeping.ts
@@ -27,20 +27,12 @@ const SleepingEffect: Counter<CardComponent> = {
 		effect.counter = this.counter
 
 		if (!target.slot.inRow()) return
-		if (!target.isHealth()) return
 
 		game.addBlockedActions(
 			this.icon,
 			'PRIMARY_ATTACK',
 			'SECONDARY_ATTACK',
 			'CHANGE_ACTIVE_HERMIT',
-		)
-
-		target.slot.row.heal(target.props.health)
-
-		game.battleLog.addEntry(
-			player.entity,
-			`$p${target.props.name}$ went to $eSleep$ and restored $gfull health$`,
 		)
 
 		observer.subscribe(player.hooks.onTurnStart, () => {


### PR DESCRIPTION
Making the healing done by Bed and Bdubs instead of the Sleeping status effect. The description implies that the healing and sleeping are done separately while the original descriptions were vague on this. This makes Bed work as described and also allow sleeping without healing. Also added row.fullHeal()