### PR TITLE
lint: add .editorconfig to help maintain consistent coding styles

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = tab
+
+[*.yml]
+indent_style = space

--- a/biome.json
+++ b/biome.json
@@ -5,6 +5,9 @@
 		"useIgnoreFile": true
 	},
 	"organizeImports": { "enabled": true },
+	"formatter": {
+		"useEditorconfig": true
+	},
 	"linter": {
 		"enabled": true,
 		"rules": {

--- a/client/src/logic/game/game-reducer.ts
+++ b/client/src/logic/game/game-reducer.ts
@@ -90,7 +90,7 @@ const gameReducer = (
 				opponentConnected: true,
 				spectatorCode:
 					action.type === localMessages.GAME_START
-						? action.spectatorCode ?? null
+						? (action.spectatorCode ?? null)
 						: null,
 			}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
 				"zod": "^3.23.8"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "1.8.3",
+				"@biomejs/biome": "1.9.4",
 				"@playwright/experimental-ct-react": "^1.47.2",
 				"@playwright/test": "^1.47.2",
 				"@types/express": "^5.0.0",
@@ -584,11 +584,12 @@
 			"dev": true
 		},
 		"node_modules/@biomejs/biome": {
-			"version": "1.8.3",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.8.3.tgz",
-			"integrity": "sha512-/uUV3MV+vyAczO+vKrPdOW0Iaet7UnJMU4bNMinggGJTAnBPjCoLEYcyYtYHNnUNYlv4xZMH6hVIQCAozq8d5w==",
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.9.4.tgz",
+			"integrity": "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==",
 			"dev": true,
 			"hasInstallScript": true,
+			"license": "MIT OR Apache-2.0",
 			"bin": {
 				"biome": "bin/biome"
 			},
@@ -600,24 +601,25 @@
 				"url": "https://opencollective.com/biome"
 			},
 			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "1.8.3",
-				"@biomejs/cli-darwin-x64": "1.8.3",
-				"@biomejs/cli-linux-arm64": "1.8.3",
-				"@biomejs/cli-linux-arm64-musl": "1.8.3",
-				"@biomejs/cli-linux-x64": "1.8.3",
-				"@biomejs/cli-linux-x64-musl": "1.8.3",
-				"@biomejs/cli-win32-arm64": "1.8.3",
-				"@biomejs/cli-win32-x64": "1.8.3"
+				"@biomejs/cli-darwin-arm64": "1.9.4",
+				"@biomejs/cli-darwin-x64": "1.9.4",
+				"@biomejs/cli-linux-arm64": "1.9.4",
+				"@biomejs/cli-linux-arm64-musl": "1.9.4",
+				"@biomejs/cli-linux-x64": "1.9.4",
+				"@biomejs/cli-linux-x64-musl": "1.9.4",
+				"@biomejs/cli-win32-arm64": "1.9.4",
+				"@biomejs/cli-win32-x64": "1.9.4"
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-arm64": {
-			"version": "1.8.3",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.8.3.tgz",
-			"integrity": "sha512-9DYOjclFpKrH/m1Oz75SSExR8VKvNSSsLnVIqdnKexj6NwmiMlKk94Wa1kZEdv6MCOHGHgyyoV57Cw8WzL5n3A==",
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.4.tgz",
+			"integrity": "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -627,13 +629,14 @@
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-x64": {
-			"version": "1.8.3",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.8.3.tgz",
-			"integrity": "sha512-UeW44L/AtbmOF7KXLCoM+9PSgPo0IDcyEUfIoOXYeANaNXXf9mLUwV1GeF2OWjyic5zj6CnAJ9uzk2LT3v/wAw==",
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.4.tgz",
+			"integrity": "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -643,13 +646,14 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64": {
-			"version": "1.8.3",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.8.3.tgz",
-			"integrity": "sha512-fed2ji8s+I/m8upWpTJGanqiJ0rnlHOK3DdxsyVLZQ8ClY6qLuPc9uehCREBifRJLl/iJyQpHIRufLDeotsPtw==",
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.4.tgz",
+			"integrity": "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
 				"linux"
@@ -659,13 +663,14 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64-musl": {
-			"version": "1.8.3",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.8.3.tgz",
-			"integrity": "sha512-9yjUfOFN7wrYsXt/T/gEWfvVxKlnh3yBpnScw98IF+oOeCYb5/b/+K7YNqKROV2i1DlMjg9g/EcN9wvj+NkMuQ==",
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.4.tgz",
+			"integrity": "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
 				"linux"
@@ -675,13 +680,14 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64": {
-			"version": "1.8.3",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.8.3.tgz",
-			"integrity": "sha512-I8G2QmuE1teISyT8ie1HXsjFRz9L1m5n83U1O6m30Kw+kPMPSKjag6QGUn+sXT8V+XWIZxFFBoTDEDZW2KPDDw==",
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.4.tgz",
+			"integrity": "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
 				"linux"
@@ -691,13 +697,14 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64-musl": {
-			"version": "1.8.3",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.8.3.tgz",
-			"integrity": "sha512-UHrGJX7PrKMKzPGoEsooKC9jXJMa28TUSMjcIlbDnIO4EAavCoVmNQaIuUSH0Ls2mpGMwUIf+aZJv657zfWWjA==",
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.4.tgz",
+			"integrity": "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
 				"linux"
@@ -707,13 +714,14 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-arm64": {
-			"version": "1.8.3",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.8.3.tgz",
-			"integrity": "sha512-J+Hu9WvrBevfy06eU1Na0lpc7uR9tibm9maHynLIoAjLZpQU3IW+OKHUtyL8p6/3pT2Ju5t5emReeIS2SAxhkQ==",
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.4.tgz",
+			"integrity": "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
 				"win32"
@@ -723,13 +731,14 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-x64": {
-			"version": "1.8.3",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.8.3.tgz",
-			"integrity": "sha512-/PJ59vA1pnQeKahemaQf4Nyj7IKUvGQSc3Ze1uIGi+Wvr1xF7rGobSrAAG01T/gUDG21vkDsZYM03NAmPiVkqg==",
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz",
+			"integrity": "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
 				"win32"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"zod": "^3.23.8"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "1.8.3",
+		"@biomejs/biome": "1.9.4",
 		"@playwright/experimental-ct-react": "^1.47.2",
 		"@playwright/test": "^1.47.2",
 		"@types/express": "^5.0.0",


### PR DESCRIPTION
## Changes

- Adds .editorconfig to setup defaults for supported editors (https://editorconfig.org/)
- Lints project to give consistent line endings and indent styles
- Bumps Biome to enable support for `.editorconfig`