### PR TITLE
Mumbo Base Set

### DIFF
--- a/common/cards/hermits/mumbojumbo-rare.ts
+++ b/common/cards/hermits/mumbojumbo-rare.ts
@@ -27,7 +27,7 @@ const MumboJumboRare: Hermit = {
 		cost: ['prankster', 'prankster'],
 		damage: 40,
 		power:
-			'Flip a coin twice.\nDo an additional 20hp damage for every heads. Total attack damage doubles if you have at least one AFK Prankster from the Base Set on the game board.',
+			'Flip a coin twice.\nDo an additional 20hp damage for every heads. Total attack damage doubles if you have at least one AFK Prankster from the Base Set expansion on the game board.',
 	},
 	onAttach(
 		game: GameModel,

--- a/common/cards/hermits/mumbojumbo-rare.ts
+++ b/common/cards/hermits/mumbojumbo-rare.ts
@@ -13,7 +13,7 @@ const MumboJumboRare: Hermit = {
 	name: 'Mumbo',
 	expansion: 'default',
 	rarity: 'rare',
-	tokens: 4,
+	tokens: 3,
 	type: 'prankster',
 	health: 290,
 	primary: {

--- a/common/cards/hermits/mumbojumbo-rare.ts
+++ b/common/cards/hermits/mumbojumbo-rare.ts
@@ -6,9 +6,6 @@ import {flipCoin} from '../../utils/coinFlips'
 import {hermit} from '../defaults'
 import {Hermit} from '../types'
 
-/*
-- Beef confirmed that double damage condition includes other rare mumbos.
-*/
 const MumboJumboRare: Hermit = {
 	...hermit,
 	id: 'mumbojumbo_rare',
@@ -30,7 +27,7 @@ const MumboJumboRare: Hermit = {
 		cost: ['prankster', 'prankster'],
 		damage: 40,
 		power:
-			'Flip a coin twice.\nDo an additional 20hp damage for every heads. Total attack damage doubles if you have at least one AFK Prankster on the game board.',
+			'Flip a coin twice.\nDo an additional 20hp damage for every heads. Total attack damage doubles if you have at least one AFK Prankster from the Base Set on the game board.',
 	},
 	onAttach(
 		game: GameModel,
@@ -53,6 +50,7 @@ const MumboJumboRare: Hermit = {
 					query.card.currentPlayer,
 					query.card.afk,
 					query.card.type('prankster'),
+					query.card.expansion('default'),
 				).length
 
 				attack.addDamage(component.entity, headsAmount * 20)

--- a/common/cards/starter-decks.ts
+++ b/common/cards/starter-decks.ts
@@ -27,6 +27,7 @@ import FrenchralisRare from './hermits/frenchralis-rare'
 import GeminiTayRare from './hermits/geminitay-rare'
 import GoatfatherRare from './hermits/goatfather-rare'
 import GrianCommon from './hermits/grian-common'
+import GrianRare from './hermits/grian-rare'
 import HelsknightRare from './hermits/helsknight-rare'
 import HotguyCommon from './hermits/hotguy-common'
 import HumanCleoCommon from './hermits/humancleo-common'
@@ -76,6 +77,7 @@ import Crossbow from './single-use/crossbow'
 import CurseOfBinding from './single-use/curse-of-binding'
 import CurseOfVanishing from './single-use/curse-of-vanishing'
 import Efficiency from './single-use/efficiency'
+import Egg from './single-use/egg'
 import Emerald from './single-use/emerald'
 import FishingRod from './single-use/fishing-rod'
 import FlintAndSteel from './single-use/flint-and-steel'
@@ -397,15 +399,22 @@ export const STARTER_DECKS: Array<StarterDeck> = [
 		cards: [
 			MumboJumboRare,
 			MumboJumboRare,
-			MumboJumboRare,
+			GrianRare,
+			GrianRare,
 			StressMonster101Rare,
 			StressMonster101Rare,
 			BoomerBdubsCommon,
 			BoomerBdubsCommon,
-			BoomerBdubsCommon,
 			TargetBlock,
 			TargetBlock,
-			GoldArmor,
+			Chest,
+			PotionOfWeakness,
+			PotionOfWeakness,
+			Egg,
+			Egg,
+			InstantHealthII,
+			InstantHealthII,
+			InstantHealthII,
 			GoldArmor,
 			GoldArmor,
 			FishingRod,
@@ -429,14 +438,6 @@ export const STARTER_DECKS: Array<StarterDeck> = [
 			PranksterItem,
 			PranksterItem,
 			PranksterItem,
-			InstantHealthII,
-			InstantHealthII,
-			InstantHealthII,
-			PotionOfWeakness,
-			PotionOfWeakness,
-			PotionOfWeakness,
-			Knockback,
-			Knockback,
 		],
 	},
 	{

--- a/common/components/query/card.ts
+++ b/common/components/query/card.ts
@@ -7,6 +7,7 @@ import {
 	StatusEffectComponent,
 } from '..'
 import {Card} from '../../cards/types'
+import {ExpansionT} from '../../const/expansions'
 import {CardEntity, PlayerEntity, RowEntity, SlotEntity} from '../../entities'
 import {StatusEffect} from '../../status-effects/status-effect'
 import {TypeT} from '../../types/cards'
@@ -77,6 +78,12 @@ export function player(player: PlayerEntity): ComponentQuery<CardComponent> {
 
 export function type(type: TypeT): ComponentQuery<CardComponent> {
 	return (_game, card) => card.isHermit() && card.props.type === type
+}
+
+export function expansion(
+	expansion: ExpansionT,
+): ComponentQuery<CardComponent> {
+	return (_game, card) => card.isHermit() && card.props.expansion === expansion
 }
 
 export const currentPlayer: ComponentQuery<CardComponent> = (game, pos) =>

--- a/tests/unit/game/hermits/mumbojumbo-rare.test.ts
+++ b/tests/unit/game/hermits/mumbojumbo-rare.test.ts
@@ -1,0 +1,61 @@
+import {describe, expect, test} from '@jest/globals'
+import BoomerBdubsCommon from 'common/cards/hermits/boomerbdubs-common'
+import EthosLabCommon from 'common/cards/hermits/ethoslab-common'
+import MumboJumboRare from 'common/cards/hermits/mumbojumbo-rare'
+import {RowComponent} from 'common/components'
+import query from 'common/components/query'
+import {testGame} from '../utils'
+
+describe('Test Mumbo Jumbo', () => {
+	test('Test Double Damage Activates Only With Base Set Pranksters', async () => {
+		await testGame(
+			{
+				playerOneDeck: [EthosLabCommon],
+				playerTwoDeck: [
+					MumboJumboRare,
+					MumboJumboRare,
+					EthosLabCommon,
+					BoomerBdubsCommon,
+				],
+				testGame: async (test, game) => {
+					await test.playCardFromHand(EthosLabCommon, 'hermit', 0)
+
+					await test.endTurn()
+
+					await test.playCardFromHand(MumboJumboRare, 'hermit', 0)
+					await test.playCardFromHand(EthosLabCommon, 'hermit', 2)
+					await test.playCardFromHand(BoomerBdubsCommon, 'hermit', 3)
+
+					await test.attack('secondary')
+
+					await test.endTurn()
+
+					expect(
+						game.components.find(
+							RowComponent,
+							query.row.opponentPlayer,
+							query.row.active,
+						)?.health,
+					).toBe(EthosLabCommon.health - 80 /* x1 Double Heads */)
+
+					await test.endTurn()
+
+					await test.playCardFromHand(MumboJumboRare, 'hermit', 1)
+
+					await test.attack('secondary')
+
+					await test.endTurn()
+
+					expect(
+						game.components.find(
+							RowComponent,
+							query.row.opponentPlayer,
+							query.row.active,
+						)?.health,
+					).toBe(EthosLabCommon.health - 240 /* x(1+2) Double Heads */)
+				},
+			},
+			{startWithAllCards: true, noItemRequirements: true, forceCoinFlip: true},
+		)
+	})
+})

--- a/tests/unit/game/hermits/mumbojumbo-rare.test.ts
+++ b/tests/unit/game/hermits/mumbojumbo-rare.test.ts
@@ -28,8 +28,6 @@ describe('Test Mumbo Jumbo', () => {
 
 					await test.attack('secondary')
 
-					await test.endTurn()
-
 					expect(
 						game.components.find(
 							RowComponent,
@@ -40,11 +38,11 @@ describe('Test Mumbo Jumbo', () => {
 
 					await test.endTurn()
 
+					await test.endTurn()
+
 					await test.playCardFromHand(MumboJumboRare, 'hermit', 1)
 
 					await test.attack('secondary')
-
-					await test.endTurn()
 
 					expect(
 						game.components.find(


### PR DESCRIPTION
Midsummer 2025 Patch #1: Mumbo's double damage condition only triggers with base set pranksters and change to 3 tokens.

Suggestor: Aetherion
No Opposition: Jacksimpson2077, Rvtar, shortweekly, Benji