### PR TITLE
Fix bed-update fuzz

### DIFF
--- a/common/cards/bed-update/attach/bouncy-bed.ts
+++ b/common/cards/bed-update/attach/bouncy-bed.ts
@@ -21,6 +21,8 @@ const BouncyBed: Attach = {
 	tokens: 2,
 	description:
 		'Move the hermit this is attached to the top row. If the top row is blocked, exile the hermit.',
+	log: (values) =>
+		`$p{You|${values.player}}$ placed $p${values.pos.name}$ on row #${values.pick.rowIndex}`,
 	onAttach(
 		game: GameModel,
 		component: CardComponent,

--- a/common/types/priorities.ts
+++ b/common/types/priorities.ts
@@ -68,8 +68,6 @@ export const rowRevive = createPriorityDictionary({
 	DEATHLOOP_REVIVE: null,
 	/** Totems may revive their row and be discarded */
 	TOTEM_REVIVE: null,
-	/** Immortality Bed returns hermit to hand */
-	IMMORTALITY_RETURN: null,
 })
 
 export const afterAttack = createPriorityDictionary({

--- a/tests/unit/game/bed-update/immortality-bed.test.ts
+++ b/tests/unit/game/bed-update/immortality-bed.test.ts
@@ -1,0 +1,58 @@
+import {describe, expect, test} from '@jest/globals'
+import ImmortalityBed from 'common/cards/bed-update/attach/immortality-bed'
+import EthosLabCommon from 'common/cards/hermits/ethoslab-common'
+import BalancedItem from 'common/cards/items/balanced-common'
+import {CardComponent} from 'common/components'
+import {
+	attack,
+	changeActiveHermit,
+	endTurn,
+	playCardFromHand,
+	testGame,
+} from '../utils'
+
+describe('Test Immortality Bed', () => {
+	test('Immortality Bed returns attached hermit to hand on knock-out without losing a life or giving a prize card', () => {
+		testGame(
+			{
+				playerOneDeck: [
+					EthosLabCommon,
+					EthosLabCommon,
+					ImmortalityBed,
+					...Array(7).fill(BalancedItem),
+				],
+				playerTwoDeck: [EthosLabCommon],
+				saga: function* (game) {
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 1)
+					yield* playCardFromHand(game, ImmortalityBed, 'attach', 0)
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
+					yield* attack(game, 'secondary')
+					expect(
+						game.opponentPlayer
+							.getHand()
+							.sort(CardComponent.compareOrder)
+							.map((card) => card.props),
+					).toStrictEqual([...Array(5).fill(BalancedItem), EthosLabCommon])
+					expect(
+						game.opponentPlayer.getDiscarded().map((card) => card.props),
+					).toStrictEqual([ImmortalityBed])
+					expect(game.opponentPlayer.activeRow).toBe(null)
+					expect(game.opponentPlayer.lives).toBe(3)
+					expect(
+						game.currentPlayer.getHand().map((card) => card.props),
+					).toStrictEqual([])
+					yield* endTurn(game)
+
+					expect(game.state.turn.availableActions).toStrictEqual([
+						'CHANGE_ACTIVE_HERMIT',
+					])
+					yield* changeActiveHermit(game, 1)
+				},
+			},
+			{noItemRequirements: true, oneShotMode: true, startWithAllCards: false},
+		)
+	})
+})


### PR DESCRIPTION
- Fixes Bouncy Bed logging `$bINVALID VALUE$` after exiling attached AFK Hermit (fixes #1486)
- Refactors Immortality Bed to wait until after knock-out to return attached Hermit to hand, restore one life, and return a prize card to the draw pile
fixes #1503, fixes #1493, fixes #1488, fixes #1487