### PR TITLE
Fix achievement progress not updating database

### DIFF
--- a/common/achievements/hall-of-all.ts
+++ b/common/achievements/hall-of-all.ts
@@ -17,8 +17,10 @@ const HallOfAll: Achievement = {
 		},
 	],
 	onGameStart(game, player, component, observer) {
-		observer.subscribe(player.hooks.onAttach, () => {
+		observer.subscribe(player.hooks.onAttach, (card) => {
 			if (
+				!card.slot.inRow() ||
+				card.player.entity !== player.entity ||
 				game.components.find(
 					SlotComponent,
 					query.slot.player(player.entity),
@@ -28,6 +30,7 @@ const HallOfAll: Achievement = {
 			)
 				return
 			component.updateGoalProgress({goal: 0})
+			observer.unsubscribeFromEverything()
 		})
 	},
 }

--- a/common/achievements/useless-machine.ts
+++ b/common/achievements/useless-machine.ts
@@ -20,8 +20,8 @@ const UselessMachine: Achievement = {
 	onGameStart(game, player, component, observer) {
 		let playerHand: Array<string> = []
 
-		observer.subscribe(player.hooks.onAttach, (slot) => {
-			if (!slot.isSingleUse()) return
+		observer.subscribe(player.hooks.onAttach, (card) => {
+			if (card.slot.type !== 'single_use') return
 			playerHand = player.getHand().map((card) => card.props.id)
 		})
 

--- a/common/components/achievement-component.ts
+++ b/common/components/achievement-component.ts
@@ -133,7 +133,11 @@ export class AchievementComponent {
 		progress = 1,
 	}: {goal: number; progress?: number}) {
 		const progressChecker = this.checkCompletion(this.goals)
-		this.goals[goal] = progress
+		this.goals = combineAchievementProgress(
+			this.props.progressionMethod,
+			this.goals,
+			{[goal]: progress},
+		)
 		progressChecker()
 	}
 }


### PR DESCRIPTION
The database now updates achievement progress with all goal updates from a game instead of only the last goal update.
- Fixes "How Did We Get Here" not being awarded if the game continues after having at least 5 statuses
- Fixes "SUStainable" only counting up to one Composter used per game