### PR TITLE
Add secret resetting

### DIFF
--- a/client/src/app/main-menu/settings.module.scss
+++ b/client/src/app/main-menu/settings.module.scss
@@ -90,9 +90,25 @@
 	height: 5.5vh;
 }
 
-.viewSecretButton {
+.secretButton {
 	height: 100%;
 	width: 20%;
+}
+
+.viewModal {
+	display: flex;
+	flex-direction: row;
+	justify-content: center;
+	gap: 0.5vh;
+	margin: 0.5vh;
+}
+
+.viewModalDescription {
+	padding: 1vh;
+}
+
+.viewModalButton {
+	width: 50%;
 }
 
 .resetModal {
@@ -118,6 +134,7 @@
 	padding: 1vh 2vh;
 	display: flex;
 	flex-direction: row;
+	gap: 1vh;
 }
 
 .dbItem {
@@ -197,7 +214,7 @@
 		display: none;
 	}
 
-	.viewSecretButton {
+	.secretButton {
 		width: 60%;
 	}
 

--- a/client/src/app/main-menu/settings.tsx
+++ b/client/src/app/main-menu/settings.tsx
@@ -478,7 +478,7 @@ function Settings({setMenuSection}: Props) {
 													onClose={closeModal}
 												>
 													<p className={css.warning}>
-														<b>⚠ This will log you out of all devices.</b>
+														<b>⚠ This will log you out of all other devices.</b>
 													</p>
 													<p className={css.warning}>
 														Only reset this when you believe someone else knows

--- a/client/src/app/main-menu/settings.tsx
+++ b/client/src/app/main-menu/settings.tsx
@@ -209,7 +209,7 @@ function Settings({setMenuSection}: Props) {
 	}
 
 	const resetSecret = () => {
-		
+		dispatch({type: localMessages.RESET_SECRET})
 	}
 
 	const handleReset = (

--- a/client/src/app/main-menu/settings.tsx
+++ b/client/src/app/main-menu/settings.tsx
@@ -481,8 +481,8 @@ function Settings({setMenuSection}: Props) {
 														<b>⚠ This will log you out of all devices.</b>
 													</p>
 													<p className={css.warning}>
-														Only reset this when you believe someone else
-														knows your secret.
+														Only reset this when you believe someone else knows
+														your secret.
 													</p>
 													<div className={css.resetModal}>
 														<Button

--- a/client/src/app/main-menu/settings.tsx
+++ b/client/src/app/main-menu/settings.tsx
@@ -208,6 +208,10 @@ function Settings({setMenuSection}: Props) {
 		setModal(<UpdatesModal onClose={closeModal} />)
 	}
 
+	const resetSecret = () => {
+		
+	}
+
 	const handleReset = (
 		title: string,
 		prompt: string,
@@ -252,7 +256,7 @@ function Settings({setMenuSection}: Props) {
 							variant="default"
 							onClick={() => setModal(null)}
 						>
-							Nevermind
+							Never mind
 						</Button>
 					</div>
 				</Modal>,
@@ -464,7 +468,46 @@ function Settings({setMenuSection}: Props) {
 								<div className={css.dbInfo}>
 									<div className={classNames(css.dbItem, css.left)}>Secret</div>
 									<Button
-										className={css.viewSecretButton}
+										className={css.secretButton}
+										variant="default"
+										onClick={() =>
+											setModal(
+												<Modal
+													setOpen
+													title={'Reset secret?'}
+													onClose={closeModal}
+												>
+													<p className={css.warning}>
+														<b>⚠ This will log you out of all devices.</b>
+													</p>
+													<p className={css.warning}>
+														Only reset this when you believe someone else
+														knows your secret.
+													</p>
+													<div className={css.resetModal}>
+														<Button
+															className={css.resetModalButton}
+															variant="error"
+															onClick={resetSecret}
+														>
+															Reset
+														</Button>
+														<Button
+															className={css.resetModalButton}
+															variant="default"
+															onClick={closeModal}
+														>
+															Never mind
+														</Button>
+													</div>
+												</Modal>,
+											)
+										}
+									>
+										Reset Secret
+									</Button>
+									<Button
+										className={css.secretButton}
 										variant="default"
 										onClick={() =>
 											setModal(
@@ -505,9 +548,9 @@ function Settings({setMenuSection}: Props) {
 															{CopyIcon()}
 														</button>
 													</div>
-													<div className={css.resetModal}>
+													<div className={css.viewModal}>
 														<Button
-															className={css.resetModalButton}
+															className={css.viewModalButton}
 															variant="default"
 															onClick={closeModal}
 														>

--- a/client/src/logic/game/database/database-reducer.ts
+++ b/client/src/logic/game/database/database-reducer.ts
@@ -81,6 +81,8 @@ const databaseReducer = (
 			return {...state, userId: action.userId, secret: action.secret}
 		case localMessages.RESET_ID_AND_SECRET:
 			return {...state, userId: null, secret: null}
+		case localMessages.RESET_SECRET:
+			return {...state, secret: null}
 		case localMessages.COSMETICS_SET:
 			return {...state, appearance: action.appearance}
 		case localMessages.DATABASE_SET:

--- a/client/src/logic/game/database/database-saga.ts
+++ b/client/src/logic/game/database/database-saga.ts
@@ -1,6 +1,11 @@
-import {LocalMessageTable, localMessages} from 'logic/messages'
+import { clientMessages } from 'common/socket-messages/client-messages'
+import { serverMessages } from 'common/socket-messages/server-messages'
+import {LocalMessage, LocalMessageTable, localMessages} from 'logic/messages'
+import { receiveMsg, sendMsg } from 'logic/socket/socket-saga'
+import { getSocket } from 'logic/socket/socket-selectors'
 import {SagaIterator} from 'redux-saga'
-import {takeEvery} from 'redux-saga/effects'
+import {call, takeEvery} from 'redux-saga/effects'
+import { put, select } from 'typed-redux-saga'
 
 function* setDatabaseKeysSaga(
 	action: LocalMessageTable[typeof localMessages.SET_ID_AND_SECRET],
@@ -14,9 +19,21 @@ function* resetDatabaseKeysSaga(): SagaIterator {
 	localStorage.removeItem('databaseInfo:secret')
 }
 
+function* resetSecretSaga(): SagaIterator {
+	const socket = yield* select(getSocket)
+	localStorage.removeItem('databaseInfo:secret')
+
+	yield* sendMsg({type: clientMessages.RESET_SECRET})
+
+	const {secret} = yield call(receiveMsg(socket, serverMessages.SECRET_RESET))
+	localStorage.setItem('databaseInfo:secret', secret)
+	yield* put<LocalMessage>({type: localMessages.LOGOUT})
+}
+
 function* databaseSaga() {
 	yield takeEvery(localMessages.SET_ID_AND_SECRET, setDatabaseKeysSaga)
 	yield takeEvery(localMessages.RESET_ID_AND_SECRET, resetDatabaseKeysSaga)
+	yield takeEvery(localMessages.RESET_SECRET, resetSecretSaga)
 }
 
 export default databaseSaga

--- a/client/src/logic/game/database/database-saga.ts
+++ b/client/src/logic/game/database/database-saga.ts
@@ -1,11 +1,11 @@
-import { clientMessages } from 'common/socket-messages/client-messages'
-import { serverMessages } from 'common/socket-messages/server-messages'
+import {clientMessages} from 'common/socket-messages/client-messages'
+import {serverMessages} from 'common/socket-messages/server-messages'
 import {LocalMessage, LocalMessageTable, localMessages} from 'logic/messages'
-import { receiveMsg, sendMsg } from 'logic/socket/socket-saga'
-import { getSocket } from 'logic/socket/socket-selectors'
+import {receiveMsg, sendMsg} from 'logic/socket/socket-saga'
+import {getSocket} from 'logic/socket/socket-selectors'
 import {SagaIterator} from 'redux-saga'
 import {call, takeEvery} from 'redux-saga/effects'
-import { put, select } from 'typed-redux-saga'
+import {put, select} from 'typed-redux-saga'
 
 function* setDatabaseKeysSaga(
 	action: LocalMessageTable[typeof localMessages.SET_ID_AND_SECRET],

--- a/client/src/logic/messages.ts
+++ b/client/src/logic/messages.ts
@@ -88,6 +88,7 @@ export const localMessages = messages('clientLocalMessages', {
 	QUEUE_VOICE: null,
 	SET_ID_AND_SECRET: null,
 	RESET_ID_AND_SECRET: null,
+	RESET_SECRET: null,
 	DATABASE_SET: null,
 	INSERT_DECK: null,
 	UPDATE_DECK: null,
@@ -254,6 +255,7 @@ type Messages = [
 		secret: string
 	},
 	{type: typeof localMessages.RESET_ID_AND_SECRET},
+	{type: typeof localMessages.RESET_SECRET},
 	{type: typeof localMessages.DATABASE_SET; data: LocalDatabase},
 	{type: typeof localMessages.INSERT_DECK; deck: Deck},
 	{type: typeof localMessages.UPDATE_DECK; deck: Deck},

--- a/client/src/logic/session/session-saga.ts
+++ b/client/src/logic/session/session-saga.ts
@@ -673,6 +673,7 @@ export function* logoutSaga() {
 	])
 	clearSession()
 	socket.disconnect()
+	delete socket.auth.playerId
 	yield put<LocalMessage>({type: localMessages.DISCONNECT})
 }
 

--- a/common/models/player-model.ts
+++ b/common/models/player-model.ts
@@ -78,4 +78,9 @@ export class PlayerModel {
 	updateAchievementProgress(achievements: AchievementProgress) {
 		this.achievementProgress = {...this.achievementProgress, ...achievements}
 	}
+
+	/** Set the user secret, should only be used when the secret is changed in the database. */
+	setSecret(secret: string) {
+		this.internalSecret = secret
+	}
 }

--- a/common/socket-messages/client-messages.ts
+++ b/common/socket-messages/client-messages.ts
@@ -40,6 +40,7 @@ export const clientMessages = messages('clientMessages', {
 	DELETE_DECK: null,
 	DELETE_TAG: null,
 	SET_COSMETIC: null,
+	RESET_SECRET: null,
 })
 
 export type ClientMessages = [
@@ -165,6 +166,7 @@ export type ClientMessages = [
 	{type: typeof clientMessages.SET_COSMETIC; cosmetic: Cosmetic['id']},
 	{type: typeof clientMessages.REPLAY_OVERVIEW; id: number},
 	{type: typeof clientMessages.CANCEL_REMATCH; rematch: RematchData},
+	{type: typeof clientMessages.RESET_SECRET},
 ]
 
 export type ClientMessage = Message<ClientMessages>

--- a/common/socket-messages/server-messages.ts
+++ b/common/socket-messages/server-messages.ts
@@ -160,9 +160,9 @@ export type ServerMessages = [
 		image?: string
 	},
 	{
-		type: typeof serverMessages.SECRET_RESET,
-		secret: string,
-	}
+		type: typeof serverMessages.SECRET_RESET
+		secret: string
+	},
 ]
 
 export type ServerMessage = Message<ServerMessages>

--- a/common/socket-messages/server-messages.ts
+++ b/common/socket-messages/server-messages.ts
@@ -60,6 +60,7 @@ export const serverMessages = messages('serverMessages', {
 	CURRENT_IMPORT_RECIEVED: null,
 	DATABASE_FAILURE: null,
 	TOAST_SEND: null,
+	SECRET_RESET: null,
 })
 
 export type ServerMessages = [
@@ -158,6 +159,10 @@ export type ServerMessages = [
 		description: string
 		image?: string
 	},
+	{
+		type: typeof serverMessages.SECRET_RESET,
+		secret: string,
+	}
 ]
 
 export type ServerMessage = Message<ServerMessages>

--- a/server/src/api/auth.ts
+++ b/server/src/api/auth.ts
@@ -69,3 +69,48 @@ export async function createUser(
 
 	return [200, userInfo.body]
 }
+
+export async function resetSecret(
+	userId: string | undefined,
+	secret: string | undefined,
+): Promise<[number, any]> {
+	if (!userId || !secret) {
+		return [
+			400,
+			{error: 'Both a User ID and Secret are required to authorize a user.'},
+		]
+	}
+
+	if (!root.db.connected) {
+		return [
+			500,
+			{
+				error: 'Endpoint is unavailable because database is disabled.',
+			},
+		]
+	}
+
+	const userInfo = await root.db.authenticateUser(userId, secret)
+
+	if (userInfo.type === 'failure') {
+		return [401, 'Authentication information is not valid.']
+	}
+
+	if (userInfo.body.banned) {
+		return [401, 'You are banned.']
+	}
+
+	const {uuid} = userInfo.body
+
+	const newSecretInfo = await root.db.regenerateSecret(uuid)
+
+	if (newSecretInfo.type === 'failure') {
+		return [500, 'Could not generate new secret.']
+	}
+
+	if (root.players[uuid]) {
+		root.players[uuid].setSecret(newSecretInfo.body.secret)
+	}
+
+	return [200, newSecretInfo]
+}

--- a/server/src/api/auth.ts
+++ b/server/src/api/auth.ts
@@ -102,7 +102,7 @@ export async function resetSecret(
 
 	const {uuid} = userInfo.body
 
-	const newSecretInfo = await root.db.regenerateSecret(uuid)
+	const newSecretInfo = await root.db.resetSecret(uuid)
 
 	if (newSecretInfo.type === 'failure') {
 		return [500, 'Could not generate new secret.']

--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -13,6 +13,7 @@ import {
 	authenticateApiKey,
 	authenticateUser,
 	createUser,
+	resetSecret,
 } from './auth'
 import {cards, deckCost, getDeckInformation, ranks, types} from './cards'
 import {
@@ -50,6 +51,14 @@ export function addApi(app: Express) {
 	app.post('/api/createUser/', async (req, res) => {
 		const username = req.get('username')
 		let ret = await createUser(username)
+		res.statusCode = ret[0]
+		res.send(ret[1])
+	})
+
+	app.get('/api/resetSecret/', async (req, res) => {
+		const userId = req.get('userId')
+		const secret = req.get('secret')
+		let ret = await resetSecret(userId, secret)
 		res.statusCode = ret[0]
 		res.send(ret[1])
 	})

--- a/server/src/db/db.ts
+++ b/server/src/db/db.ts
@@ -2280,4 +2280,40 @@ export class Database {
 			}
 		}
 	}
+
+	public async regenerateSecret(
+		uuid: string,
+	): Promise<DatabaseResult<{secret: string}>> {
+		try {
+			const secret = (await this.pool.query('SELECT * FROM uuid_generate_v4()'))
+				.rows[0]['uuid_generate_v4']
+
+			const result = await this.pool.query(
+				`
+					UPDATE users
+					SET secret = crypt($2, gen_salt('bf', $3))
+					WHERE user_id = $1;
+				`,
+				[uuid, secret, this.bfDepth],
+			)
+
+			if (result.rowCount !== 1) {
+				return {
+					type: 'failure',
+				}
+			}
+
+			return {
+				type: 'success',
+				body: {
+					secret: secret,
+				},
+			}
+		} catch (e) {
+			console.log(e)
+			return {
+				type: 'failure',
+			}
+		}
+	}
 }

--- a/server/src/db/db.ts
+++ b/server/src/db/db.ts
@@ -2281,7 +2281,7 @@ export class Database {
 		}
 	}
 
-	public async regenerateSecret(
+	public async resetSecret(
 		uuid: string,
 	): Promise<DatabaseResult<{secret: string}>> {
 		try {

--- a/server/src/routines/handle-client-message.ts
+++ b/server/src/routines/handle-client-message.ts
@@ -38,6 +38,7 @@ import {
 } from './matchmaking'
 import {
 	loadUpdatesSaga,
+	resetSecret,
 	updateCosmeticSaga,
 	updateMinecraftNameSaga,
 	updateUsernameSaga,
@@ -169,6 +170,10 @@ function* handler(message: RecievedClientMessage) {
 			)
 		case clientMessages.REPLAY_OVERVIEW:
 			return yield* getOverview(
+				message as RecievedClientMessage<typeof message.type>,
+			)
+		case clientMessages.RESET_SECRET:
+			return yield* resetSecret(
 				message as RecievedClientMessage<typeof message.type>,
 			)
 	}

--- a/server/src/routines/player.ts
+++ b/server/src/routines/player.ts
@@ -225,20 +225,20 @@ export function* updateCosmeticSaga(
 	})
 }
 
-export function* resetSecret(action: RecievedClientMessage<typeof clientMessages.RESET_SECRET>) {
+export function* resetSecret(
+	action: RecievedClientMessage<typeof clientMessages.RESET_SECRET>,
+) {
 	const player = root.players[action.playerId]
 	const {uuid} = player
 
-	const secret = yield* call(
-		[root.db, root.db.resetSecret],
-		uuid,
-	)
+	const secret = yield* call([root.db, root.db.resetSecret], uuid)
 
 	if (secret.type === 'failure') {
 		broadcast([player], {
 			type: serverMessages.TOAST_SEND,
 			title: 'Could not reset',
-			description: 'Failed to reset user secret, try logging out and then back in.',
+			description:
+				'Failed to reset user secret, try logging out and then back in.',
 			image: 'images/icons/warning_icon.png',
 		})
 		return

--- a/server/src/routines/player.ts
+++ b/server/src/routines/player.ts
@@ -20,7 +20,7 @@ import {
 } from 'db/db-reciever'
 import {LocalMessage, LocalMessageTable, localMessages} from 'messages'
 import {getGame} from 'selectors'
-import {delay, put, race, select, take} from 'typed-redux-saga'
+import {call, delay, put, race, select, take} from 'typed-redux-saga'
 import root from '../serverRoot'
 import {broadcast} from '../utils/comm'
 
@@ -222,5 +222,30 @@ export function* updateCosmeticSaga(
 	broadcast([player], {
 		type: serverMessages.COSMETICS_UPDATE,
 		appearance: player.appearance,
+	})
+}
+
+export function* resetSecret(action: RecievedClientMessage<typeof clientMessages.RESET_SECRET>) {
+	const player = root.players[action.playerId]
+	const {uuid} = player
+
+	const secret = yield* call(
+		[root.db, root.db.resetSecret],
+		uuid,
+	)
+
+	if (secret.type === 'failure') {
+		broadcast([player], {
+			type: serverMessages.TOAST_SEND,
+			title: 'Could not reset',
+			description: 'Failed to reset user secret, try logging out and then back in.',
+			image: 'images/icons/warning_icon.png',
+		})
+		return
+	}
+
+	broadcast([player], {
+		type: serverMessages.SECRET_RESET,
+		...secret.body,
 	})
 }


### PR DESCRIPTION
Adds a button with a confirm modal to reset the user secret. This logs the player out of all devices except the one they are currently on.

This also fixes a bug where syncing whilst logged in would not immediately log you back in (you had to refresh)

Re-opened due to me nuking my fork