### PR TITLE
docs: update environment variable examples

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+DATABASE_URL = postgresql://hctcg:hctcg@localhost:5432/hctcg

--- a/example.env
+++ b/example.env
@@ -1,4 +1,0 @@
-API_KEYS = ["123456", "otherKey12"]
-BOT_KEY = "123456"
-BOT_URL = "http://127.0.0.1:8085"
-


### PR DESCRIPTION
## Changes

- Renamed `.example.env` to use the more widely-supported filename of `.env.examples`
- Removed unused environment variables as examples
- Added `DATABASE_URL` as example env variable