### PR TITLE
Possible fix for connection timeouts

### DIFF
--- a/server/src/db/db.ts
+++ b/server/src/db/db.ts
@@ -60,7 +60,13 @@ export class Database {
 		allAchievements: Array<Achievement>,
 		bfDepth: number,
 	) {
-		this.pool = new Pool({connectionString: env.DATABASE_URL})
+		this.pool = new Pool({
+			connectionString: env.DATABASE_URL,
+			/* Refresh a client's connection to the DB every two minutes. This is
+			 * to fix an issue where the client is disconnectd from the fly database
+			 * and is never reconnectd. Right now this is a theoretical issue and fix. */
+			connectionTimeoutMillis: 60 * 1000 * 2,
+		})
 		this.allCards = allCards
 		this.allAchievements = allAchievements
 		this.bfDepth = bfDepth

--- a/server/src/db/db.ts
+++ b/server/src/db/db.ts
@@ -63,9 +63,9 @@ export class Database {
 		this.pool = new Pool({
 			connectionString: env.DATABASE_URL,
 			/* Refresh a client's connection to the DB every two minutes. This is
-			 * to fix an issue where the client is disconnectd from the fly database
+			 * to fix an issue where the client can not connect to the ly database
 			 * and is never reconnectd. Right now this is a theoretical issue and fix. */
-			connectionTimeoutMillis: 60 * 1000 * 2,
+			connectionTimeoutMillis: 60 * 1000,
 		})
 		this.allCards = allCards
 		this.allAchievements = allAchievements


### PR DESCRIPTION
The theory is that something is going wrong with the fly proxy and clients are losing connection, but they do not know that they are losing connection and are never connected. This forces the clients in the pool to be refreshed every two minutes.